### PR TITLE
Remove duplicate "hecu" starting profession in More Military mod

### DIFF
--- a/Kenan-Modpack/More_Military/hecu.json
+++ b/Kenan-Modpack/More_Military/hecu.json
@@ -287,11 +287,5 @@
     "type": "ARMOR",
     "name": { "str": "H.E.C.U backpack" },
     "description": "Based on the MOLLE backpack's design, this backpack strikes a fine balance between storage space and encumbrance, while allowing for better mobility."
-  },
-  {
-    "type": "scenario",
-    "id": "lab_chal",
-    "copy-from": "lab_chal",
-    "extend": { "professions": [ "hecu" ] }
   }
 ]


### PR DESCRIPTION
`hecu` starting profession is repeated in `Kenan-Modpack/More_Military/cs_scenarios.json` and [causes loading error](https://github.com/CleverRaven/Cataclysm-DDA/pull/48470):
<img width="555" alt="debugmsg" src="https://user-images.githubusercontent.com/21075502/114279992-464e9080-9a05-11eb-9318-3fa88242c531.png">
