### PR TITLE
rebalance laser dino spawns to be more common/possible to find.

### DIFF
--- a/Kenan-Modpack/laser_dinos_zinos/monstergroups/laser_dinos_zinos.json
+++ b/Kenan-Modpack/laser_dinos_zinos/monstergroups/laser_dinos_zinos.json
@@ -4,8 +4,8 @@
     "name": "GROUP_CENTRAL_LAB",
     "default": "mon_zombie_scientist",
     "monsters": [
-      { "monster": "mon_spinosaurus_bio_op", "freq": 25, "cost_multiplier": 50 },
-      { "monster": "mon_zpinosaurus_bio_op", "freq": 25, "cost_multiplier": 55, "starts": 72 }
+      { "monster": "mon_spinosaurus_bio_op", "freq": 25, "cost_multiplier": 30 },
+      { "monster": "mon_zpinosaurus_bio_op", "freq": 25, "cost_multiplier": 30, "starts": 72 }
     ]
   },
   {
@@ -13,8 +13,8 @@
     "name": "GROUP_LAB_CYBORG",
     "default": "mon_broken_cyborg",
     "monsters": [
-      { "monster": "mon_spinosaurus_bio_op", "freq": 40, "cost_multiplier": 70 },
-      { "monster": "mon_zpinosaurus_bio_op", "freq": 40, "cost_multiplier": 70, "starts": 72 }
+      { "monster": "mon_spinosaurus_bio_op", "freq": 40, "cost_multiplier": 25 },
+      { "monster": "mon_zpinosaurus_bio_op", "freq": 40, "cost_multiplier": 25, "starts": 72 }
     ]
   },
   {
@@ -22,8 +22,8 @@
     "name": "GROUP_LAB",
     "default": "mon_zombie_scientist",
     "monsters": [
-      { "monster": "mon_spinosaurus_bio_op", "freq": 25, "cost_multiplier": 50 },
-      { "monster": "mon_zpinosaurus_bio_op", "freq": 25, "cost_multiplier": 55, "starts": 72 }
+      { "monster": "mon_spinosaurus_bio_op", "freq": 25, "cost_multiplier": 30 },
+      { "monster": "mon_zpinosaurus_bio_op", "freq": 25, "cost_multiplier": 35, "starts": 72 }
     ]
   }
 ]


### PR DESCRIPTION
couldnt really find any in my testing naturally (such a low chance), so decreased the weight to more closely follow dinomod spawn rates for large scary cbm dino bosses in the lab variations that call upon these monster groups. tested and found one in central lab at 50x spawn rate world setting. proves it's working. no errors found.

my justification is that the monsters are not as hard as they seem, a 20 rounds of a decent caliber will solve the laser dino fast, and i believe everything is better with laser dinos.

![found one in central lab](https://user-images.githubusercontent.com/75153234/104414862-2c98cc80-552e-11eb-81b2-f82c998793da.png)
