### PR TITLE
Bug workarounds added to recipes

### DIFF
--- a/Kenan-Modpack/Project_Kawaii/AMTS_recipes.json
+++ b/Kenan-Modpack/Project_Kawaii/AMTS_recipes.json
@@ -1,5 +1,39 @@
 [
   {
+    "type": "recipe",
+    "activity_level": "LIGHT_EXERCISE",
+    "result": "kawaii_amts_reciver",
+    "category": "CC_ELECTRONIC",
+    "subcategory": "CSC_ELECTRONIC_TOOLS",
+    "skill_used": "electronics",
+    "difficulty": 2,
+    "time": "25 m",
+    "autolearn": true,
+    "reversible": false,
+    "book_learn": [ [ "radio_book", 2 ], [ "textbook_anarch", 3 ] ],
+    "using": [ [ "soldering_standard", 10 ] ],
+    "proficiencies": [ { "proficiency": "prof_elec_soldering" } ],
+    "qualities": [ { "id": "SCREW", "level": 1 } ],
+    "components": [ [ [ "receiver", 1 ] ], [ [ "antenna", 1 ] ], [ [ "scrap", 5 ] ], [ [ "cable", 7 ] ] ]
+  },
+  {
+    "type": "recipe",
+    "activity_level": "LIGHT_EXERCISE",
+    "result": "kawaii_amts_transmitter",
+    "category": "CC_ELECTRONIC",
+    "subcategory": "CSC_ELECTRONIC_TOOLS",
+    "skill_used": "electronics",
+    "difficulty": 2,
+    "time": "25 m",
+    "autolearn": true,
+    "reversible": false,
+    "book_learn": [ [ "radio_book", 2 ], [ "textbook_anarch", 3 ] ],
+    "using": [ [ "soldering_standard", 10 ] ],
+    "proficiencies": [ { "proficiency": "prof_elec_soldering" } ],
+    "qualities": [ { "id": "SCREW", "level": 1 } ],
+    "components": [ [ [ "receiver", 1 ] ], [ [ "antenna", 1 ] ], [ [ "scrap", 5 ] ], [ [ "cable", 7 ] ] ]
+  },
+  {
     "result": "kawaii_amts_pac_t1_01",
     "activity_level": "LIGHT_EXERCISE",
     "type": "recipe",
@@ -8,7 +42,7 @@
     "skill_used": "fabrication",
     "time": 1000,
     "reversible": false,
-    "autolearn": false,
+    "autolearn": true,
     "book_learn": [ [ "kawaii_book_pacsys_tier1", 0 ], [ "kawaii_book_pacsys_tier_kawaii", 0 ] ],
     "components": [ [ [ "kawaii_amts_pacsys", 1 ] ], [ [ "log", 3 ] ] ]
   },
@@ -21,7 +55,7 @@
     "skill_used": "fabrication",
     "time": 1000,
     "reversible": false,
-    "autolearn": false,
+    "autolearn": true,
     "book_learn": [ [ "kawaii_book_pacsys_tier1", 0 ], [ "kawaii_book_pacsys_tier_kawaii", 0 ] ],
     "components": [ [ [ "kawaii_amts_pacsys", 1 ] ], [ [ "scrap", 30 ] ] ]
   },
@@ -34,7 +68,7 @@
     "skill_used": "fabrication",
     "time": 1000,
     "reversible": false,
-    "autolearn": false,
+    "autolearn": true,
     "book_learn": [ [ "kawaii_book_pacsys_tier2", 0 ], [ "kawaii_book_pacsys_tier_kawaii", 0 ] ],
     "components": [ [ [ "kawaii_amts_pacsys", 1 ] ], [ [ "rag", 30 ] ] ]
   },
@@ -47,7 +81,7 @@
     "skill_used": "fabrication",
     "time": 1000,
     "reversible": false,
-    "autolearn": false,
+    "autolearn": true,
     "book_learn": [ [ "kawaii_book_pacsys_tier2", 0 ], [ "kawaii_book_pacsys_tier_kawaii", 0 ] ],
     "components": [ [ [ "kawaii_amts_pacsys", 1 ] ], [ [ "log", 6 ] ] ]
   },
@@ -60,7 +94,7 @@
     "skill_used": "fabrication",
     "time": 1000,
     "reversible": false,
-    "autolearn": false,
+    "autolearn": true,
     "book_learn": [ [ "kawaii_book_pacsys_tier2", 0 ], [ "kawaii_book_pacsys_tier_kawaii", 0 ] ],
     "components": [ [ [ "kawaii_amts_pacsys", 1 ] ], [ [ "scrap", 60 ] ] ]
   },
@@ -73,7 +107,7 @@
     "skill_used": "fabrication",
     "time": 1000,
     "reversible": false,
-    "autolearn": false,
+    "autolearn": true,
     "book_learn": [ [ "kawaii_book_pacsys_tier2", 0 ], [ "kawaii_book_pacsys_tier_kawaii", 0 ] ],
     "components": [ [ [ "kawaii_amts_pacsys", 1 ] ], [ [ "rag", 60 ] ] ]
   },
@@ -86,7 +120,7 @@
     "skill_used": "fabrication",
     "time": 1000,
     "reversible": false,
-    "autolearn": false,
+    "autolearn": true,
     "charges": 1000,
     "book_learn": [ [ "kawaii_book_pacsys_tier1", 0 ], [ "kawaii_book_pacsys_tier_kawaii", 0 ] ],
     "qualities": [ { "id": "AMTS_TRANSMITTER", "level": 1 } ],
@@ -101,7 +135,7 @@
     "skill_used": "fabrication",
     "time": 1000,
     "reversible": false,
-    "autolearn": false,
+    "autolearn": true,
     "book_learn": [ [ "kawaii_book_pacsys_tier1", 0 ], [ "kawaii_book_pacsys_tier_kawaii", 0 ] ],
     "qualities": [ { "id": "AMTS_RECEIVER", "level": 1 } ],
     "components": [ [ [ "kawaii_amts_point", 10 ] ] ]
@@ -115,7 +149,7 @@
     "skill_used": "fabrication",
     "time": 1000,
     "reversible": false,
-    "autolearn": false,
+    "autolearn": true,
     "charges": 250,
     "book_learn": [ [ "kawaii_book_pacsys_tier1", 0 ], [ "kawaii_book_pacsys_tier_kawaii", 0 ] ],
     "qualities": [ { "id": "AMTS_TRANSMITTER", "level": 1 } ],
@@ -130,7 +164,7 @@
     "skill_used": "fabrication",
     "time": 1000,
     "reversible": false,
-    "autolearn": false,
+    "autolearn": true,
     "charges": 500,
     "book_learn": [ [ "kawaii_book_pacsys_tier2", 0 ], [ "kawaii_book_pacsys_tier_kawaii", 0 ] ],
     "qualities": [ { "id": "AMTS_TRANSMITTER", "level": 1 } ],
@@ -146,7 +180,7 @@
     "skill_used": "fabrication",
     "time": 1000,
     "reversible": false,
-    "autolearn": false,
+    "autolearn": true,
     "book_learn": [ [ "kawaii_book_pacsys_tier1", 0 ], [ "kawaii_book_pacsys_tier_kawaii", 0 ] ],
     "qualities": [ { "id": "AMTS_RECEIVER", "level": 1 } ],
     "components": [ [ [ "kawaii_amts_point", 50 ] ] ]
@@ -161,7 +195,7 @@
     "skill_used": "fabrication",
     "time": 1000,
     "reversible": false,
-    "autolearn": false,
+    "autolearn": true,
     "book_learn": [ [ "kawaii_book_pacsys_tier1", 0 ], [ "kawaii_book_pacsys_tier_kawaii", 0 ] ],
     "qualities": [ { "id": "AMTS_RECEIVER", "level": 1 } ],
     "components": [ [ [ "kawaii_amts_point", 100 ] ] ]
@@ -176,7 +210,7 @@
     "skill_used": "fabrication",
     "time": 1000,
     "reversible": false,
-    "autolearn": false,
+    "autolearn": true,
     "book_learn": [ [ "kawaii_book_pacsys_tier1", 0 ], [ "kawaii_book_pacsys_tier_kawaii", 0 ] ],
     "qualities": [ { "id": "AMTS_RECEIVER", "level": 1 } ],
     "components": [ [ [ "kawaii_amts_point", 200 ] ] ]
@@ -191,7 +225,7 @@
     "skill_used": "fabrication",
     "time": 1000,
     "reversible": false,
-    "autolearn": false,
+    "autolearn": true,
     "book_learn": [ [ "kawaii_book_pacsys_tier1", 0 ], [ "kawaii_book_pacsys_tier_kawaii", 0 ] ],
     "qualities": [ { "id": "AMTS_RECEIVER", "level": 1 } ],
     "components": [ [ [ "kawaii_amts_point", 150 ] ] ]
@@ -206,7 +240,7 @@
     "skill_used": "fabrication",
     "time": 1000,
     "reversible": false,
-    "autolearn": false,
+    "autolearn": true,
     "book_learn": [ [ "kawaii_book_pacsys_tier_kawaii", 0 ] ],
     "qualities": [ { "id": "AMTS_RECEIVER", "level": 1 } ],
     "components": [ [ [ "kawaii_amts_point", 200 ] ] ]
@@ -221,7 +255,7 @@
     "skill_used": "fabrication",
     "time": 1000,
     "reversible": false,
-    "autolearn": false,
+    "autolearn": true,
     "book_learn": [ [ "kawaii_book_pacsys_tier_kawaii", 0 ] ],
     "qualities": [ { "id": "AMTS_RECEIVER", "level": 1 } ],
     "components": [ [ [ "kawaii_amts_point", 300 ] ] ]
@@ -236,7 +270,7 @@
     "skill_used": "fabrication",
     "time": 1000,
     "reversible": false,
-    "autolearn": false,
+    "autolearn": true,
     "book_learn": [ [ "kawaii_book_pacsys_tier_kawaii", 0 ] ],
     "qualities": [ { "id": "AMTS_RECEIVER", "level": 1 } ],
     "components": [ [ [ "kawaii_amts_point", 500 ] ] ]
@@ -251,7 +285,7 @@
     "skill_used": "fabrication",
     "time": 1000,
     "reversible": false,
-    "autolearn": false,
+    "autolearn": true,
     "book_learn": [ [ "kawaii_book_pacsys_tier1", 0 ], [ "kawaii_book_pacsys_tier_kawaii", 0 ] ],
     "qualities": [ { "id": "AMTS_RECEIVER", "level": 1 } ],
     "components": [ [ [ "kawaii_amts_point", 100 ] ] ]
@@ -266,7 +300,7 @@
     "skill_used": "fabrication",
     "time": 1000,
     "reversible": false,
-    "autolearn": false,
+    "autolearn": true,
     "book_learn": [ [ "kawaii_book_pacsys_tier1", 0 ], [ "kawaii_book_pacsys_tier_kawaii", 0 ] ],
     "qualities": [ { "id": "AMTS_RECEIVER", "level": 1 } ],
     "components": [ [ [ "kawaii_amts_point", 300 ] ] ]
@@ -281,7 +315,7 @@
     "skill_used": "fabrication",
     "time": 1000,
     "reversible": false,
-    "autolearn": false,
+    "autolearn": true,
     "book_learn": [ [ "kawaii_book_pacsys_tier3", 0 ], [ "kawaii_book_pacsys_tier_kawaii", 0 ] ],
     "qualities": [ { "id": "AMTS_RECEIVER", "level": 1 } ],
     "components": [ [ [ "kawaii_amts_point", 750 ] ] ]
@@ -296,7 +330,7 @@
     "skill_used": "fabrication",
     "time": 1000,
     "reversible": false,
-    "autolearn": false,
+    "autolearn": true,
     "book_learn": [ [ "kawaii_book_pacsys_tier1", 0 ], [ "kawaii_book_pacsys_tier_kawaii", 0 ] ],
     "qualities": [ { "id": "AMTS_RECEIVER", "level": 1 } ],
     "components": [ [ [ "kawaii_amts_point", 500 ] ] ]
@@ -311,7 +345,7 @@
     "skill_used": "fabrication",
     "time": 1000,
     "reversible": false,
-    "autolearn": false,
+    "autolearn": true,
     "book_learn": [ [ "kawaii_book_pacsys_tier1", 0 ], [ "kawaii_book_pacsys_tier_kawaii", 0 ] ],
     "qualities": [ { "id": "AMTS_RECEIVER", "level": 1 } ],
     "components": [ [ [ "kawaii_amts_point", 1000 ] ] ]
@@ -326,7 +360,7 @@
     "skill_used": "fabrication",
     "time": 1000,
     "reversible": false,
-    "autolearn": false,
+    "autolearn": true,
     "book_learn": [ [ "kawaii_book_pacsys_tier1", 0 ], [ "kawaii_book_pacsys_tier_kawaii", 0 ] ],
     "qualities": [ { "id": "AMTS_RECEIVER", "level": 1 } ],
     "components": [ [ [ "kawaii_amts_point", 500 ] ] ]
@@ -341,7 +375,7 @@
     "skill_used": "fabrication",
     "time": 1000,
     "reversible": false,
-    "autolearn": false,
+    "autolearn": true,
     "book_learn": [ [ "kawaii_book_pacsys_tier1", 0 ], [ "kawaii_book_pacsys_tier_kawaii", 0 ] ],
     "qualities": [ { "id": "AMTS_RECEIVER", "level": 1 } ],
     "components": [ [ [ "kawaii_amts_point", 500 ] ] ]
@@ -356,7 +390,7 @@
     "skill_used": "fabrication",
     "time": 1000,
     "reversible": false,
-    "autolearn": false,
+    "autolearn": true,
     "book_learn": [ [ "kawaii_book_pacsys_tier3", 0 ], [ "kawaii_book_pacsys_tier_kawaii", 0 ] ],
     "qualities": [ { "id": "AMTS_RECEIVER", "level": 1 } ],
     "components": [ [ [ "kawaii_amts_point", 2000 ] ] ]
@@ -371,7 +405,7 @@
     "skill_used": "fabrication",
     "time": 1000,
     "reversible": false,
-    "autolearn": false,
+    "autolearn": true,
     "book_learn": [ [ "kawaii_book_pacsys_tier3", 0 ], [ "kawaii_book_pacsys_tier_kawaii", 0 ] ],
     "qualities": [ { "id": "AMTS_RECEIVER", "level": 1 } ],
     "components": [ [ [ "kawaii_amts_point", 3000 ] ] ]
@@ -386,7 +420,7 @@
     "skill_used": "fabrication",
     "time": 1000,
     "reversible": false,
-    "autolearn": false,
+    "autolearn": true,
     "book_learn": [ [ "kawaii_book_pacsys_tier3", 0 ], [ "kawaii_book_pacsys_tier_kawaii", 0 ] ],
     "qualities": [ { "id": "AMTS_RECEIVER", "level": 1 } ],
     "components": [ [ [ "kawaii_amts_point", 1500 ] ] ]
@@ -401,7 +435,7 @@
     "skill_used": "fabrication",
     "time": 1000,
     "reversible": false,
-    "autolearn": false,
+    "autolearn": true,
     "book_learn": [ [ "kawaii_book_pacsys_tier3", 0 ], [ "kawaii_book_pacsys_tier_kawaii", 0 ] ],
     "qualities": [ { "id": "AMTS_RECEIVER", "level": 1 } ],
     "components": [ [ [ "kawaii_amts_point", 750 ] ] ]
@@ -416,7 +450,7 @@
     "skill_used": "fabrication",
     "time": 1000,
     "reversible": false,
-    "autolearn": false,
+    "autolearn": true,
     "book_learn": [ [ "kawaii_book_pacsys_tier3", 0 ], [ "kawaii_book_pacsys_tier_kawaii", 0 ] ],
     "qualities": [ { "id": "AMTS_RECEIVER", "level": 1 } ],
     "components": [ [ [ "kawaii_amts_point", 500 ] ] ]
@@ -431,7 +465,7 @@
     "skill_used": "fabrication",
     "time": 1000,
     "reversible": false,
-    "autolearn": false,
+    "autolearn": true,
     "book_learn": [ [ "kawaii_book_pacsys_tier2", 0 ], [ "kawaii_book_pacsys_tier_kawaii", 0 ] ],
     "qualities": [ { "id": "AMTS_RECEIVER", "level": 1 } ],
     "components": [ [ [ "kawaii_amts_point", 500 ] ] ]
@@ -446,7 +480,7 @@
     "skill_used": "fabrication",
     "time": 1000,
     "reversible": false,
-    "autolearn": false,
+    "autolearn": true,
     "book_learn": [ [ "kawaii_book_pacsys_tier2", 0 ], [ "kawaii_book_pacsys_tier_kawaii", 0 ] ],
     "qualities": [ { "id": "AMTS_RECEIVER", "level": 1 } ],
     "components": [ [ [ "kawaii_amts_point", 1000 ] ] ]
@@ -461,7 +495,7 @@
     "skill_used": "fabrication",
     "time": 1000,
     "reversible": false,
-    "autolearn": false,
+    "autolearn": true,
     "book_learn": [ [ "kawaii_book_pacsys_tier3", 0 ], [ "kawaii_book_pacsys_tier_kawaii", 0 ] ],
     "qualities": [ { "id": "AMTS_RECEIVER", "level": 1 } ],
     "components": [ [ [ "kawaii_amts_point", 500 ] ] ]
@@ -476,7 +510,7 @@
     "skill_used": "fabrication",
     "time": 1000,
     "reversible": false,
-    "autolearn": false,
+    "autolearn": true,
     "book_learn": [ [ "kawaii_book_pacsys_tier3", 0 ], [ "kawaii_book_pacsys_tier_kawaii", 0 ] ],
     "qualities": [ { "id": "AMTS_RECEIVER", "level": 1 } ],
     "components": [ [ [ "kawaii_amts_point", 500 ] ] ]
@@ -491,7 +525,7 @@
     "skill_used": "fabrication",
     "time": 1000,
     "reversible": false,
-    "autolearn": false,
+    "autolearn": true,
     "book_learn": [ [ "kawaii_book_pacsys_tier3", 0 ], [ "kawaii_book_pacsys_tier_kawaii", 0 ] ],
     "qualities": [ { "id": "AMTS_RECEIVER", "level": 1 } ],
     "components": [ [ [ "kawaii_amts_point", 750 ] ] ]
@@ -506,7 +540,7 @@
     "skill_used": "fabrication",
     "time": 1000,
     "reversible": false,
-    "autolearn": false,
+    "autolearn": true,
     "book_learn": [ [ "kawaii_book_pacsys_tier3", 0 ], [ "kawaii_book_pacsys_tier_kawaii", 0 ] ],
     "qualities": [ { "id": "AMTS_RECEIVER", "level": 1 } ],
     "components": [ [ [ "kawaii_amts_point", 2500 ] ] ]
@@ -521,7 +555,7 @@
     "skill_used": "fabrication",
     "time": 1000,
     "reversible": false,
-    "autolearn": false,
+    "autolearn": true,
     "book_learn": [ [ "kawaii_book_pacsys_tier2", 0 ], [ "kawaii_book_pacsys_tier_kawaii", 0 ] ],
     "qualities": [ { "id": "AMTS_RECEIVER", "level": 1 } ],
     "components": [ [ [ "kawaii_amts_point", 1000 ] ] ]
@@ -536,7 +570,7 @@
     "skill_used": "fabrication",
     "time": 1000,
     "reversible": false,
-    "autolearn": false,
+    "autolearn": true,
     "book_learn": [ [ "kawaii_book_pacsys_tier_kawaii", 0 ] ],
     "qualities": [ { "id": "AMTS_RECEIVER", "level": 1 } ],
     "components": [ [ [ "kawaii_amts_point", 2000 ] ] ]
@@ -551,7 +585,7 @@
     "skill_used": "fabrication",
     "time": 1000,
     "reversible": false,
-    "autolearn": false,
+    "autolearn": true,
     "book_learn": [ [ "kawaii_book_pacsys_tier3", 0 ], [ "kawaii_book_pacsys_tier_kawaii", 0 ] ],
     "qualities": [ { "id": "AMTS_RECEIVER", "level": 1 } ],
     "components": [ [ [ "kawaii_amts_point", 1000 ] ] ]
@@ -566,7 +600,7 @@
     "skill_used": "fabrication",
     "time": 1000,
     "reversible": false,
-    "autolearn": false,
+    "autolearn": true,
     "book_learn": [ [ "kawaii_book_pacsys_tier2", 0 ], [ "kawaii_book_pacsys_tier_kawaii", 0 ] ],
     "qualities": [ { "id": "AMTS_RECEIVER", "level": 1 } ],
     "components": [ [ [ "kawaii_amts_point", 750 ] ] ]
@@ -581,7 +615,7 @@
     "skill_used": "fabrication",
     "time": 1000,
     "reversible": false,
-    "autolearn": false,
+    "autolearn": true,
     "book_learn": [ [ "kawaii_book_pacsys_tier2", 0 ], [ "kawaii_book_pacsys_tier_kawaii", 0 ] ],
     "qualities": [ { "id": "AMTS_RECEIVER", "level": 1 } ],
     "components": [ [ [ "kawaii_amts_point", 2000 ] ] ]
@@ -596,7 +630,7 @@
     "skill_used": "fabrication",
     "time": 1000,
     "reversible": false,
-    "autolearn": false,
+    "autolearn": true,
     "book_learn": [ [ "kawaii_book_pacsys_tier2", 0 ], [ "kawaii_book_pacsys_tier_kawaii", 0 ] ],
     "qualities": [ { "id": "AMTS_RECEIVER", "level": 1 } ],
     "components": [ [ [ "kawaii_amts_point", 2000 ] ] ]
@@ -611,7 +645,7 @@
     "skill_used": "fabrication",
     "time": 1000,
     "reversible": false,
-    "autolearn": false,
+    "autolearn": true,
     "book_learn": [ [ "kawaii_book_pacsys_tier2", 0 ], [ "kawaii_book_pacsys_tier_kawaii", 0 ] ],
     "qualities": [ { "id": "AMTS_RECEIVER", "level": 1 } ],
     "components": [ [ [ "kawaii_amts_point", 1500 ] ] ]
@@ -626,7 +660,7 @@
     "skill_used": "fabrication",
     "time": 1000,
     "reversible": false,
-    "autolearn": false,
+    "autolearn": true,
     "book_learn": [ [ "kawaii_book_pacsys_tier3", 0 ], [ "kawaii_book_pacsys_tier_kawaii", 0 ] ],
     "qualities": [ { "id": "AMTS_RECEIVER", "level": 1 } ],
     "components": [ [ [ "kawaii_amts_point", 3000 ] ] ]
@@ -641,7 +675,7 @@
     "skill_used": "fabrication",
     "time": 1000,
     "reversible": false,
-    "autolearn": false,
+    "autolearn": true,
     "book_learn": [ [ "kawaii_book_pacsys_tier2", 0 ], [ "kawaii_book_pacsys_tier_kawaii", 0 ] ],
     "qualities": [ { "id": "AMTS_RECEIVER", "level": 1 } ],
     "components": [ [ [ "kawaii_amts_point", 1000 ] ] ]
@@ -656,7 +690,7 @@
     "skill_used": "fabrication",
     "time": 1000,
     "reversible": false,
-    "autolearn": false,
+    "autolearn": true,
     "book_learn": [ [ "kawaii_book_pacsys_tier3", 0 ], [ "kawaii_book_pacsys_tier_kawaii", 0 ] ],
     "qualities": [ { "id": "AMTS_RECEIVER", "level": 1 } ],
     "components": [ [ [ "kawaii_amts_point", 2500 ] ] ]
@@ -671,7 +705,7 @@
     "skill_used": "fabrication",
     "time": 1000,
     "reversible": false,
-    "autolearn": false,
+    "autolearn": true,
     "book_learn": [ [ "kawaii_book_pacsys_tier3", 0 ], [ "kawaii_book_pacsys_tier_kawaii", 0 ] ],
     "qualities": [ { "id": "AMTS_RECEIVER", "level": 1 } ],
     "components": [ [ [ "kawaii_amts_point", 1000 ] ] ]
@@ -686,7 +720,7 @@
     "skill_used": "fabrication",
     "time": 1000,
     "reversible": false,
-    "autolearn": false,
+    "autolearn": true,
     "book_learn": [ [ "kawaii_book_pacsys_tier3", 0 ], [ "kawaii_book_pacsys_tier_kawaii", 0 ] ],
     "qualities": [ { "id": "AMTS_RECEIVER", "level": 1 } ],
     "components": [ [ [ "kawaii_amts_point", 2000 ] ] ]
@@ -701,7 +735,7 @@
     "skill_used": "fabrication",
     "time": 1000,
     "reversible": false,
-    "autolearn": false,
+    "autolearn": true,
     "book_learn": [ [ "kawaii_book_pacsys_tier3", 0 ], [ "kawaii_book_pacsys_tier_kawaii", 0 ] ],
     "qualities": [ { "id": "AMTS_RECEIVER", "level": 1 } ],
     "components": [ [ [ "kawaii_amts_point", 600 ] ] ]
@@ -716,7 +750,7 @@
     "skill_used": "fabrication",
     "time": 1000,
     "reversible": false,
-    "autolearn": false,
+    "autolearn": true,
     "book_learn": [ [ "kawaii_book_pacsys_tier3", 0 ], [ "kawaii_book_pacsys_tier_kawaii", 0 ] ],
     "qualities": [ { "id": "AMTS_RECEIVER", "level": 1 } ],
     "components": [ [ [ "kawaii_amts_point", 500 ] ] ]
@@ -731,7 +765,7 @@
     "skill_used": "fabrication",
     "time": 1000,
     "reversible": false,
-    "autolearn": false,
+    "autolearn": true,
     "book_learn": [ [ "kawaii_book_pacsys_tier3", 0 ], [ "kawaii_book_pacsys_tier_kawaii", 0 ] ],
     "qualities": [ { "id": "AMTS_RECEIVER", "level": 1 } ],
     "components": [ [ [ "kawaii_amts_point", 1000 ] ] ]
@@ -746,7 +780,7 @@
     "skill_used": "fabrication",
     "time": 1000,
     "reversible": false,
-    "autolearn": false,
+    "autolearn": true,
     "book_learn": [ [ "kawaii_book_pacsys_tier3", 0 ], [ "kawaii_book_pacsys_tier_kawaii", 0 ] ],
     "qualities": [ { "id": "AMTS_RECEIVER", "level": 1 } ],
     "components": [ [ [ "kawaii_amts_point", 2000 ] ] ]
@@ -761,7 +795,7 @@
     "skill_used": "fabrication",
     "time": 1000,
     "reversible": false,
-    "autolearn": false,
+    "autolearn": true,
     "book_learn": [ [ "kawaii_book_pacsys_tier_kawaii", 0 ] ],
     "qualities": [ { "id": "AMTS_RECEIVER", "level": 1 } ],
     "components": [ [ [ "kawaii_amts_point", 5000 ] ] ]
@@ -776,7 +810,7 @@
     "skill_used": "fabrication",
     "time": 1000,
     "reversible": false,
-    "autolearn": false,
+    "autolearn": true,
     "book_learn": [ [ "kawaii_book_pacsys_tier_kawaii", 0 ] ],
     "qualities": [ { "id": "AMTS_RECEIVER", "level": 1 } ],
     "components": [ [ [ "kawaii_amts_point", 5000 ] ] ]
@@ -791,7 +825,7 @@
     "skill_used": "fabrication",
     "time": 1000,
     "reversible": false,
-    "autolearn": false,
+    "autolearn": true,
     "book_learn": [ [ "kawaii_book_pacsys_tier_kawaii", 0 ] ],
     "qualities": [ { "id": "AMTS_RECEIVER", "level": 1 } ],
     "components": [ [ [ "kawaii_amts_point", 3000 ] ] ]
@@ -806,7 +840,7 @@
     "skill_used": "fabrication",
     "time": 1000,
     "reversible": false,
-    "autolearn": false,
+    "autolearn": true,
     "book_learn": [ [ "kawaii_book_pacsys_tier1", 0 ], [ "kawaii_book_pacsys_tier_kawaii", 0 ] ],
     "qualities": [ { "id": "AMTS_RECEIVER", "level": 1 } ],
     "components": [ [ [ "kawaii_amts_point", 200 ] ] ]
@@ -821,7 +855,7 @@
     "skill_used": "fabrication",
     "time": 1000,
     "reversible": false,
-    "autolearn": false,
+    "autolearn": true,
     "book_learn": [ [ "kawaii_book_pacsys_tier1", 0 ], [ "kawaii_book_pacsys_tier_kawaii", 0 ] ],
     "qualities": [ { "id": "AMTS_RECEIVER", "level": 1 } ],
     "components": [ [ [ "kawaii_amts_point", 500 ] ] ]
@@ -836,7 +870,7 @@
     "skill_used": "fabrication",
     "time": 100,
     "reversible": false,
-    "autolearn": false,
+    "autolearn": true,
     "book_learn": [ [ "kawaii_book_pacsys_tier1", 0 ], [ "kawaii_book_pacsys_tier_kawaii", 0 ] ],
     "qualities": [ { "id": "AMTS_RECEIVER", "level": 1 } ],
     "components": [ [ [ "kawaii_amts_point", 200 ] ] ]
@@ -851,7 +885,7 @@
     "skill_used": "fabrication",
     "time": 100,
     "reversible": false,
-    "autolearn": false,
+    "autolearn": true,
     "book_learn": [ [ "kawaii_book_pacsys_tier1", 0 ], [ "kawaii_book_pacsys_tier_kawaii", 0 ] ],
     "qualities": [ { "id": "AMTS_RECEIVER", "level": 1 } ],
     "components": [ [ [ "kawaii_amts_point", 200 ] ] ]
@@ -866,7 +900,7 @@
     "skill_used": "fabrication",
     "time": 100,
     "reversible": false,
-    "autolearn": false,
+    "autolearn": true,
     "book_learn": [ [ "kawaii_book_pacsys_tier1", 0 ], [ "kawaii_book_pacsys_tier_kawaii", 0 ] ],
     "qualities": [ { "id": "AMTS_RECEIVER", "level": 1 } ],
     "components": [ [ [ "kawaii_amts_point", 50 ] ] ]
@@ -881,7 +915,7 @@
     "skill_used": "fabrication",
     "time": 100,
     "reversible": false,
-    "autolearn": false,
+    "autolearn": true,
     "book_learn": [ [ "kawaii_book_pacsys_tier1", 0 ], [ "kawaii_book_pacsys_tier_kawaii", 0 ] ],
     "qualities": [ { "id": "AMTS_RECEIVER", "level": 1 } ],
     "components": [ [ [ "kawaii_amts_point", 50 ] ] ]
@@ -896,7 +930,7 @@
     "skill_used": "fabrication",
     "time": 100,
     "reversible": false,
-    "autolearn": false,
+    "autolearn": true,
     "book_learn": [ [ "kawaii_book_pacsys_tier1", 0 ], [ "kawaii_book_pacsys_tier_kawaii", 0 ] ],
     "qualities": [ { "id": "AMTS_RECEIVER", "level": 1 } ],
     "components": [ [ [ "kawaii_amts_point", 300 ] ] ]
@@ -911,7 +945,7 @@
     "skill_used": "fabrication",
     "time": 100,
     "reversible": false,
-    "autolearn": false,
+    "autolearn": true,
     "book_learn": [ [ "kawaii_book_pacsys_tier2", 0 ], [ "kawaii_book_pacsys_tier_kawaii", 0 ] ],
     "qualities": [ { "id": "AMTS_RECEIVER", "level": 1 } ],
     "components": [ [ [ "kawaii_amts_point", 500 ] ] ]
@@ -926,7 +960,7 @@
     "skill_used": "fabrication",
     "time": 100,
     "reversible": false,
-    "autolearn": false,
+    "autolearn": true,
     "book_learn": [ [ "kawaii_book_pacsys_tier2", 0 ], [ "kawaii_book_pacsys_tier_kawaii", 0 ] ],
     "qualities": [ { "id": "AMTS_RECEIVER", "level": 1 } ],
     "components": [ [ [ "kawaii_amts_point", 500 ] ] ]
@@ -941,7 +975,7 @@
     "skill_used": "fabrication",
     "time": 1000,
     "reversible": false,
-    "autolearn": false,
+    "autolearn": true,
     "book_learn": [ [ "kawaii_book_pacsys_tier3", 0 ], [ "kawaii_book_pacsys_tier_kawaii", 0 ] ],
     "qualities": [ { "id": "AMTS_RECEIVER", "level": 1 } ],
     "components": [ [ [ "kawaii_amts_point", 200 ] ] ]
@@ -956,7 +990,7 @@
     "skill_used": "fabrication",
     "time": 1000,
     "reversible": false,
-    "autolearn": false,
+    "autolearn": true,
     "book_learn": [ [ "kawaii_book_pacsys_tier3", 0 ], [ "kawaii_book_pacsys_tier_kawaii", 0 ] ],
     "qualities": [ { "id": "AMTS_RECEIVER", "level": 1 } ],
     "components": [ [ [ "kawaii_amts_point", 2500 ] ] ]
@@ -971,7 +1005,7 @@
     "skill_used": "fabrication",
     "time": 1000,
     "reversible": false,
-    "autolearn": false,
+    "autolearn": true,
     "book_learn": [ [ "kawaii_book_pacsys_tier3", 0 ], [ "kawaii_book_pacsys_tier_kawaii", 0 ] ],
     "qualities": [ { "id": "AMTS_RECEIVER", "level": 1 } ],
     "components": [ [ [ "kawaii_amts_point", 3000 ] ] ]
@@ -986,7 +1020,7 @@
     "skill_used": "fabrication",
     "time": 1000,
     "reversible": false,
-    "autolearn": false,
+    "autolearn": true,
     "book_learn": [ [ "kawaii_book_pacsys_tier3", 0 ], [ "kawaii_book_pacsys_tier_kawaii", 0 ] ],
     "qualities": [ { "id": "AMTS_RECEIVER", "level": 1 } ],
     "components": [ [ [ "kawaii_amts_point", 1500 ] ] ]
@@ -1001,7 +1035,7 @@
     "skill_used": "fabrication",
     "time": 1000,
     "reversible": false,
-    "autolearn": false,
+    "autolearn": true,
     "book_learn": [ [ "kawaii_book_pacsys_tier3", 0 ], [ "kawaii_book_pacsys_tier_kawaii", 0 ] ],
     "qualities": [ { "id": "AMTS_RECEIVER", "level": 1 } ],
     "components": [ [ [ "kawaii_amts_point", 2000 ] ] ]
@@ -1016,7 +1050,7 @@
     "skill_used": "fabrication",
     "time": 1000,
     "reversible": false,
-    "autolearn": false,
+    "autolearn": true,
     "book_learn": [ [ "kawaii_book_pacsys_tier3", 0 ], [ "kawaii_book_pacsys_tier_kawaii", 0 ] ],
     "qualities": [ { "id": "AMTS_RECEIVER", "level": 1 } ],
     "components": [ [ [ "kawaii_amts_point", 3500 ] ] ]
@@ -1031,7 +1065,7 @@
     "skill_used": "fabrication",
     "time": 1000,
     "reversible": false,
-    "autolearn": false,
+    "autolearn": true,
     "book_learn": [ [ "kawaii_book_pacsys_tier3", 0 ], [ "kawaii_book_pacsys_tier_kawaii", 0 ] ],
     "qualities": [ { "id": "AMTS_RECEIVER", "level": 1 } ],
     "components": [ [ [ "kawaii_amts_point", 750 ] ] ]
@@ -1046,7 +1080,7 @@
     "skill_used": "fabrication",
     "time": 1000,
     "reversible": false,
-    "autolearn": false,
+    "autolearn": true,
     "book_learn": [ [ "kawaii_book_pacsys_tier3", 0 ], [ "kawaii_book_pacsys_tier_kawaii", 0 ] ],
     "qualities": [ { "id": "AMTS_RECEIVER", "level": 1 } ],
     "components": [ [ [ "kawaii_amts_point", 6000 ] ] ]
@@ -1061,7 +1095,7 @@
     "skill_used": "fabrication",
     "time": 1000,
     "reversible": false,
-    "autolearn": false,
+    "autolearn": true,
     "book_learn": [ [ "kawaii_book_pacsys_tier3", 0 ], [ "kawaii_book_pacsys_tier_kawaii", 0 ] ],
     "qualities": [ { "id": "AMTS_RECEIVER", "level": 1 } ],
     "components": [ [ [ "kawaii_amts_point", 6000 ] ] ]
@@ -1076,7 +1110,7 @@
     "skill_used": "fabrication",
     "time": 1000,
     "reversible": false,
-    "autolearn": false,
+    "autolearn": true,
     "book_learn": [ [ "kawaii_book_pacsys_tier3", 0 ], [ "kawaii_book_pacsys_tier_kawaii", 0 ] ],
     "qualities": [ { "id": "AMTS_RECEIVER", "level": 1 } ],
     "components": [ [ [ "kawaii_amts_point", 3500 ] ] ]
@@ -1091,7 +1125,7 @@
     "skill_used": "fabrication",
     "time": 1000,
     "reversible": false,
-    "autolearn": false,
+    "autolearn": true,
     "book_learn": [ [ "kawaii_book_pacsys_tier3", 0 ], [ "kawaii_book_pacsys_tier_kawaii", 0 ] ],
     "qualities": [ { "id": "AMTS_RECEIVER", "level": 1 } ],
     "components": [ [ [ "kawaii_amts_point", 4000 ] ] ]
@@ -1106,7 +1140,7 @@
     "skill_used": "fabrication",
     "time": 1000,
     "reversible": false,
-    "autolearn": false,
+    "autolearn": true,
     "book_learn": [ [ "kawaii_book_pacsys_tier3", 0 ], [ "kawaii_book_pacsys_tier_kawaii", 0 ] ],
     "qualities": [ { "id": "AMTS_RECEIVER", "level": 1 } ],
     "components": [ [ [ "kawaii_amts_point", 2500 ] ] ]
@@ -1121,7 +1155,7 @@
     "skill_used": "fabrication",
     "time": 1000,
     "reversible": false,
-    "autolearn": false,
+    "autolearn": true,
     "book_learn": [ [ "kawaii_book_pacsys_tier3", 0 ], [ "kawaii_book_pacsys_tier_kawaii", 0 ] ],
     "qualities": [ { "id": "AMTS_RECEIVER", "level": 1 } ],
     "components": [ [ [ "kawaii_amts_point", 4500 ] ] ]
@@ -1136,7 +1170,7 @@
     "skill_used": "fabrication",
     "time": 1000,
     "reversible": false,
-    "autolearn": false,
+    "autolearn": true,
     "book_learn": [ [ "kawaii_book_pacsys_tier3", 0 ], [ "kawaii_book_pacsys_tier_kawaii", 0 ] ],
     "qualities": [ { "id": "AMTS_RECEIVER", "level": 1 } ],
     "components": [ [ [ "kawaii_amts_point", 1500 ] ] ]
@@ -1151,7 +1185,7 @@
     "skill_used": "fabrication",
     "time": 1000,
     "reversible": false,
-    "autolearn": false,
+    "autolearn": true,
     "book_learn": [ [ "kawaii_book_pacsys_tier3", 0 ], [ "kawaii_book_pacsys_tier_kawaii", 0 ] ],
     "qualities": [ { "id": "AMTS_RECEIVER", "level": 1 } ],
     "components": [ [ [ "kawaii_amts_point", 1500 ] ] ]
@@ -1166,7 +1200,7 @@
     "skill_used": "fabrication",
     "time": 1000,
     "reversible": false,
-    "autolearn": false,
+    "autolearn": true,
     "book_learn": [ [ "kawaii_book_pacsys_tier3", 0 ], [ "kawaii_book_pacsys_tier_kawaii", 0 ] ],
     "qualities": [ { "id": "AMTS_RECEIVER", "level": 1 } ],
     "components": [ [ [ "kawaii_amts_point", 8500 ] ] ]
@@ -1181,7 +1215,7 @@
     "skill_used": "fabrication",
     "time": 1000,
     "reversible": false,
-    "autolearn": false,
+    "autolearn": true,
     "book_learn": [ [ "kawaii_book_pacsys_tier3", 0 ], [ "kawaii_book_pacsys_tier_kawaii", 0 ] ],
     "qualities": [ { "id": "AMTS_RECEIVER", "level": 1 } ],
     "components": [ [ [ "kawaii_amts_point", 2000 ] ] ]


### PR DESCRIPTION
- The recipe for converting T1 packages into points does not appear in-game, even when using the "unlock all recipes" debug cheat. So I removed T1 resource packages were removed to prevent confusion, at least until the issue could be figured out.
- The AMTS Transmitter and Receiver were not appearing in their relevant itemgroup spawn locations. Not sure why exactly, but as a workaround made them craftable so they can still be obtained.