### PR TITLE
fix: Modular_Turrets overwrite makes hub01 mission unable to complete

### DIFF
--- a/Kenan-Modpack/Modular_Turrets/monster_override.json
+++ b/Kenan-Modpack/Modular_Turrets/monster_override.json
@@ -177,32 +177,37 @@
   {
     "type": "MONSTER",
     "id": "mon_copbot",
-    "copy-from": "mon_defbot_riotcontrol"
+    "copy-from": "mon_defbot_riotcontrol",
+    "revert_to_itype": "bot_copbot"
   },
   {
     "type": "MONSTER",
     "id": "mon_riotbot",
     "looks_like": "mon_secubot",
-    "copy-from": "mon_defbot_riotcontrol"
+    "copy-from": "mon_defbot_riotcontrol",
+    "revert_to_itype": "bot_riotbot"
   },
   {
     "type": "MONSTER",
     "id": "mon_secubot",
     "copy-from": "mon_defbot_9mm",
-    "description": "An automated defense robot still active due to its internal power source. This one is equipped with an integrated 9mm firearm."
+    "description": "An automated defense robot still active due to its internal power source. This one is equipped with an integrated 9mm firearm.",
+    "revert_to_itype": "bot_secubot"
   },
   {
     "type": "MONSTER",
     "id": "mon_chickenbot",
     "copy-from": "mon_chickenbot",
     "death_drops": { "groups": [ [ "broken_robots", 5 ] ] },
-    "death_function": [ "BROKEN" ]
+    "death_function": [ "BROKEN" ],
+    "revert_to_itype": "bot_chickenbot"
   },
   {
     "type": "MONSTER",
     "id": "mon_tankbot",
     "copy-from": "mon_tankbot",
     "death_drops": { "groups": [ [ "broken_robots", 5 ] ] },
-    "death_function": [ "BROKEN" ]
+    "death_function": [ "BROKEN" ],
+    "revert_to_itype": "bot_tankbot"
   }
 ]


### PR DESCRIPTION
Hub01 have a mission that ask to bring back a bot, and generated mission target is unable to revert to item, due to lack of `revert_to_itype` in JSON.

I try add this and that mission is OK now (can "e" to bring bot back to item to hand for the mission), so I bring it here so this fix can be used by every one.