### PR TITLE
Artyom's Emporium - Change ammo damage type from 'stab' to 'bullet'

### DIFF
--- a/Kenan-Modpack/Artyom_Emporium_v.1/art_ammo.json
+++ b/Kenan-Modpack/Artyom_Emporium_v.1/art_ammo.json
@@ -14,7 +14,7 @@
     "to_hit": 0,
     "ammo_type": "380",
     "casing": ".380_casing",
-    "damage": { "damage_type": "stab", "amount": 18, "armor_penetration": 6 },
+    "damage": { "damage_type": "bullet", "amount": 18, "armor_penetration": 6 },
     "range": 16,
     "dispersion": 120,
     "recoil": 50,
@@ -36,7 +36,7 @@
     "bashing": 1,
     "to_hit": 0,
     "ammo_type": "components",
-    "damage": { "damage_type": "stab", "amount": 0, "armor_penetration": 0 },
+    "damage": { "damage_type": "bullet", "amount": 0, "armor_penetration": 0 },
     "range": 0,
     "dispersion": 0,
     "recoil": 0,
@@ -58,7 +58,7 @@
     "ammo_type": ".303",
     "casing": ".303_casing",
     "range": 65,
-    "damage": { "damage_type": "stab", "amount": 60, "armor_penetration": 2 },
+    "damage": { "damage_type": "bullet", "amount": 60, "armor_penetration": 2 },
     "dispersion": 15,
     "recoil": 3000,
     "effects": [ "COOKOFF" ]
@@ -78,7 +78,7 @@
     "bashing": 1,
     "to_hit": 0,
     "ammo_type": "components",
-    "damage": { "damage_type": "stab", "amount": 0, "armor_penetration": 0 },
+    "damage": { "damage_type": "bullet", "amount": 0, "armor_penetration": 0 },
     "range": 0,
     "dispersion": 0,
     "recoil": 0,
@@ -89,7 +89,7 @@
     "copy-from": ".303",
     "type": "AMMO",
     "name": { "str": "reloaded .303 British" },
-    "proportional": { "price": 0.7, "damage": { "damage_type": "stab", "amount": 0.9 }, "dispersion": 1.1 },
+    "proportional": { "price": 0.7, "damage": { "damage_type": "bullet", "amount": 0.9 }, "dispersion": 1.1 },
     "extend": { "effects": [ "RECYCLED" ] },
     "delete": { "effects": [ "NEVER_MISFIRES" ] }
   },
@@ -98,7 +98,7 @@
     "copy-from": "308",
     "type": "AMMO",
     "name": { "str": "Match .308" },
-    "proportional": { "price": 2.0, "damage": { "damage_type": "stab", "amount": 1.1 }, "dispersion": 0.8 },
+    "proportional": { "price": 2.0, "damage": { "damage_type": "bullet", "amount": 1.1 }, "dispersion": 0.8 },
     "extend": { "effects": [ "RECYCLED", "NEVER_MISFIRES" ] }
   },
   {
@@ -107,7 +107,7 @@
     "type": "AMMO",
     "name": { "str": "7.62x54mmR API/Explosive" },
     "description": "Originally used by Soviet Anti-Air weapons, then used by snipers to blow apart fascist light armour. Now used by you. Careful using it too close to yourself. ",
-    "damage": { "damage_type": "stab", "armor_penetration": 10 },
+    "damage": { "damage_type": "bullet", "armor_penetration": 10 },
     "extend": { "effects": [ "INCENDIARY", "EXPLOSIVE_SMALL" ] }
   },
   {
@@ -125,7 +125,7 @@
     "to_hit": 0,
     "ammo_type": ".300",
     "casing": ".300_casing",
-    "damage": { "damage_type": "stab", "amount": 32, "armor_penetration": 8 },
+    "damage": { "damage_type": "bullet", "amount": 32, "armor_penetration": 8 },
     "range": 20,
     "dispersion": 100,
     "recoil": 430,
@@ -147,7 +147,7 @@
     "to_hit": 0,
     "ammo_type": ".300",
     "casing": ".300_casing",
-    "damage": { "damage_type": "stab", "amount": 48, "armor_penetration": 16 },
+    "damage": { "damage_type": "bullet", "amount": 48, "armor_penetration": 16 },
     "range": 40,
     "dispersion": 110,
     "recoil": 450,
@@ -159,7 +159,7 @@
     "copy-from": ".300",
     "type": "AMMO",
     "name": { "str": "reloaded .300 Blackout", "str_pl": "reloaded .300 Blackout" },
-    "proportional": { "price": 0.7, "damage": { "damage_type": "stab", "amount": 0.9 }, "dispersion": 1.1 },
+    "proportional": { "price": 0.7, "damage": { "damage_type": "bullet", "amount": 0.9 }, "dispersion": 1.1 },
     "extend": { "effects": [ "RECYCLED" ] },
     "delete": { "effects": [ "NEVER_MISFIRES" ] }
   },
@@ -168,7 +168,7 @@
     "copy-from": ".3002",
     "type": "AMMO",
     "name": { "str": "reloaded .300 Blackout Match", "str_pl": "reloaded .300 Blackout Match" },
-    "proportional": { "price": 0.8, "damage": { "damage_type": "stab", "amount": 0.9 }, "dispersion": 1.1 },
+    "proportional": { "price": 0.8, "damage": { "damage_type": "bullet", "amount": 0.9 }, "dispersion": 1.1 },
     "extend": { "effects": [ "RECYCLED" ] },
     "delete": { "effects": [ "NEVER_MISFIRES" ] }
   },
@@ -187,7 +187,7 @@
     "bashing": 1,
     "to_hit": 0,
     "ammo_type": "components",
-    "damage": { "damage_type": "stab", "amount": 0, "armor_penetration": 0 },
+    "damage": { "damage_type": "bullet", "amount": 0, "armor_penetration": 0 },
     "range": 0,
     "dispersion": 0,
     "recoil": 0,
@@ -208,7 +208,7 @@
     "color": "yellow",
     "ammo_type": ".460",
     "casing": "45_casing",
-    "damage": { "damage_type": "stab", "amount": 40, "armor_penetration": 5 },
+    "damage": { "damage_type": "bullet", "amount": 40, "armor_penetration": 5 },
     "range": 16,
     "dispersion": 110,
     "recoil": 290,
@@ -219,7 +219,7 @@
     "copy-from": ".460",
     "type": "AMMO",
     "name": { "str": "reloaded .460 Rowland", "str_pl": "reloaded .460 Rowland" },
-    "proportional": { "price": 0.7, "damage": { "damage_type": "stab", "amount": 0.9 }, "dispersion": 1.1 },
+    "proportional": { "price": 0.7, "damage": { "damage_type": "bullet", "amount": 0.9 }, "dispersion": 1.1 },
     "extend": { "effects": [ "RECYCLED" ] },
     "delete": { "effects": [ "NEVER_MISFIRES" ] }
   },
@@ -239,7 +239,7 @@
     "ammo_type": "7.92mm",
     "casing": "8mm_casing",
     "range": 65,
-    "damage": { "damage_type": "stab", "amount": 55, "armor_penetration": 2 },
+    "damage": { "damage_type": "bullet", "amount": 55, "armor_penetration": 2 },
     "dispersion": 11,
     "recoil": 3100,
     "effects": [ "COOKOFF" ]
@@ -259,7 +259,7 @@
     "bashing": 1,
     "to_hit": 0,
     "ammo_type": "components",
-    "damage": { "damage_type": "stab", "amount": 0, "armor_penetration": 0 },
+    "damage": { "damage_type": "bullet", "amount": 0, "armor_penetration": 0 },
     "range": 0,
     "dispersion": 0,
     "recoil": 0,
@@ -270,7 +270,7 @@
     "copy-from": "8mmMauser",
     "type": "AMMO",
     "name": { "str": "reloaded 8mm Mauser" },
-    "proportional": { "price": 0.7, "damage": { "damage_type": "stab", "amount": 0.9 }, "dispersion": 1.1 },
+    "proportional": { "price": 0.7, "damage": { "damage_type": "bullet", "amount": 0.9 }, "dispersion": 1.1 },
     "extend": { "effects": [ "RECYCLED" ] },
     "delete": { "effects": [ "NEVER_MISFIRES" ] }
   },
@@ -279,7 +279,7 @@
     "copy-from": ".303",
     "type": "AMMO",
     "name": { "str": "Match .303" },
-    "proportional": { "price": 2.0, "damage": { "damage_type": "stab", "amount": 1.1 }, "dispersion": 0.8 },
+    "proportional": { "price": 2.0, "damage": { "damage_type": "bullet", "amount": 1.1 }, "dispersion": 0.8 },
     "extend": { "effects": [ "RECYCLED", "NEVER_MISFIRES" ] }
   },
   {
@@ -291,7 +291,7 @@
     "price": "150 USD",
     "description": "Easily capable of blowing apart light targets, this ammo is used as anti-materiel ammunition the world over.",
     "count": 5,
-    "damage": { "damage_type": "stab", "amount": 110, "armor_penetration": 12 },
+    "damage": { "damage_type": "bullet", "amount": 110, "armor_penetration": 12 },
     "extend": { "effects": [ "EXPLOSIVE_SMALL" ] }
   },
   {
@@ -300,7 +300,7 @@
     "type": "AMMO",
     "name": { "str": "Match 5.56 NATO" },
     "description": "A handloaded 5.56 NATO cartridge. Loaded for accuracy and damage, very well made - but quite expensive.",
-    "proportional": { "price": 2.0, "damage": { "damage_type": "stab", "amount": 1.1 }, "dispersion": 0.8 },
+    "proportional": { "price": 2.0, "damage": { "damage_type": "bullet", "amount": 1.1 }, "dispersion": 0.8 },
     "extend": { "effects": [ "RECYCLED", "NEVER_MISFIRES" ] }
   },
   {
@@ -309,7 +309,7 @@
     "type": "AMMO",
     "name": { "str": "Match .30-06" },
     "description": "A handloaded .30-06 cartridge. Loaded for accuracy and damage, very well made - but quite expensive.",
-    "proportional": { "price": 2.0, "damage": { "damage_type": "stab", "amount": 1.1 }, "dispersion": 0.8 },
+    "proportional": { "price": 2.0, "damage": { "damage_type": "bullet", "amount": 1.1 }, "dispersion": 0.8 },
     "extend": { "effects": [ "RECYCLED", "NEVER_MISFIRES" ] }
   },
   {
@@ -318,7 +318,7 @@
     "type": "AMMO",
     "name": { "str": "Match 7.62x39mm" },
     "description": "A handloaded 7.62x39mm cartridge. Loaded for accuracy and damage, very well made - but quite expensive. Based on the M87 loading.",
-    "proportional": { "price": 2.0, "damage": { "damage_type": "stab", "amount": 1.1 }, "dispersion": 0.8 },
+    "proportional": { "price": 2.0, "damage": { "damage_type": "bullet", "amount": 1.1 }, "dispersion": 0.8 },
     "extend": { "effects": [ "RECYCLED", "NEVER_MISFIRES" ] }
   },
   {
@@ -329,7 +329,7 @@
     "description": "A very quiet, very lightweight .22LR round meant for indoors practice without ear protection. The gun is louder than the ammunition. Handmade in the US of A.",
     "proportional": {
       "price": 2.0,
-      "damage": { "damage_type": "stab", "amount": 0.8 },
+      "damage": { "damage_type": "bullet", "amount": 0.8 },
       "dispersion": 1.1,
       "range": 0.8,
       "recoil": 0.01,
@@ -343,7 +343,7 @@
     "type": "AMMO",
     "name": { "str": "Match 5.45x39" },
     "description": "A handloaded 5.45x39 cartridge. Loaded for accuracy and damage, very well made - but quite expensive.",
-    "proportional": { "price": 2.0, "damage": { "damage_type": "stab", "amount": 1.1 }, "dispersion": 0.8 },
+    "proportional": { "price": 2.0, "damage": { "damage_type": "bullet", "amount": 1.1 }, "dispersion": 0.8 },
     "extend": { "effects": [ "RECYCLED", "NEVER_MISFIRES" ] }
   },
   {
@@ -352,7 +352,7 @@
     "type": "AMMO",
     "name": { "str": "Match 8mm Mauser" },
     "description": "A handloaded 8mm Mauser cartridge. Loaded for accuracy and damage, very well made - but quite expensive.",
-    "proportional": { "price": 1.9, "damage": { "damage_type": "stab", "amount": 1.1 }, "dispersion": 0.8 },
+    "proportional": { "price": 1.9, "damage": { "damage_type": "bullet", "amount": 1.1 }, "dispersion": 0.8 },
     "extend": { "effects": [ "RECYCLED", "NEVER_MISFIRES" ] }
   }
 ]


### PR DESCRIPTION
Changed Ammo damage type from stab to bullet
---

Bullets themselves did not show any damage info on the examine panels.
Magazines loaded with them had no damage value on the reload screen.
Guns loaded with *Match* bullets were doing zero damage, and had crazy dispersion spray.

Likely because they'd apply proportional damage to the base item with a wrong damage type, so it would base off zero.
