### PR TITLE
Update modular turrets to drop ammo

### DIFF
--- a/Kenan-Modpack/Modular_Turrets/monster.json
+++ b/Kenan-Modpack/Modular_Turrets/monster.json
@@ -17,7 +17,7 @@
     "armor_acid": 14,
     "death_function": [ "BROKEN" ],
     "death_drops": "broken_robots",
-    "flags": [ "SEES", "NOHEAD", "ELECTRONIC", "IMMOBILE", "NO_BREATHE" ]
+    "flags": [ "SEES", "NOHEAD", "ELECTRONIC", "IMMOBILE", "NO_BREATHE", "DROPS_AMMO" ]
   },
   {
     "id": "mon_turret_disarmed",
@@ -67,6 +67,7 @@
     "color": "light_gray",
     "luminance": 200,
     "revert_to_itype": "bot_turret_9mm",
+    "starting_ammo": { "9mm": 100 },	
     "special_attacks": [
       {
         "type": "gun",
@@ -90,6 +91,7 @@
     "color": "red",
     "luminance": 200,
     "revert_to_itype": "bot_turret_shot",
+	"starting_ammo": { "shot_00": 75 },
     "special_attacks": [
       {
         "type": "gun",
@@ -159,6 +161,7 @@
     "color": "green",
     "luminance": 200,
     "revert_to_itype": "bot_milturret_556",
+	"starting_ammo": { "556": 100 },
     "special_attacks": [
       {
         "type": "gun",
@@ -189,6 +192,7 @@
     "color": "green",
     "luminance": 200,
     "revert_to_itype": "bot_milturret_308",
+	"starting_ammo": { "762_51": 75 },
     "special_attacks": [
       {
         "type": "gun",
@@ -219,6 +223,7 @@
     "color": "green",
     "luminance": 200,
     "revert_to_itype": "bot_milturret_50bmg",
+	"starting_ammo": { "50bmg": 75 },
     "special_attacks": [
       {
         "type": "gun",
@@ -250,6 +255,7 @@
     "color": "green",
     "luminance": 200,
     "revert_to_itype": "bot_milturret_8x40mm",
+    "starting_ammo": { "8mm_fmj": 150 },
     "special_attacks": [
       {
         "type": "gun",
@@ -280,6 +286,7 @@
     "color": "green",
     "luminance": 200,
     "revert_to_itype": "bot_milturret_needle",
+	"starting_ammo": { "5x50dart": 150 },
     "special_attacks": [
       {
         "type": "gun",
@@ -310,6 +317,7 @@
     "color": "red",
     "luminance": 200,
     "revert_to_itype": "bot_milturret_40mm",
+    "starting_ammo": { "40x46mm_m433": 15 },	
     "special_attacks": [
       {
         "type": "gun",

--- a/Kenan-Modpack/Modular_Turrets/monster.json
+++ b/Kenan-Modpack/Modular_Turrets/monster.json
@@ -67,7 +67,7 @@
     "color": "light_gray",
     "luminance": 200,
     "revert_to_itype": "bot_turret_9mm",
-    "starting_ammo": { "9mm": 100 },	
+    "starting_ammo": { "9mm": 100 },
     "special_attacks": [
       {
         "type": "gun",
@@ -91,7 +91,7 @@
     "color": "red",
     "luminance": 200,
     "revert_to_itype": "bot_turret_shot",
-	"starting_ammo": { "shot_00": 75 },
+    "starting_ammo": { "shot_00": 75 },
     "special_attacks": [
       {
         "type": "gun",
@@ -161,7 +161,7 @@
     "color": "green",
     "luminance": 200,
     "revert_to_itype": "bot_milturret_556",
-	"starting_ammo": { "556": 100 },
+    "starting_ammo": { "556": 100 },
     "special_attacks": [
       {
         "type": "gun",
@@ -192,7 +192,7 @@
     "color": "green",
     "luminance": 200,
     "revert_to_itype": "bot_milturret_308",
-	"starting_ammo": { "762_51": 75 },
+    "starting_ammo": { "762_51": 75 },
     "special_attacks": [
       {
         "type": "gun",
@@ -223,7 +223,7 @@
     "color": "green",
     "luminance": 200,
     "revert_to_itype": "bot_milturret_50bmg",
-	"starting_ammo": { "50bmg": 75 },
+    "starting_ammo": { "50bmg": 75 },
     "special_attacks": [
       {
         "type": "gun",
@@ -286,7 +286,7 @@
     "color": "green",
     "luminance": 200,
     "revert_to_itype": "bot_milturret_needle",
-	"starting_ammo": { "5x50dart": 150 },
+    "starting_ammo": { "5x50dart": 150 },
     "special_attacks": [
       {
         "type": "gun",
@@ -317,7 +317,7 @@
     "color": "red",
     "luminance": 200,
     "revert_to_itype": "bot_milturret_40mm",
-    "starting_ammo": { "40x46mm_m433": 15 },	
+    "starting_ammo": { "40x46mm_m433": 15 },
     "special_attacks": [
       {
         "type": "gun",


### PR DESCRIPTION
The amount of ammo dropped is static so I used really low numbers since they are now a guaranteed source of ammo, this way a player who kills the 4 turrets to military bunker entrance isn't all of a sudden swimming in 10,000 rounds of 556