### PR TITLE
Fixed kawaii bags

### DIFF
--- a/Kenan-Modpack/Project_Kawaii/items.json
+++ b/Kenan-Modpack/Project_Kawaii/items.json
@@ -34,6 +34,7 @@
     "covers": [ "torso", "arm_l", "arm_r", "leg_l", "leg_r" ],
     "coverage": 80,
     "encumbrance": 20,
+	  "max_encumbrance": 40,
     "pocket_data": [
       { "pocket_type": "CONTAINER", "max_contains_volume": "8 L", "max_contains_weight": "16 kg", "moves": 75 },
       { "pocket_type": "CONTAINER", "max_contains_volume": "8 L", "max_contains_weight": "16 kg", "moves": 75 },
@@ -65,6 +66,7 @@
     "covers": [ "torso", "arm_l", "arm_r", "leg_l", "leg_r" ],
     "coverage": 95,
     "encumbrance": 20,
+	  "max_encumbrance": 40,
     "pocket_data": [
       { "pocket_type": "CONTAINER", "max_contains_volume": "8 L", "max_contains_weight": "16 kg", "moves": 75 },
       { "pocket_type": "CONTAINER", "max_contains_volume": "8 L", "max_contains_weight": "16 kg", "moves": 75 },
@@ -97,6 +99,7 @@
     "covers": [ "leg_l", "leg_r", "torso", "arm_l", "arm_r" ],
     "coverage": 100,
     "encumbrance": 15,
+	  "max_encumbrance": 22,
     "pocket_data": [
       { "pocket_type": "CONTAINER", "max_contains_volume": "2 L", "max_contains_weight": "4 kg", "moves": 75 },
       { "pocket_type": "CONTAINER", "max_contains_volume": "2 L", "max_contains_weight": "4 kg", "moves": 75 },
@@ -136,6 +139,7 @@
     "covers": [ "leg_l", "leg_r", "torso", "arm_l", "arm_r" ],
     "coverage": 100,
     "encumbrance": 25,
+	  "max_encumbrance": 33,
     "pocket_data": [
       { "pocket_type": "CONTAINER", "max_contains_volume": "2500 ml", "max_contains_weight": "5 kg", "moves": 75 },
       { "pocket_type": "CONTAINER", "max_contains_volume": "2500 ml", "max_contains_weight": "5 kg", "moves": 75 },
@@ -175,6 +179,7 @@
     "covers": [ "leg_l", "leg_r", "torso", "arm_l", "arm_r" ],
     "coverage": 100,
     "encumbrance": 15,
+	  "max_encumbrance": 23,
     "pocket_data": [
       { "pocket_type": "CONTAINER", "max_contains_volume": "2500 ml", "max_contains_weight": "5 kg", "moves": 75 },
       { "pocket_type": "CONTAINER", "max_contains_volume": "2500 ml", "max_contains_weight": "5 kg", "moves": 75 },
@@ -210,6 +215,7 @@
     "covers": [ "torso", "arm_l", "arm_r", "leg_l", "leg_r" ],
     "coverage": 85,
     "encumbrance": 20,
+	  "max_encumbrance": 34,
     "pocket_data": [
       { "pocket_type": "CONTAINER", "max_contains_volume": "6 L", "max_contains_weight": "12 kg", "moves": 75 },
       { "pocket_type": "CONTAINER", "max_contains_volume": "6 L", "max_contains_weight": "12 kg", "moves": 75 },
@@ -252,6 +258,7 @@
     "covers": [ "torso", "arm_l", "arm_r", "leg_l", "leg_r" ],
     "coverage": 85,
     "encumbrance": 7,
+	  "max_encumbrance": 10,
     "pocket_data": [
       { "pocket_type": "CONTAINER", "max_contains_volume": "1250 ml", "max_contains_weight": "2 kg", "moves": 75 },
       { "pocket_type": "CONTAINER", "max_contains_volume": "1250 ml", "max_contains_weight": "2 kg", "moves": 75 }
@@ -312,6 +319,7 @@
     "covers": [ "torso", "arm_l", "arm_r", "leg_l", "leg_r" ],
     "coverage": 85,
     "encumbrance": 5,
+	  "max_encumbrance": 8,
     "pocket_data": [
       { "pocket_type": "CONTAINER", "max_contains_volume": "1250 ml", "max_contains_weight": "2 kg", "moves": 75 },
       { "pocket_type": "CONTAINER", "max_contains_volume": "1250 ml", "max_contains_weight": "2 kg", "moves": 75 }
@@ -485,6 +493,7 @@
     "covers": [ "torso" ],
     "coverage": 60,
     "encumbrance": 5,
+	  "max_encumbrance": 8,
     "pocket_data": [
       { "pocket_type": "CONTAINER", "max_contains_volume": "1500 ml", "max_contains_weight": "3 kg", "moves": 75 },
       { "pocket_type": "CONTAINER", "max_contains_volume": "1500 ml", "max_contains_weight": "3 kg", "moves": 75 }
@@ -1112,10 +1121,10 @@
     "encumbrance": 30,
 	"max_encumbrance": 30,
     "pocket_data": [
-      { "pocket_type": "CONTAINER", "max_contains_volume": "12 L", "max_contains_weight": "24 kg", "moves": 75 },
-      { "pocket_type": "CONTAINER", "max_contains_volume": "12 L", "max_contains_weight": "24 kg", "moves": 75 },
-      { "pocket_type": "CONTAINER", "max_contains_volume": "3 L", "max_contains_weight": "6 kg", "moves": 75 },
-      { "pocket_type": "CONTAINER", "max_contains_volume": "3 L", "max_contains_weight": "6 kg", "moves": 75 }
+      { "pocket_type": "CONTAINER", "rigid": true, "max_contains_volume": "12 L", "max_contains_weight": "24 kg", "moves": 75 },
+      { "pocket_type": "CONTAINER", "rigid": true, "max_contains_volume": "12 L", "max_contains_weight": "24 kg", "moves": 75 },
+      { "pocket_type": "CONTAINER", "rigid": true, "max_contains_volume": "3 L", "max_contains_weight": "6 kg", "moves": 75 },
+      { "pocket_type": "CONTAINER", "rigid": true, "max_contains_volume": "3 L", "max_contains_weight": "6 kg", "moves": 75 }
     ],
     "warmth": 0,
     "material_thickness": 2,
@@ -1137,10 +1146,10 @@
     "encumbrance": 15,
 	"max_encumbrance": 15,
     "pocket_data": [
-      { "pocket_type": "CONTAINER", "max_contains_volume": "8 L", "max_contains_weight": "16 kg", "moves": 75 },
-      { "pocket_type": "CONTAINER", "max_contains_volume": "8 L", "max_contains_weight": "16 kg", "moves": 75 },
-      { "pocket_type": "CONTAINER", "max_contains_volume": "2 L", "max_contains_weight": "4 kg", "moves": 75 },
-      { "pocket_type": "CONTAINER", "max_contains_volume": "2 L", "max_contains_weight": "4 kg", "moves": 75 }
+      { "pocket_type": "CONTAINER", "rigid": true, "max_contains_volume": "8 L", "max_contains_weight": "16 kg", "moves": 75 },
+      { "pocket_type": "CONTAINER", "rigid": true, "max_contains_volume": "8 L", "max_contains_weight": "16 kg", "moves": 75 },
+      { "pocket_type": "CONTAINER", "rigid": true, "max_contains_volume": "2 L", "max_contains_weight": "4 kg", "moves": 75 },
+      { "pocket_type": "CONTAINER", "rigid": true, "max_contains_volume": "2 L", "max_contains_weight": "4 kg", "moves": 75 }
     ],
     "warmth": 0,
     "material_thickness": 2,
@@ -1162,10 +1171,10 @@
     "encumbrance": 8,
 	"max_encumbrance": 8,
     "pocket_data": [
-      { "pocket_type": "CONTAINER", "max_contains_volume": "4 L", "max_contains_weight": "6 kg", "moves": 75 },
-      { "pocket_type": "CONTAINER", "max_contains_volume": "4 L", "max_contains_weight": "6 kg", "moves": 75 },
-      { "pocket_type": "CONTAINER", "max_contains_volume": "2250 ml", "max_contains_weight": "5 kg", "moves": 75 },
-      { "pocket_type": "CONTAINER", "max_contains_volume": "2250 ml", "max_contains_weight": "5 kg", "moves": 75 }
+      { "pocket_type": "CONTAINER", "rigid": true, "max_contains_volume": "4 L", "max_contains_weight": "6 kg", "moves": 75 },
+      { "pocket_type": "CONTAINER", "rigid": true, "max_contains_volume": "4 L", "max_contains_weight": "6 kg", "moves": 75 },
+      { "pocket_type": "CONTAINER", "rigid": true, "max_contains_volume": "2250 ml", "max_contains_weight": "5 kg", "moves": 75 },
+      { "pocket_type": "CONTAINER", "rigid": true, "max_contains_volume": "2250 ml", "max_contains_weight": "5 kg", "moves": 75 }
     ],
     "warmth": 0,
     "material_thickness": 2,
@@ -1185,7 +1194,7 @@
     "covers": [ "leg_l" ],
     "coverage": 5,
     "encumbrance": 2,
-	"max_encumbrance": 3,
+	"max_encumbrance": 5,
     "pocket_data": [
       { "pocket_type": "CONTAINER", "max_contains_volume": "1250 ml", "max_contains_weight": "2 kg", "moves": 75 },
       { "pocket_type": "CONTAINER", "max_contains_volume": "1250 ml", "max_contains_weight": "2 kg", "moves": 75 }

--- a/Kenan-Modpack/Project_Kawaii/items.json
+++ b/Kenan-Modpack/Project_Kawaii/items.json
@@ -13,9 +13,7 @@
     "covers": [ "torso", "arm_l", "arm_r", "leg_l", "leg_r" ],
     "coverage": 75,
     "encumbrance": 7,
-    "pocket_data": [
-      { "pocket_type": "CONTAINER", "max_contains_volume": "3500 ml", "max_contains_weight": "4 kg", "moves": 75 }
-    ],
+    "pocket_data": [ { "pocket_type": "CONTAINER", "max_contains_volume": "3500 ml", "max_contains_weight": "4 kg", "moves": 75 } ],
     "warmth": 15,
     "material_thickness": 1,
     "flags": [ "VARSIZE", "FANCY" ]
@@ -34,7 +32,7 @@
     "covers": [ "torso", "arm_l", "arm_r", "leg_l", "leg_r" ],
     "coverage": 80,
     "encumbrance": 20,
-	  "max_encumbrance": 40,
+    "max_encumbrance": 40,
     "pocket_data": [
       { "pocket_type": "CONTAINER", "max_contains_volume": "8 L", "max_contains_weight": "16 kg", "moves": 75 },
       { "pocket_type": "CONTAINER", "max_contains_volume": "8 L", "max_contains_weight": "16 kg", "moves": 75 },
@@ -66,7 +64,7 @@
     "covers": [ "torso", "arm_l", "arm_r", "leg_l", "leg_r" ],
     "coverage": 95,
     "encumbrance": 20,
-	  "max_encumbrance": 40,
+    "max_encumbrance": 40,
     "pocket_data": [
       { "pocket_type": "CONTAINER", "max_contains_volume": "8 L", "max_contains_weight": "16 kg", "moves": 75 },
       { "pocket_type": "CONTAINER", "max_contains_volume": "8 L", "max_contains_weight": "16 kg", "moves": 75 },
@@ -99,7 +97,7 @@
     "covers": [ "leg_l", "leg_r", "torso", "arm_l", "arm_r" ],
     "coverage": 100,
     "encumbrance": 15,
-	  "max_encumbrance": 22,
+    "max_encumbrance": 22,
     "pocket_data": [
       { "pocket_type": "CONTAINER", "max_contains_volume": "2 L", "max_contains_weight": "4 kg", "moves": 75 },
       { "pocket_type": "CONTAINER", "max_contains_volume": "2 L", "max_contains_weight": "4 kg", "moves": 75 },
@@ -139,7 +137,7 @@
     "covers": [ "leg_l", "leg_r", "torso", "arm_l", "arm_r" ],
     "coverage": 100,
     "encumbrance": 25,
-	  "max_encumbrance": 33,
+    "max_encumbrance": 33,
     "pocket_data": [
       { "pocket_type": "CONTAINER", "max_contains_volume": "2500 ml", "max_contains_weight": "5 kg", "moves": 75 },
       { "pocket_type": "CONTAINER", "max_contains_volume": "2500 ml", "max_contains_weight": "5 kg", "moves": 75 },
@@ -179,7 +177,7 @@
     "covers": [ "leg_l", "leg_r", "torso", "arm_l", "arm_r" ],
     "coverage": 100,
     "encumbrance": 15,
-	  "max_encumbrance": 23,
+    "max_encumbrance": 23,
     "pocket_data": [
       { "pocket_type": "CONTAINER", "max_contains_volume": "2500 ml", "max_contains_weight": "5 kg", "moves": 75 },
       { "pocket_type": "CONTAINER", "max_contains_volume": "2500 ml", "max_contains_weight": "5 kg", "moves": 75 },
@@ -215,7 +213,7 @@
     "covers": [ "torso", "arm_l", "arm_r", "leg_l", "leg_r" ],
     "coverage": 85,
     "encumbrance": 20,
-	  "max_encumbrance": 34,
+    "max_encumbrance": 34,
     "pocket_data": [
       { "pocket_type": "CONTAINER", "max_contains_volume": "6 L", "max_contains_weight": "12 kg", "moves": 75 },
       { "pocket_type": "CONTAINER", "max_contains_volume": "6 L", "max_contains_weight": "12 kg", "moves": 75 },
@@ -258,7 +256,7 @@
     "covers": [ "torso", "arm_l", "arm_r", "leg_l", "leg_r" ],
     "coverage": 85,
     "encumbrance": 7,
-	  "max_encumbrance": 10,
+    "max_encumbrance": 10,
     "pocket_data": [
       { "pocket_type": "CONTAINER", "max_contains_volume": "1250 ml", "max_contains_weight": "2 kg", "moves": 75 },
       { "pocket_type": "CONTAINER", "max_contains_volume": "1250 ml", "max_contains_weight": "2 kg", "moves": 75 }
@@ -319,7 +317,7 @@
     "covers": [ "torso", "arm_l", "arm_r", "leg_l", "leg_r" ],
     "coverage": 85,
     "encumbrance": 5,
-	  "max_encumbrance": 8,
+    "max_encumbrance": 8,
     "pocket_data": [
       { "pocket_type": "CONTAINER", "max_contains_volume": "1250 ml", "max_contains_weight": "2 kg", "moves": 75 },
       { "pocket_type": "CONTAINER", "max_contains_volume": "1250 ml", "max_contains_weight": "2 kg", "moves": 75 }
@@ -493,7 +491,7 @@
     "covers": [ "torso" ],
     "coverage": 60,
     "encumbrance": 5,
-	  "max_encumbrance": 8,
+    "max_encumbrance": 8,
     "pocket_data": [
       { "pocket_type": "CONTAINER", "max_contains_volume": "1500 ml", "max_contains_weight": "3 kg", "moves": 75 },
       { "pocket_type": "CONTAINER", "max_contains_volume": "1500 ml", "max_contains_weight": "3 kg", "moves": 75 }
@@ -1119,9 +1117,15 @@
     "covers": [ "torso" ],
     "coverage": 30,
     "encumbrance": 30,
-	"max_encumbrance": 30,
+    "max_encumbrance": 30,
     "pocket_data": [
-      { "pocket_type": "CONTAINER", "rigid": true, "max_contains_volume": "15 L", "max_contains_weight": "24 kg", "moves": 75 }
+      {
+        "pocket_type": "CONTAINER",
+        "rigid": true,
+        "max_contains_volume": "15 L",
+        "max_contains_weight": "24 kg",
+        "moves": 75
+      }
     ],
     "warmth": 0,
     "material_thickness": 2,
@@ -1141,9 +1145,15 @@
     "covers": [ "torso" ],
     "coverage": 15,
     "encumbrance": 15,
-	"max_encumbrance": 15,
+    "max_encumbrance": 15,
     "pocket_data": [
-      { "pocket_type": "CONTAINER", "rigid": true, "max_contains_volume": "10 L", "max_contains_weight": "16 kg", "moves": 75 }
+      {
+        "pocket_type": "CONTAINER",
+        "rigid": true,
+        "max_contains_volume": "10 L",
+        "max_contains_weight": "16 kg",
+        "moves": 75
+      }
     ],
     "warmth": 0,
     "material_thickness": 2,
@@ -1163,7 +1173,7 @@
     "covers": [ "torso" ],
     "coverage": 10,
     "encumbrance": 8,
-	"max_encumbrance": 8,
+    "max_encumbrance": 8,
     "pocket_data": [
       { "pocket_type": "CONTAINER", "rigid": true, "max_contains_volume": "5 L", "max_contains_weight": "6 kg", "moves": 75 }
     ],
@@ -1185,7 +1195,7 @@
     "covers": [ "leg_l" ],
     "coverage": 5,
     "encumbrance": 2,
-	"max_encumbrance": 5,
+    "max_encumbrance": 5,
     "pocket_data": [
       { "pocket_type": "CONTAINER", "max_contains_volume": "1250 ml", "max_contains_weight": "2 kg", "moves": 75 },
       { "pocket_type": "CONTAINER", "max_contains_volume": "1250 ml", "max_contains_weight": "2 kg", "moves": 75 }

--- a/Kenan-Modpack/Project_Kawaii/items.json
+++ b/Kenan-Modpack/Project_Kawaii/items.json
@@ -1133,7 +1133,7 @@
     "name": { "str": "Cute Mini-Hardcase" },
     "description": "A smaller version of the standard hardcase.",
     "weight": "1300 g",
-    "volume": "11000 mL",
+    "volume": "11000 ml",
     "price": "80 USD",
     "material": [ "plastic", "steel" ],
     "symbol": "[",

--- a/Kenan-Modpack/Project_Kawaii/items.json
+++ b/Kenan-Modpack/Project_Kawaii/items.json
@@ -1104,12 +1104,13 @@
     "weight": "900 g",
     "volume": "4500 ml",
     "price": "120 USD",
-    "material": [ "cotton" ],
+    "material": [ "plastic", "steel" ],
     "symbol": "[",
     "color": "dark_gray",
     "covers": [ "torso" ],
     "coverage": 30,
     "encumbrance": 30,
+	"max_encumbrance": 30,
     "pocket_data": [
       { "pocket_type": "CONTAINER", "max_contains_volume": "12 L", "max_contains_weight": "24 kg", "moves": 75 },
       { "pocket_type": "CONTAINER", "max_contains_volume": "12 L", "max_contains_weight": "24 kg", "moves": 75 },
@@ -1118,7 +1119,7 @@
     ],
     "warmth": 0,
     "material_thickness": 2,
-    "flags": [ "BELTED" ]
+    "flags": [ "BELTED", "WATER_FRIENDLY", "STURDY" ]
   },
   {
     "id": "kawaii_maid_hardcase_mini",
@@ -1128,12 +1129,13 @@
     "weight": "650 g",
     "volume": "3 L",
     "price": "80 USD",
-    "material": [ "cotton" ],
+    "material": [ "plastic", "steel" ],
     "symbol": "[",
     "color": "dark_gray",
     "covers": [ "torso" ],
     "coverage": 15,
     "encumbrance": 15,
+	"max_encumbrance": 15,
     "pocket_data": [
       { "pocket_type": "CONTAINER", "max_contains_volume": "8 L", "max_contains_weight": "16 kg", "moves": 75 },
       { "pocket_type": "CONTAINER", "max_contains_volume": "8 L", "max_contains_weight": "16 kg", "moves": 75 },
@@ -1142,7 +1144,7 @@
     ],
     "warmth": 0,
     "material_thickness": 2,
-    "flags": [ "BELTED" ]
+    "flags": [ "BELTED", "WATER_FRIENDLY", "STURDY" ]
   },
   {
     "id": "kawaii_maid_hardcase_slim",
@@ -1152,12 +1154,13 @@
     "weight": "400 g",
     "volume": "2250 ml",
     "price": "80 USD",
-    "material": [ "cotton" ],
+    "material": [ "plastic", "steel" ],
     "symbol": "[",
     "color": "dark_gray",
     "covers": [ "torso" ],
     "coverage": 10,
     "encumbrance": 8,
+	"max_encumbrance": 8,
     "pocket_data": [
       { "pocket_type": "CONTAINER", "max_contains_volume": "4 L", "max_contains_weight": "6 kg", "moves": 75 },
       { "pocket_type": "CONTAINER", "max_contains_volume": "4 L", "max_contains_weight": "6 kg", "moves": 75 },
@@ -1166,7 +1169,7 @@
     ],
     "warmth": 0,
     "material_thickness": 2,
-    "flags": [ "BELTED" ]
+    "flags": [ "BELTED", "WATER_FRIENDLY", "STURDY" ]
   },
   {
     "id": "kawaii_secretpoach",
@@ -1182,6 +1185,7 @@
     "covers": [ "leg_l" ],
     "coverage": 5,
     "encumbrance": 2,
+	"max_encumbrance": 3,
     "pocket_data": [
       { "pocket_type": "CONTAINER", "max_contains_volume": "1250 ml", "max_contains_weight": "2 kg", "moves": 75 },
       { "pocket_type": "CONTAINER", "max_contains_volume": "1250 ml", "max_contains_weight": "2 kg", "moves": 75 }

--- a/Kenan-Modpack/Project_Kawaii/items.json
+++ b/Kenan-Modpack/Project_Kawaii/items.json
@@ -1110,8 +1110,8 @@
     "type": "ARMOR",
     "name": { "str": "Cute Hardcase" },
     "description": "A huge rectangular hardcase. Normally used for carrying large musical instruments, sniper rifles, or sensitive electrical equipment.",
-    "weight": "900 g",
-    "volume": "4500 ml",
+    "weight": "1800 g",
+    "volume": "17000 ml",
     "price": "120 USD",
     "material": [ "plastic", "steel" ],
     "symbol": "[",
@@ -1121,10 +1121,7 @@
     "encumbrance": 30,
 	"max_encumbrance": 30,
     "pocket_data": [
-      { "pocket_type": "CONTAINER", "rigid": true, "max_contains_volume": "12 L", "max_contains_weight": "24 kg", "moves": 75 },
-      { "pocket_type": "CONTAINER", "rigid": true, "max_contains_volume": "12 L", "max_contains_weight": "24 kg", "moves": 75 },
-      { "pocket_type": "CONTAINER", "rigid": true, "max_contains_volume": "3 L", "max_contains_weight": "6 kg", "moves": 75 },
-      { "pocket_type": "CONTAINER", "rigid": true, "max_contains_volume": "3 L", "max_contains_weight": "6 kg", "moves": 75 }
+      { "pocket_type": "CONTAINER", "rigid": true, "max_contains_volume": "15 L", "max_contains_weight": "24 kg", "moves": 75 }
     ],
     "warmth": 0,
     "material_thickness": 2,
@@ -1135,8 +1132,8 @@
     "type": "ARMOR",
     "name": { "str": "Cute Mini-Hardcase" },
     "description": "A smaller version of the standard hardcase.",
-    "weight": "650 g",
-    "volume": "3 L",
+    "weight": "1300 g",
+    "volume": "11000 mL",
     "price": "80 USD",
     "material": [ "plastic", "steel" ],
     "symbol": "[",
@@ -1146,10 +1143,7 @@
     "encumbrance": 15,
 	"max_encumbrance": 15,
     "pocket_data": [
-      { "pocket_type": "CONTAINER", "rigid": true, "max_contains_volume": "8 L", "max_contains_weight": "16 kg", "moves": 75 },
-      { "pocket_type": "CONTAINER", "rigid": true, "max_contains_volume": "8 L", "max_contains_weight": "16 kg", "moves": 75 },
-      { "pocket_type": "CONTAINER", "rigid": true, "max_contains_volume": "2 L", "max_contains_weight": "4 kg", "moves": 75 },
-      { "pocket_type": "CONTAINER", "rigid": true, "max_contains_volume": "2 L", "max_contains_weight": "4 kg", "moves": 75 }
+      { "pocket_type": "CONTAINER", "rigid": true, "max_contains_volume": "10 L", "max_contains_weight": "16 kg", "moves": 75 }
     ],
     "warmth": 0,
     "material_thickness": 2,
@@ -1160,8 +1154,8 @@
     "type": "ARMOR",
     "name": { "str": "Cute Slim Hardcase" },
     "description": "A slimmer version of the hardcase.",
-    "weight": "400 g",
-    "volume": "2250 ml",
+    "weight": "800 g",
+    "volume": "6500 ml",
     "price": "80 USD",
     "material": [ "plastic", "steel" ],
     "symbol": "[",
@@ -1171,10 +1165,7 @@
     "encumbrance": 8,
 	"max_encumbrance": 8,
     "pocket_data": [
-      { "pocket_type": "CONTAINER", "rigid": true, "max_contains_volume": "4 L", "max_contains_weight": "6 kg", "moves": 75 },
-      { "pocket_type": "CONTAINER", "rigid": true, "max_contains_volume": "4 L", "max_contains_weight": "6 kg", "moves": 75 },
-      { "pocket_type": "CONTAINER", "rigid": true, "max_contains_volume": "2250 ml", "max_contains_weight": "5 kg", "moves": 75 },
-      { "pocket_type": "CONTAINER", "rigid": true, "max_contains_volume": "2250 ml", "max_contains_weight": "5 kg", "moves": 75 }
+      { "pocket_type": "CONTAINER", "rigid": true, "max_contains_volume": "5 L", "max_contains_weight": "6 kg", "moves": 75 }
     ],
     "warmth": 0,
     "material_thickness": 2,


### PR DESCRIPTION
Fixed bags. They lacked any max encumbrance cap (causing encumbrance to skyrocket to 90+ when filled). They were also coded as soft, cloth containers like a backpack despite being described as hard-case containers, so materials were changed from cotton to plastic/steel. Also added water_friendly and sturdy similar to other hardcase containers in CDDA (like the violin case).