### PR TITLE
Update armor.json

### DIFF
--- a/Kenan-Modpack/PKs_Rebalancing/items/armor.json
+++ b/Kenan-Modpack/PKs_Rebalancing/items/armor.json
@@ -38,22 +38,22 @@
         "max_contains_volume": "1500 ml",
         "max_contains_weight": "4 kg",
         "max_item_length": "550 mm",
-        "moves": 80
+        "moves": 40
       },
       {
         "pocket_type": "CONTAINER",
         "max_contains_volume": "1500 ml",
         "max_contains_weight": "4 kg",
         "max_item_length": "550 mm",
-        "moves": 80
+        "moves": 40
       },
       {
         "pocket_type": "CONTAINER",
         "holster": true,
         "min_item_volume": "1500 ml",
-        "max_contains_volume": "3500 ml",
-        "max_contains_weight": "4100 g",
-        "max_item_length": "550 mm",
+        "max_contains_volume": "4000 ml",
+        "max_contains_weight": "9600 g",
+        "max_item_length": "1170 mm",
         "moves": 60
       }
     ],


### PR DESCRIPTION
Adjusted large back holster to be actually large enough for heavy weapons. This is doom guys armor. He uses big stupid guns. The back holster is now big enough to actually fit a BFG big fucking gun ( matched max weight, volume, and length to the specs of the BFG 2041-2)

Similarly, the small pockets, while not flagged as holsters (so you can fill them with drugs instead of guns, as per the description of carrying multiple guns as well as stim packs and stuff), are dreadfully slow at 80 moves to retrieve a small arm. There are regular holsters that have as little as 20 or 30 moves, but these are not gun specific pockets so I didn't bring them that low, but to a much improved 40 moves as a sort of hybrid pocket/holster.