### PR TITLE
Add Easy Containers: Simplification of the pocket system

### DIFF
--- a/Kenan-Modpack/easy_containers/items/armor/ammo_pouch.json
+++ b/Kenan-Modpack/easy_containers/items/armor/ammo_pouch.json
@@ -1,0 +1,448 @@
+[
+    {
+        "type": "ARMOR",
+        "id": "ammo_pouch",
+        "copy-from": "ammo_pouch",
+        "name": {
+            "str": "ammo pouch",
+            "str_pl": "ammo pouches"
+        },
+        "pocket_data": [
+            {
+                "ammo_restriction": {
+                    "pebble": 60,
+                    "700nx": 60,
+                    "50": 60,
+                    "4570": 60,
+                    "BB": 60,
+                    "410shot": 60,
+                    "22": 60,
+                    "shot": 60,
+                    "9mm": 60,
+                    "357sig": 60,
+                    "9x18": 60,
+                    "380": 60,
+                    "38": 60,
+                    "40": 60,
+                    "10mm": 60,
+                    "44": 60,
+                    "45": 60,
+                    "460": 60,
+                    "454": 60,
+                    "45colt": 60,
+                    "500": 60,
+                    "57": 60,
+                    "46": 60,
+                    "762": 60,
+                    "545x39": 60,
+                    "223": 60,
+                    "3006": 60,
+                    "270win": 60,
+                    "308": 60,
+                    "12mm": 60,
+                    "8x40mm": 60,
+                    "20x66mm": 60,
+                    "5x50": 60,
+                    "metal_rail": 60,
+                    "stimpack_ammo": 60,
+                    "ampoule": 60,
+                    "300": 60,
+                    "32": 60,
+                    "762x25": 60,
+                    "flintlock": 60,
+                    "36paper": 60,
+                    "44paper": 60,
+                    "762R": 60,
+                    "paintball": 60
+                },
+                "moves": 35,
+                "max_contains_weight": "1000 kg",
+                "max_item_length": "1 km"
+            }
+        ]
+    },
+    {
+        "type": "ARMOR",
+        "id": "ammo_satchel",
+        "copy-from": "ammo_satchel",
+        "name": {
+            "str": "ammo satchel"
+        },
+        "pocket_data": [
+            {
+                "pocket_type": "CONTAINER",
+                "max_item_length": "1 km",
+                "max_contains_volume": "1500 ml",
+                "max_contains_weight": "1000 kg",
+                "moves": 40,
+                "flag_restriction": [
+                    "MAG_COMPACT",
+                    "MAG_BULKY"
+                ]
+            }
+        ]
+    },
+    {
+        "type": "ARMOR",
+        "id": "chestpouch",
+        "copy-from": "chestpouch",
+        "name": {
+            "str": "chest ammo pouch",
+            "str_pl": "chest ammo pouches"
+        },
+        "pocket_data": [
+            {
+                "pocket_type": "CONTAINER",
+                "max_item_length": "1 km",
+                "max_contains_volume": "750 ml",
+                "max_contains_weight": "1000 kg",
+                "moves": 40,
+                "flag_restriction": [
+                    "MAG_COMPACT"
+                ]
+            }
+        ]
+    },
+    {
+        "type": "ARMOR",
+        "id": "chestrig",
+        "copy-from": "chestrig",
+        "name": {
+            "str_sp": "chest rig"
+        },
+        "pocket_data": [
+            {
+                "pocket_type": "CONTAINER",
+                "max_item_length": "1 km",
+                "max_contains_volume": "750 ml",
+                "max_contains_weight": "1000 kg",
+                "moves": 40,
+                "flag_restriction": [
+                    "MAG_COMPACT"
+                ]
+            },
+            {
+                "pocket_type": "CONTAINER",
+                "max_item_length": "1 km",
+                "max_contains_volume": "750 ml",
+                "max_contains_weight": "1000 kg",
+                "moves": 40,
+                "flag_restriction": [
+                    "MAG_COMPACT"
+                ]
+            },
+            {
+                "pocket_type": "CONTAINER",
+                "max_item_length": "1 km",
+                "max_contains_volume": "750 ml",
+                "max_contains_weight": "1000 kg",
+                "moves": 40,
+                "flag_restriction": [
+                    "MAG_COMPACT"
+                ]
+            },
+            {
+                "pocket_type": "CONTAINER",
+                "max_item_length": "1 km",
+                "max_contains_volume": "750 ml",
+                "max_contains_weight": "1000 kg",
+                "moves": 40,
+                "flag_restriction": [
+                    "MAG_COMPACT"
+                ]
+            }
+        ]
+    },
+    {
+        "type": "ARMOR",
+        "id": "javelin_bag",
+        "copy-from": "javelin_bag",
+        "name": {
+            "str": "javelin bag"
+        },
+        "pocket_data": [
+            {
+                "pocket_type": "CONTAINER",
+                "max_contains_volume": "1250 ml",
+                "max_contains_weight": "1000 kg",
+                "moves": 30,
+                "flag_restriction": [
+                    "JAVELIN"
+                ],
+                "max_item_length": "1 km"
+            },
+            {
+                "pocket_type": "CONTAINER",
+                "max_contains_volume": "1250 ml",
+                "max_contains_weight": "1000 kg",
+                "moves": 30,
+                "flag_restriction": [
+                    "JAVELIN"
+                ],
+                "max_item_length": "1 km"
+            },
+            {
+                "pocket_type": "CONTAINER",
+                "max_contains_volume": "1250 ml",
+                "max_contains_weight": "1000 kg",
+                "moves": 30,
+                "flag_restriction": [
+                    "JAVELIN"
+                ],
+                "max_item_length": "1 km"
+            },
+            {
+                "pocket_type": "CONTAINER",
+                "max_contains_volume": "1250 ml",
+                "max_contains_weight": "1000 kg",
+                "moves": 30,
+                "flag_restriction": [
+                    "JAVELIN"
+                ],
+                "max_item_length": "1 km"
+            },
+            {
+                "pocket_type": "CONTAINER",
+                "max_contains_volume": "1250 ml",
+                "max_contains_weight": "1000 kg",
+                "moves": 30,
+                "flag_restriction": [
+                    "JAVELIN"
+                ],
+                "max_item_length": "1 km"
+            }
+        ]
+    },
+    {
+        "type": "ARMOR",
+        "id": "legpouch",
+        "copy-from": "legpouch",
+        "name": {
+            "str": "ankle ammo pouch",
+            "str_pl": "ankle ammo pouches"
+        },
+        "pocket_data": [
+            {
+                "pocket_type": "CONTAINER",
+                "max_item_length": "1 km",
+                "max_contains_volume": "250 ml",
+                "max_contains_weight": "1000 kg",
+                "moves": 40,
+                "flag_restriction": [
+                    "MAG_COMPACT"
+                ]
+            }
+        ]
+    },
+    {
+        "type": "ARMOR",
+        "id": "legpouch_large",
+        "copy-from": "legpouch_large",
+        "name": {
+            "str": "leg ammo pouch",
+            "str_pl": "leg ammo pouches"
+        },
+        "pocket_data": [
+            {
+                "pocket_type": "CONTAINER",
+                "max_item_length": "1 km",
+                "max_contains_volume": "500 ml",
+                "max_contains_weight": "1000 kg",
+                "moves": 40,
+                "flag_restriction": [
+                    "MAG_COMPACT"
+                ]
+            },
+            {
+                "pocket_type": "CONTAINER",
+                "max_item_length": "1 km",
+                "max_contains_volume": "500 ml",
+                "max_contains_weight": "1000 kg",
+                "moves": 40,
+                "flag_restriction": [
+                    "MAG_COMPACT"
+                ]
+            }
+        ]
+    },
+    {
+        "type": "ARMOR",
+        "id": "quiver",
+        "copy-from": "quiver",
+        "name": {
+            "str": "quiver"
+        },
+        "pocket_data": [
+            {
+                "ammo_restriction": {
+                    "arrow": 20,
+                    "bolt": 20
+                },
+                "moves": 20,
+                "max_contains_weight": "1000 kg",
+                "max_item_length": "1 km"
+            }
+        ]
+    },
+    {
+        "type": "ARMOR",
+        "id": "quiver_birchbark",
+        "copy-from": "quiver_birchbark",
+        "name": {
+            "str": "birchbark quiver"
+        },
+        "pocket_data": [
+            {
+                "ammo_restriction": {
+                    "arrow": 20,
+                    "bolt": 20
+                },
+                "moves": 20,
+                "max_contains_weight": "1000 kg",
+                "max_item_length": "1 km"
+            }
+        ]
+    },
+    {
+        "type": "ARMOR",
+        "id": "quiver_large",
+        "copy-from": "quiver_large",
+        "name": {
+            "str": "large quiver"
+        },
+        "pocket_data": [
+            {
+                "ammo_restriction": {
+                    "arrow": 60,
+                    "bolt": 60
+                },
+                "moves": 20,
+                "max_contains_weight": "1000 kg",
+                "max_item_length": "1 km"
+            }
+        ]
+    },
+    {
+        "type": "ARMOR",
+        "id": "quiver_large_birchbark",
+        "copy-from": "quiver_large_birchbark",
+        "name": {
+            "str": "large birchbark quiver"
+        },
+        "pocket_data": [
+            {
+                "ammo_restriction": {
+                    "arrow": 60,
+                    "bolt": 60
+                },
+                "moves": 20,
+                "max_contains_weight": "1000 kg",
+                "max_item_length": "1 km"
+            }
+        ]
+    },
+    {
+        "type": "ARMOR",
+        "id": "tacvest",
+        "copy-from": "tacvest",
+        "name": {
+            "str": "tac vest"
+        },
+        "pocket_data": [
+            {
+                "pocket_type": "CONTAINER",
+                "max_item_length": "1 km",
+                "max_contains_volume": "1 L",
+                "max_contains_weight": "1000 kg",
+                "flag_restriction": [
+                    "MAG_COMPACT",
+                    "MAG_BULKY"
+                ],
+                "moves": 60
+            },
+            {
+                "pocket_type": "CONTAINER",
+                "max_item_length": "1 km",
+                "max_contains_volume": "1 L",
+                "max_contains_weight": "1000 kg",
+                "flag_restriction": [
+                    "MAG_COMPACT",
+                    "MAG_BULKY"
+                ],
+                "moves": 60
+            },
+            {
+                "pocket_type": "CONTAINER",
+                "max_item_length": "1 km",
+                "max_contains_volume": "1 L",
+                "max_contains_weight": "1000 kg",
+                "flag_restriction": [
+                    "MAG_COMPACT",
+                    "MAG_BULKY"
+                ],
+                "moves": 60
+            },
+            {
+                "pocket_type": "CONTAINER",
+                "max_item_length": "1 km",
+                "max_contains_volume": "1 L",
+                "max_contains_weight": "1000 kg",
+                "flag_restriction": [
+                    "MAG_COMPACT",
+                    "MAG_BULKY"
+                ],
+                "moves": 60
+            }
+        ]
+    },
+    {
+        "type": "ARMOR",
+        "id": "xlkevlar",
+        "copy-from": "xlkevlar",
+        "name": {
+            "str": "XL Kevlar vest"
+        },
+        "pocket_data": [
+            {
+                "pocket_type": "CONTAINER",
+                "max_item_length": "1 km",
+                "max_contains_volume": "1 L",
+                "max_contains_weight": "1000 kg",
+                "moves": 60,
+                "flag_restriction": [
+                    "MAG_COMPACT"
+                ]
+            },
+            {
+                "pocket_type": "CONTAINER",
+                "max_item_length": "1 km",
+                "max_contains_volume": "1 L",
+                "max_contains_weight": "1000 kg",
+                "moves": 60,
+                "flag_restriction": [
+                    "MAG_COMPACT"
+                ]
+            },
+            {
+                "pocket_type": "CONTAINER",
+                "max_item_length": "1 km",
+                "max_contains_volume": "1 L",
+                "max_contains_weight": "1000 kg",
+                "moves": 60,
+                "flag_restriction": [
+                    "MAG_COMPACT"
+                ]
+            },
+            {
+                "pocket_type": "CONTAINER",
+                "max_item_length": "1 km",
+                "max_contains_volume": "1 L",
+                "max_contains_weight": "1000 kg",
+                "moves": 60,
+                "flag_restriction": [
+                    "MAG_COMPACT"
+                ]
+            }
+        ]
+    }
+]

--- a/Kenan-Modpack/easy_containers/items/armor/bandolier.json
+++ b/Kenan-Modpack/easy_containers/items/armor/bandolier.json
@@ -1,0 +1,277 @@
+[
+    {
+        "type": "ARMOR",
+        "id": "bandolier_pistol",
+        "copy-from": "bandolier_pistol",
+        "name": {
+            "str": "pistol bandolier"
+        },
+        "pocket_data": [
+            {
+                "ammo_restriction": {
+                    "32": 18,
+                    "762x25": 18,
+                    "38": 18,
+                    "357mag": 18,
+                    "357sig": 18,
+                    "380": 18,
+                    "38super": 18,
+                    "40": 18,
+                    "10mm": 18,
+                    "44": 18,
+                    "45": 18,
+                    "45colt": 18,
+                    "46": 18,
+                    "57": 18,
+                    "9x18": 18,
+                    "9mm": 18,
+                    "454": 18,
+                    "460": 18,
+                    "500": 18
+                },
+                "moves": 20,
+                "max_contains_weight": "1000 kg",
+                "max_item_length": "1 km"
+            }
+        ]
+    },
+    {
+        "type": "ARMOR",
+        "id": "bandolier_rifle",
+        "copy-from": "bandolier_rifle",
+        "name": {
+            "str": "rifle bandolier"
+        },
+        "pocket_data": [
+            {
+                "ammo_restriction": {
+                    "22": 16,
+                    "223": 16,
+                    "270win": 16,
+                    "300blk": 16,
+                    "5x50": 16,
+                    "545x39": 16,
+                    "3006": 16,
+                    "308": 16,
+                    "300": 16,
+                    "762": 16,
+                    "762R": 16,
+                    "8x40mm": 16,
+                    "4570": 16,
+                    "50": 16,
+                    "700nx": 16
+                },
+                "moves": 20,
+                "max_contains_weight": "1000 kg",
+                "max_item_length": "1 km"
+            }
+        ]
+    },
+    {
+        "type": "ARMOR",
+        "id": "bandolier_shotgun",
+        "copy-from": "bandolier_shotgun",
+        "name": {
+            "str": "waist shotgun bandolier"
+        },
+        "pocket_data": [
+            {
+                "ammo_restriction": {
+                    "410shot": 25,
+                    "shot": 25,
+                    "20x66mm": 25,
+                    "signal_flare": 25
+                },
+                "moves": 25,
+                "max_contains_weight": "1000 kg",
+                "max_item_length": "1 km"
+            }
+        ]
+    },
+    {
+        "type": "ARMOR",
+        "id": "torso_bandolier_grenade",
+        "copy-from": "torso_bandolier_grenade",
+        "name": {
+            "str": "torso grenade bandolier"
+        },
+        "pocket_data": [
+            {
+                "ammo_restriction": {
+                    "40x46mm": 6,
+                    "40x53mm": 6
+                },
+                "moves": 20,
+                "max_contains_weight": "1000 kg",
+                "max_item_length": "1 km"
+            }
+        ]
+    },
+    {
+        "type": "ARMOR",
+        "id": "torso_bandolier_shotgun",
+        "copy-from": "torso_bandolier_shotgun",
+        "name": {
+            "str": "torso shotgun bandolier"
+        },
+        "pocket_data": [
+            {
+                "ammo_restriction": {
+                    "410shot": 50,
+                    "shot": 50,
+                    "20x66mm": 50,
+                    "signal_flare": 50
+                },
+                "moves": 35,
+                "max_contains_weight": "1000 kg",
+                "max_item_length": "1 km"
+            }
+        ]
+    },
+    {
+        "type": "ARMOR",
+        "id": "flintlock_pouch",
+        "copy-from": "flintlock_pouch",
+        "name": {
+            "str": "paper cartridge pouch",
+            "str_pl": "paper cartridge pouches"
+        },
+        "pocket_data": [
+            {
+                "ammo_restriction": {
+                    "flintlock": 14,
+                    "36paper": 14,
+                    "44paper": 14,
+                    "blunderbuss": 14,
+                    "shotcanister": 14,
+                    "shotpaper": 14
+                },
+                "moves": 20,
+                "max_contains_weight": "1000 kg",
+                "max_item_length": "1 km"
+            }
+        ]
+    },
+    {
+        "type": "ARMOR",
+        "id": "bandolier_wrist",
+        "copy-from": "bandolier_wrist",
+        "name": {
+            "str": "wrist bandolier"
+        },
+        "pocket_data": [
+            {
+                "ammo_restriction": {
+                    "22": 4,
+                    "223": 4,
+                    "270win": 4,
+                    "300blk": 4,
+                    "5x50": 4,
+                    "545x39": 4,
+                    "3006": 4,
+                    "308": 4,
+                    "300": 4,
+                    "762": 4,
+                    "762R": 4,
+                    "8x40mm": 4,
+                    "4570": 4,
+                    "50": 4,
+                    "700nx": 4
+                },
+                "moves": 20,
+                "max_contains_weight": "1000 kg",
+                "max_item_length": "1 km"
+            }
+        ]
+    },
+    {
+        "type": "ARMOR",
+        "id": "grenade_pouch",
+        "copy-from": "grenade_pouch",
+        "name": {
+            "str": "grenade pouch",
+            "str_pl": "grenade pouches"
+        },
+        "pocket_data": [
+            {
+                "ammo_restriction": {
+                    "40x46mm": 4,
+                    "40x53mm": 4
+                },
+                "moves": 20,
+                "max_contains_weight": "1000 kg",
+                "max_item_length": "1 km"
+            }
+        ]
+    },
+    {
+        "type": "ARMOR",
+        "id": "stone_pouch",
+        "copy-from": "stone_pouch",
+        "name": {
+            "str": "stone pouch",
+            "str_pl": "stone pouches"
+        },
+        "pocket_data": [
+            {
+                "ammo_restriction": {
+                    "rock": 10
+                },
+                "moves": 20,
+                "max_contains_weight": "1000 kg",
+                "max_item_length": "1 km"
+            }
+        ]
+    },
+    {
+        "type": "ARMOR",
+        "id": "grenadebandolier",
+        "copy-from": "grenadebandolier",
+        "name": {
+            "str": "large grenade pouch",
+            "str_pl": "large grenade pouches"
+        },
+        "pocket_data": [
+            {
+                "pocket_type": "CONTAINER",
+                "max_contains_volume": "750 ml",
+                "max_contains_weight": "1000 kg",
+                "moves": 30,
+                "flag_restriction": [
+                    "GRENADE"
+                ],
+                "max_item_length": "1 km"
+            },
+            {
+                "pocket_type": "CONTAINER",
+                "max_contains_volume": "750 ml",
+                "max_contains_weight": "1000 kg",
+                "moves": 30,
+                "flag_restriction": [
+                    "GRENADE"
+                ],
+                "max_item_length": "1 km"
+            },
+            {
+                "pocket_type": "CONTAINER",
+                "max_contains_volume": "750 ml",
+                "max_contains_weight": "1000 kg",
+                "moves": 30,
+                "flag_restriction": [
+                    "GRENADE"
+                ],
+                "max_item_length": "1 km"
+            },
+            {
+                "pocket_type": "CONTAINER",
+                "max_contains_volume": "750 ml",
+                "max_contains_weight": "1000 kg",
+                "moves": 30,
+                "flag_restriction": [
+                    "GRENADE"
+                ],
+                "max_item_length": "1 km"
+            }
+        ]
+    }
+]

--- a/Kenan-Modpack/easy_containers/items/armor/belts.json
+++ b/Kenan-Modpack/easy_containers/items/armor/belts.json
@@ -1,0 +1,212 @@
+[
+    {
+        "type": "ARMOR",
+        "id": "fireman_belt",
+        "copy-from": "fireman_belt",
+        "name": {
+            "str": "firefighter belt"
+        },
+        "pocket_data": [
+            {
+                "max_contains_volume": "2 L",
+                "max_contains_weight": "1000 kg",
+                "max_item_length": "1 km",
+                "moves": 50,
+                "flag_restriction": [
+                    "BELT_CLIP"
+                ],
+                "holster": true
+            }
+        ]
+    },
+    {
+        "type": "ARMOR",
+        "id": "leather_belt",
+        "copy-from": "leather_belt",
+        "name": {
+            "str": "leather belt"
+        },
+        "pocket_data": [
+            {
+                "holster": true,
+                "max_contains_volume": "1 L",
+                "max_contains_weight": "1000 kg",
+                "max_item_length": "1 km",
+                "moves": 60,
+                "flag_restriction": [
+                    "BELT_CLIP"
+                ]
+            }
+        ]
+    },
+    {
+        "type": "ARMOR",
+        "id": "police_belt",
+        "copy-from": "police_belt",
+        "name": {
+            "str": "police duty belt"
+        },
+        "pocket_data": [
+            {
+                "holster": true,
+                "max_contains_volume": "2250 ml",
+                "max_contains_weight": "1000 kg",
+                "max_item_length": "1 km",
+                "moves": 50,
+                "flag_restriction": [
+                    "BELT_CLIP"
+                ]
+            }
+        ]
+    },
+    {
+        "type": "ARMOR",
+        "id": "survivor_belt_notools",
+        "copy-from": "survivor_belt_notools",
+        "name": {
+            "str": "survivor belt"
+        },
+        "pocket_data": [
+            {
+                "max_contains_volume": "1000 ml",
+                "max_contains_weight": "1000 kg",
+                "max_item_length": "1 km"
+            },
+            {
+                "holster": true,
+                "max_contains_volume": "1 L",
+                "max_contains_weight": "1000 kg",
+                "max_item_length": "1 km",
+                "moves": 3,
+                "flag_restriction": [
+                    "SHEATH_KNIFE"
+                ]
+            },
+            {
+                "holster": true,
+                "max_contains_volume": "1500 ml",
+                "max_contains_weight": "1000 kg",
+                "max_item_length": "1 km",
+                "moves": 50,
+                "flag_restriction": [
+                    "BELT_CLIP",
+                    "SHEATH_KNIFE"
+                ]
+            },
+            {
+                "holster": true,
+                "max_contains_volume": "1500 ml",
+                "max_contains_weight": "1000 kg",
+                "max_item_length": "1 km",
+                "moves": 50,
+                "flag_restriction": [
+                    "BELT_CLIP",
+                    "SHEATH_KNIFE"
+                ]
+            },
+            {
+                "holster": true,
+                "max_contains_volume": "1500 ml",
+                "max_contains_weight": "1000 kg",
+                "max_item_length": "1 km",
+                "moves": 50,
+                "flag_restriction": [
+                    "BELT_CLIP",
+                    "SHEATH_KNIFE"
+                ]
+            },
+            {
+                "holster": true,
+                "max_contains_volume": "1500 ml",
+                "max_contains_weight": "1000 kg",
+                "max_item_length": "1 km",
+                "moves": 50,
+                "flag_restriction": [
+                    "BELT_CLIP",
+                    "SHEATH_KNIFE"
+                ]
+            },
+            {
+                "holster": true,
+                "max_contains_volume": "1500 ml",
+                "max_contains_weight": "1000 kg",
+                "max_item_length": "1 km",
+                "moves": 50,
+                "flag_restriction": [
+                    "BELT_CLIP",
+                    "SHEATH_KNIFE"
+                ]
+            }
+        ]
+    },
+    {
+        "type": "ARMOR",
+        "id": "tool_belt",
+        "copy-from": "tool_belt",
+        "name": {
+            "str": "tool belt"
+        },
+        "pocket_data": [
+            {
+                "max_contains_volume": "1000 ml",
+                "max_contains_weight": "1000 kg",
+                "max_item_length": "1 km"
+            },
+            {
+                "holster": true,
+                "max_contains_volume": "1500 ml",
+                "max_contains_weight": "1000 kg",
+                "max_item_length": "1 km",
+                "moves": 50,
+                "flag_restriction": [
+                    "BELT_CLIP",
+                    "SHEATH_KNIFE"
+                ]
+            },
+            {
+                "holster": true,
+                "max_contains_volume": "1500 ml",
+                "max_contains_weight": "1000 kg",
+                "max_item_length": "1 km",
+                "moves": 50,
+                "flag_restriction": [
+                    "BELT_CLIP",
+                    "SHEATH_KNIFE"
+                ]
+            },
+            {
+                "holster": true,
+                "max_contains_volume": "1500 ml",
+                "max_contains_weight": "1000 kg",
+                "max_item_length": "1 km",
+                "moves": 50,
+                "flag_restriction": [
+                    "BELT_CLIP",
+                    "SHEATH_KNIFE"
+                ]
+            },
+            {
+                "holster": true,
+                "max_contains_volume": "1500 ml",
+                "max_contains_weight": "1000 kg",
+                "max_item_length": "1 km",
+                "moves": 50,
+                "flag_restriction": [
+                    "BELT_CLIP",
+                    "SHEATH_KNIFE"
+                ]
+            },
+            {
+                "holster": true,
+                "max_contains_volume": "1500 ml",
+                "max_contains_weight": "1000 kg",
+                "max_item_length": "1 km",
+                "moves": 50,
+                "flag_restriction": [
+                    "BELT_CLIP",
+                    "SHEATH_KNIFE"
+                ]
+            }
+        ]
+    }
+]

--- a/Kenan-Modpack/easy_containers/items/armor/boots.json
+++ b/Kenan-Modpack/easy_containers/items/armor/boots.json
@@ -1,0 +1,18 @@
+[
+    {
+        "type": "ARMOR",
+        "id": "boots_western",
+        "copy-from": "boots_western",
+        "name": {
+            "str": "pair of western boots",
+            "str_pl": "pairs of western boots"
+        },
+        "pocket_data": [
+            {
+                "max_contains_volume": "500 ml",
+                "max_contains_weight": "1000 kg",
+                "max_item_length": "1 km"
+            }
+        ]
+    }
+]

--- a/Kenan-Modpack/easy_containers/items/armor/coats.json
+++ b/Kenan-Modpack/easy_containers/items/armor/coats.json
@@ -1,0 +1,617 @@
+[
+    {
+        "type": "ARMOR",
+        "id": "bunker_coat",
+        "copy-from": "bunker_coat",
+        "name": {
+            "str": "turnout coat"
+        },
+        "pocket_data": [
+            {
+                "max_contains_volume": "2000 ml",
+                "max_contains_weight": "1000 kg",
+                "max_item_length": "1 km"
+            }
+        ]
+    },
+    {
+        "type": "ARMOR",
+        "id": "coat_fur",
+        "copy-from": "coat_fur",
+        "name": {
+            "str": "fur coat"
+        },
+        "pocket_data": [
+            {
+                "max_contains_volume": "1000 ml",
+                "max_contains_weight": "1000 kg",
+                "max_item_length": "1 km"
+            }
+        ]
+    },
+    {
+        "type": "ARMOR",
+        "id": "coat_fur_sf",
+        "copy-from": "coat_fur_sf",
+        "name": {
+            "str": "sable coat"
+        },
+        "pocket_data": [
+            {
+                "max_contains_volume": "1400 ml",
+                "max_contains_weight": "1000 kg",
+                "max_item_length": "1 km"
+            }
+        ]
+    },
+    {
+        "type": "ARMOR",
+        "id": "coat_lab",
+        "copy-from": "coat_lab",
+        "name": {
+            "str": "lab coat"
+        },
+        "pocket_data": [
+            {
+                "max_contains_volume": "3500 ml",
+                "max_contains_weight": "1000 kg",
+                "max_item_length": "1 km"
+            }
+        ]
+    },
+    {
+        "type": "ARMOR",
+        "id": "coat_rain",
+        "copy-from": "coat_rain",
+        "name": {
+            "str": "rain coat"
+        },
+        "pocket_data": [
+            {
+                "max_contains_volume": "3000 ml",
+                "max_contains_weight": "1000 kg",
+                "max_item_length": "1 km"
+            }
+        ]
+    },
+    {
+        "type": "ARMOR",
+        "id": "coat_winter",
+        "copy-from": "coat_winter",
+        "name": {
+            "str": "winter coat"
+        },
+        "pocket_data": [
+            {
+                "max_contains_volume": "3200 ml",
+                "max_contains_weight": "1000 kg",
+                "max_item_length": "1 km"
+            }
+        ]
+    },
+    {
+        "type": "ARMOR",
+        "id": "duster",
+        "copy-from": "duster",
+        "name": {
+            "str": "duster"
+        },
+        "pocket_data": [
+            {
+                "max_contains_volume": "6000 ml",
+                "max_contains_weight": "1000 kg",
+                "max_item_length": "1 km"
+            }
+        ]
+    },
+    {
+        "type": "ARMOR",
+        "id": "duster_fur",
+        "copy-from": "duster_fur",
+        "name": {
+            "str": "fur duster"
+        },
+        "pocket_data": [
+            {
+                "max_contains_volume": "6000 ml",
+                "max_contains_weight": "1000 kg",
+                "max_item_length": "1 km"
+            }
+        ]
+    },
+    {
+        "type": "ARMOR",
+        "id": "duster_leather",
+        "copy-from": "duster_leather",
+        "name": {
+            "str": "leather duster"
+        },
+        "pocket_data": [
+            {
+                "max_contains_volume": "6000 ml",
+                "max_contains_weight": "1000 kg",
+                "max_item_length": "1 km"
+            }
+        ]
+    },
+    {
+        "type": "ARMOR",
+        "id": "duster_survivor",
+        "copy-from": "duster_survivor",
+        "name": {
+            "str": "survivor duster"
+        },
+        "pocket_data": [
+            {
+                "max_contains_volume": "9000 ml",
+                "max_contains_weight": "1000 kg",
+                "max_item_length": "1 km"
+            }
+        ]
+    },
+    {
+        "type": "ARMOR",
+        "id": "greatcoat",
+        "copy-from": "greatcoat",
+        "name": {
+            "str": "greatcoat"
+        },
+        "pocket_data": [
+            {
+                "max_contains_volume": "5000 ml",
+                "max_contains_weight": "1000 kg",
+                "max_item_length": "1 km"
+            }
+        ]
+    },
+    {
+        "type": "ARMOR",
+        "id": "house_coat",
+        "copy-from": "house_coat",
+        "name": {
+            "str": "bathrobe"
+        },
+        "pocket_data": [
+            {
+                "max_contains_volume": "1500 ml",
+                "max_contains_weight": "1000 kg",
+                "max_item_length": "1 km"
+            }
+        ]
+    },
+    {
+        "type": "ARMOR",
+        "id": "jacket_army",
+        "copy-from": "jacket_army",
+        "name": {
+            "str_sp": "army jacket"
+        },
+        "pocket_data": [
+            {
+                "max_contains_volume": "4500 ml",
+                "max_contains_weight": "1000 kg",
+                "max_item_length": "1 km"
+            }
+        ]
+    },
+    {
+        "type": "ARMOR",
+        "id": "jacket_chef",
+        "copy-from": "jacket_chef",
+        "name": {
+            "str": "chef's jacket"
+        },
+        "pocket_data": [
+            {
+                "max_contains_volume": "1250 ml",
+                "max_contains_weight": "1000 kg",
+                "max_item_length": "1 km"
+            }
+        ]
+    },
+    {
+        "type": "ARMOR",
+        "id": "jacket_evac",
+        "copy-from": "jacket_evac",
+        "name": {
+            "str": "emergency jacket"
+        },
+        "pocket_data": [
+            {
+                "max_contains_volume": "700 ml",
+                "max_contains_weight": "1000 kg",
+                "max_item_length": "1 km"
+            }
+        ]
+    },
+    {
+        "type": "ARMOR",
+        "id": "jacket_flannel",
+        "copy-from": "jacket_flannel",
+        "name": {
+            "str": "flannel jacket"
+        },
+        "pocket_data": [
+            {
+                "max_contains_volume": "1000 ml",
+                "max_contains_weight": "1000 kg",
+                "max_item_length": "1 km"
+            }
+        ]
+    },
+    {
+        "type": "ARMOR",
+        "id": "jacket_jean",
+        "copy-from": "jacket_jean",
+        "name": {
+            "str": "jean jacket"
+        },
+        "pocket_data": [
+            {
+                "max_contains_volume": "700 ml",
+                "max_contains_weight": "1000 kg",
+                "max_item_length": "1 km"
+            }
+        ]
+    },
+    {
+        "type": "ARMOR",
+        "id": "jacket_leather",
+        "copy-from": "jacket_leather",
+        "name": {
+            "str": "leather jacket"
+        },
+        "pocket_data": [
+            {
+                "max_contains_volume": "1400 ml",
+                "max_contains_weight": "1000 kg",
+                "max_item_length": "1 km"
+            }
+        ]
+    },
+    {
+        "type": "ARMOR",
+        "id": "jacket_leather_red",
+        "copy-from": "jacket_leather_red",
+        "name": {
+            "str": "red leather jacket"
+        },
+        "pocket_data": [
+            {
+                "max_contains_volume": "1400 ml",
+                "max_contains_weight": "1000 kg",
+                "max_item_length": "1 km"
+            }
+        ]
+    },
+    {
+        "type": "ARMOR",
+        "id": "jacket_light",
+        "copy-from": "jacket_light",
+        "name": {
+            "str": "light jacket"
+        },
+        "pocket_data": [
+            {
+                "max_contains_volume": "1400 ml",
+                "max_contains_weight": "1000 kg",
+                "max_item_length": "1 km"
+            }
+        ]
+    },
+    {
+        "type": "ARMOR",
+        "id": "jacket_windbreaker",
+        "copy-from": "jacket_windbreaker",
+        "name": {
+            "str": "windbreaker"
+        },
+        "pocket_data": [
+            {
+                "max_contains_volume": "1700 ml",
+                "max_contains_weight": "1000 kg",
+                "max_item_length": "1 km"
+            }
+        ]
+    },
+    {
+        "type": "ARMOR",
+        "id": "kimono",
+        "copy-from": "kimono",
+        "name": {
+            "str": "kimono"
+        },
+        "pocket_data": [
+            {
+                "max_contains_volume": "1000 ml",
+                "max_contains_weight": "1000 kg",
+                "max_item_length": "1 km"
+            }
+        ]
+    },
+    {
+        "type": "ARMOR",
+        "id": "yukata",
+        "copy-from": "yukata",
+        "name": {
+            "str": "yukata"
+        },
+        "pocket_data": [
+            {
+                "max_contains_volume": "1000 ml",
+                "max_contains_weight": "1000 kg",
+                "max_item_length": "1 km"
+            }
+        ]
+    },
+    {
+        "type": "ARMOR",
+        "id": "peacoat",
+        "copy-from": "peacoat",
+        "name": {
+            "str": "peacoat"
+        },
+        "pocket_data": [
+            {
+                "max_contains_volume": "3500 ml",
+                "max_contains_weight": "1000 kg",
+                "max_item_length": "1 km"
+            }
+        ]
+    },
+    {
+        "type": "ARMOR",
+        "id": "robe",
+        "copy-from": "robe",
+        "name": {
+            "str": "robe"
+        },
+        "pocket_data": [
+            {
+                "max_contains_volume": "3000 ml",
+                "max_contains_weight": "1000 kg",
+                "max_item_length": "1 km"
+            }
+        ]
+    },
+    {
+        "type": "ARMOR",
+        "id": "ski_jacket",
+        "copy-from": "ski_jacket",
+        "name": {
+            "str": "ski jacket"
+        },
+        "pocket_data": [
+            {
+                "max_contains_volume": "1900 ml",
+                "max_contains_weight": "1000 kg",
+                "max_item_length": "1 km"
+            }
+        ]
+    },
+    {
+        "type": "ARMOR",
+        "id": "sleeveless_duster",
+        "copy-from": "sleeveless_duster",
+        "name": {
+            "str": "sleeveless duster"
+        },
+        "pocket_data": [
+            {
+                "max_contains_volume": "6000 ml",
+                "max_contains_weight": "1000 kg",
+                "max_item_length": "1 km"
+            }
+        ]
+    },
+    {
+        "type": "ARMOR",
+        "id": "sleeveless_duster_fur",
+        "copy-from": "sleeveless_duster_fur",
+        "name": {
+            "str": "sleeveless fur duster"
+        },
+        "pocket_data": [
+            {
+                "max_contains_volume": "6000 ml",
+                "max_contains_weight": "1000 kg",
+                "max_item_length": "1 km"
+            }
+        ]
+    },
+    {
+        "type": "ARMOR",
+        "id": "sleeveless_duster_leather",
+        "copy-from": "sleeveless_duster_leather",
+        "name": {
+            "str": "sleeveless leather duster"
+        },
+        "pocket_data": [
+            {
+                "max_contains_volume": "6000 ml",
+                "max_contains_weight": "1000 kg",
+                "max_item_length": "1 km"
+            }
+        ]
+    },
+    {
+        "type": "ARMOR",
+        "id": "sleeveless_duster_survivor",
+        "copy-from": "sleeveless_duster_survivor",
+        "name": {
+            "str": "sleeveless survivor duster"
+        },
+        "pocket_data": [
+            {
+                "max_contains_volume": "9000 ml",
+                "max_contains_weight": "1000 kg",
+                "max_item_length": "1 km"
+            }
+        ]
+    },
+    {
+        "type": "ARMOR",
+        "id": "sleeveless_trenchcoat",
+        "copy-from": "sleeveless_trenchcoat",
+        "name": {
+            "str": "sleeveless trenchcoat"
+        },
+        "pocket_data": [
+            {
+                "max_contains_volume": "6000 ml",
+                "max_contains_weight": "1000 kg",
+                "max_item_length": "1 km"
+            }
+        ]
+    },
+    {
+        "type": "ARMOR",
+        "id": "sleeveless_trenchcoat_fur",
+        "copy-from": "sleeveless_trenchcoat_fur",
+        "name": {
+            "str": "sleeveless fur trenchcoat"
+        },
+        "pocket_data": [
+            {
+                "max_contains_volume": "6000 ml",
+                "max_contains_weight": "1000 kg",
+                "max_item_length": "1 km"
+            }
+        ]
+    },
+    {
+        "type": "ARMOR",
+        "id": "sleeveless_trenchcoat_leather",
+        "copy-from": "sleeveless_trenchcoat_leather",
+        "name": {
+            "str": "sleeveless leather trenchcoat"
+        },
+        "pocket_data": [
+            {
+                "max_contains_volume": "6000 ml",
+                "max_contains_weight": "1000 kg",
+                "max_item_length": "1 km"
+            }
+        ]
+    },
+    {
+        "type": "ARMOR",
+        "id": "sleeveless_trenchcoat_survivor",
+        "copy-from": "sleeveless_trenchcoat_survivor",
+        "name": {
+            "str": "sleeveless survivor trenchcoat"
+        },
+        "pocket_data": [
+            {
+                "max_contains_volume": "9000 ml",
+                "max_contains_weight": "1000 kg",
+                "max_item_length": "1 km"
+            }
+        ]
+    },
+    {
+        "type": "ARMOR",
+        "id": "trenchcoat",
+        "copy-from": "trenchcoat",
+        "name": {
+            "str": "trenchcoat"
+        },
+        "pocket_data": [
+            {
+                "max_contains_volume": "6000 ml",
+                "max_contains_weight": "1000 kg",
+                "max_item_length": "1 km"
+            }
+        ]
+    },
+    {
+        "type": "ARMOR",
+        "id": "trenchcoat_fur",
+        "copy-from": "trenchcoat_fur",
+        "name": {
+            "str": "fur trenchcoat"
+        },
+        "pocket_data": [
+            {
+                "max_contains_volume": "6000 ml",
+                "max_contains_weight": "1000 kg",
+                "max_item_length": "1 km"
+            }
+        ]
+    },
+    {
+        "type": "ARMOR",
+        "id": "trenchcoat_leather",
+        "copy-from": "trenchcoat_leather",
+        "name": {
+            "str": "leather trenchcoat"
+        },
+        "pocket_data": [
+            {
+                "max_contains_volume": "6000 ml",
+                "max_contains_weight": "1000 kg",
+                "max_item_length": "1 km"
+            }
+        ]
+    },
+    {
+        "type": "ARMOR",
+        "id": "trenchcoat_survivor",
+        "copy-from": "trenchcoat_survivor",
+        "name": {
+            "str": "survivor trenchcoat"
+        },
+        "pocket_data": [
+            {
+                "max_contains_volume": "9000 ml",
+                "max_contains_weight": "1000 kg",
+                "max_item_length": "1 km"
+            }
+        ]
+    },
+    {
+        "type": "ARMOR",
+        "id": "tux",
+        "copy-from": "tux",
+        "name": {
+            "str": "tuxedo"
+        },
+        "pocket_data": [
+            {
+                "max_contains_volume": "1200 ml",
+                "max_contains_weight": "1000 kg",
+                "max_item_length": "1 km"
+            }
+        ]
+    },
+    {
+        "type": "ARMOR",
+        "id": "waistcoat",
+        "copy-from": "waistcoat",
+        "name": {
+            "str": "waistcoat"
+        },
+        "pocket_data": [
+            {
+                "max_contains_volume": "1500 ml",
+                "max_contains_weight": "1000 kg",
+                "max_item_length": "1 km"
+            }
+        ]
+    },
+    {
+        "type": "ARMOR",
+        "id": "winter_jacket_army",
+        "copy-from": "winter_jacket_army",
+        "name": {
+            "str": "army winter jacket"
+        },
+        "pocket_data": [
+            {
+                "max_contains_volume": "5000 ml",
+                "max_contains_weight": "1000 kg",
+                "max_item_length": "1 km"
+            }
+        ]
+    }
+]

--- a/Kenan-Modpack/easy_containers/items/armor/hats.json
+++ b/Kenan-Modpack/easy_containers/items/armor/hats.json
@@ -1,0 +1,19 @@
+[
+    {
+        "type": "ARMOR",
+        "id": "drinking_hat",
+        "copy-from": "drinking_hat",
+        "name": {
+            "str": "drinking hat"
+        },
+        "pocket_data": [
+            {
+                "max_contains_volume": "500 ml",
+                "max_contains_weight": "1000 kg",
+                "watertight": true,
+                "rigid": true,
+                "max_item_length": "1 km"
+            }
+        ]
+    }
+]

--- a/Kenan-Modpack/easy_containers/items/armor/holster.json
+++ b/Kenan-Modpack/easy_containers/items/armor/holster.json
@@ -1,0 +1,260 @@
+[
+    {
+        "type": "ARMOR",
+        "id": "back_holster",
+        "copy-from": "back_holster",
+        "name": {
+            "str": "back holster"
+        },
+        "pocket_data": [
+            {
+                "pocket_type": "CONTAINER",
+                "holster": true,
+                "max_contains_volume": "9 L",
+                "max_contains_weight": "1000 kg",
+                "max_item_length": "1 km",
+                "moves": 150
+            }
+        ]
+    },
+    {
+        "type": "ARMOR",
+        "id": "baldric_holster",
+        "copy-from": "baldric_holster",
+        "name": {
+            "str": "baldric holster"
+        },
+        "pocket_data": [
+            {
+                "pocket_type": "CONTAINER",
+                "holster": true,
+                "max_contains_volume": "1 L",
+                "max_contains_weight": "1000 kg",
+                "max_item_length": "1 km",
+                "moves": 50
+            },
+            {
+                "pocket_type": "CONTAINER",
+                "holster": true,
+                "max_contains_volume": "1 L",
+                "max_contains_weight": "1000 kg",
+                "max_item_length": "1 km",
+                "moves": 50
+            },
+            {
+                "pocket_type": "CONTAINER",
+                "holster": true,
+                "max_contains_volume": "1 L",
+                "max_contains_weight": "1000 kg",
+                "max_item_length": "1 km",
+                "moves": 50
+            },
+            {
+                "pocket_type": "CONTAINER",
+                "holster": true,
+                "max_contains_volume": "1 L",
+                "max_contains_weight": "1000 kg",
+                "max_item_length": "1 km",
+                "moves": 50
+            },
+            {
+                "pocket_type": "CONTAINER",
+                "holster": true,
+                "max_contains_volume": "1 L",
+                "max_contains_weight": "1000 kg",
+                "max_item_length": "1 km",
+                "moves": 50
+            },
+            {
+                "pocket_type": "CONTAINER",
+                "holster": true,
+                "max_contains_volume": "1 L",
+                "max_contains_weight": "1000 kg",
+                "max_item_length": "1 km",
+                "moves": 50
+            }
+        ]
+    },
+    {
+        "type": "ARMOR",
+        "id": "bootstrap",
+        "copy-from": "bootstrap",
+        "name": {
+            "str": "ankle holster"
+        },
+        "pocket_data": [
+            {
+                "max_contains_volume": "400 ml",
+                "max_contains_weight": "1000 kg",
+                "max_item_length": "1 km"
+            }
+        ]
+    },
+    {
+        "type": "ARMOR",
+        "id": "bow_sling",
+        "copy-from": "bow_sling",
+        "name": {
+            "str": "bow sling"
+        },
+        "pocket_data": [
+            {
+                "pocket_type": "CONTAINER",
+                "holster": true,
+                "max_contains_volume": "5 L",
+                "max_contains_weight": "1000 kg",
+                "max_item_length": "1 km",
+                "moves": 50,
+                "flag_restriction": [
+                    "SHEATH_BOW"
+                ]
+            }
+        ]
+    },
+    {
+        "type": "ARMOR",
+        "id": "holster",
+        "copy-from": "holster",
+        "name": {
+            "str": "holster"
+        },
+        "pocket_data": [
+            {
+                "magazine_well": "350 ml",
+                "pocket_type": "CONTAINER",
+                "holster": true,
+                "max_contains_volume": "1000 ml",
+                "max_contains_weight": "1000 kg",
+                "max_item_length": "1 km",
+                "moves": 50
+            }
+        ]
+    },
+    {
+        "type": "ARMOR",
+        "id": "western_holster",
+        "copy-from": "western_holster",
+        "name": {
+            "str": "western holster"
+        },
+        "pocket_data": [
+            {
+                "pocket_type": "CONTAINER",
+                "holster": true,
+                "max_contains_volume": "400 ml",
+                "max_contains_weight": "1000 kg",
+                "max_item_length": "1 km",
+                "moves": 30
+            },
+            {
+                "pocket_type": "CONTAINER",
+                "holster": false,
+                "rigid": true,
+                "ammo_restriction": {
+                    "32": 18,
+                    "762x25": 18,
+                    "38": 18,
+                    "357mag": 18,
+                    "357sig": 18,
+                    "380": 18,
+                    "38super": 18,
+                    "40": 18,
+                    "10mm": 18,
+                    "44": 18,
+                    "45": 18,
+                    "45colt": 18,
+                    "46": 18,
+                    "57": 18,
+                    "9x18": 18,
+                    "9mm": 18,
+                    "454": 18,
+                    "460": 18,
+                    "500": 18
+                },
+                "moves": 20,
+                "max_contains_weight": "1000 kg",
+                "max_item_length": "1 km"
+            }
+        ]
+    },
+    {
+        "type": "ARMOR",
+        "id": "sholster",
+        "copy-from": "sholster",
+        "name": {
+            "str": "fast draw holster"
+        },
+        "pocket_data": [
+            {
+                "magazine_well": "200 ml",
+                "pocket_type": "CONTAINER",
+                "holster": true,
+                "max_contains_volume": "490 ml",
+                "max_contains_weight": "1000 kg",
+                "max_item_length": "1 km",
+                "moves": 30
+            }
+        ]
+    },
+    {
+        "type": "ARMOR",
+        "id": "bholster",
+        "copy-from": "bholster",
+        "name": {
+            "str": "deep concealment holster"
+        },
+        "pocket_data": [
+            {
+                "magazine_well": "150 ml",
+                "pocket_type": "CONTAINER",
+                "holster": true,
+                "max_contains_volume": "400 ml",
+                "max_contains_weight": "1000 kg",
+                "max_item_length": "1 km",
+                "moves": 210
+            }
+        ]
+    },
+    {
+        "type": "ARMOR",
+        "id": "survivor_vest",
+        "copy-from": "survivor_vest",
+        "name": {
+            "str": "survivor harness",
+            "str_pl": "survivor harnesses"
+        },
+        "pocket_data": [
+            {
+                "max_contains_volume": "4500 ml",
+                "max_contains_weight": "1000 kg",
+                "max_item_length": "1 km"
+            },
+            {
+                "pocket_type": "CONTAINER",
+                "holster": true,
+                "max_contains_volume": "8 L",
+                "max_contains_weight": "1000 kg",
+                "max_item_length": "1 km",
+                "moves": 50
+            }
+        ]
+    },
+    {
+        "type": "ARMOR",
+        "id": "XL_holster",
+        "copy-from": "XL_holster",
+        "name": {
+            "str": "XL holster"
+        },
+        "pocket_data": [
+            {
+                "pocket_type": "CONTAINER",
+                "holster": true,
+                "max_contains_volume": "1500 ml",
+                "max_contains_weight": "1000 kg",
+                "max_item_length": "1 km",
+                "moves": 70
+            }
+        ]
+    }
+]

--- a/Kenan-Modpack/easy_containers/items/armor/legs_armor.json
+++ b/Kenan-Modpack/easy_containers/items/armor/legs_armor.json
@@ -1,0 +1,62 @@
+[
+    {
+        "type": "ARMOR",
+        "id": "bunker_pants",
+        "copy-from": "bunker_pants",
+        "name": {
+            "str_sp": "turnout trousers"
+        },
+        "pocket_data": [
+            {
+                "max_contains_volume": "1500 ml",
+                "max_contains_weight": "1000 kg",
+                "max_item_length": "1 km"
+            }
+        ]
+    },
+    {
+        "type": "ARMOR",
+        "id": "fencing_pants",
+        "copy-from": "fencing_pants",
+        "name": {
+            "str_sp": "fencing pants"
+        },
+        "pocket_data": [
+            {
+                "max_contains_volume": "500 ml",
+                "max_contains_weight": "1000 kg",
+                "max_item_length": "1 km"
+            }
+        ]
+    },
+    {
+        "type": "ARMOR",
+        "id": "lsurvivor_pants",
+        "copy-from": "lsurvivor_pants",
+        "name": {
+            "str_sp": "light survivor cargo pants"
+        },
+        "pocket_data": [
+            {
+                "max_contains_volume": "2900 ml",
+                "max_contains_weight": "1000 kg",
+                "max_item_length": "1 km"
+            }
+        ]
+    },
+    {
+        "type": "ARMOR",
+        "id": "pants_survivor",
+        "copy-from": "pants_survivor",
+        "name": {
+            "str_sp": "survivor cargo pants"
+        },
+        "pocket_data": [
+            {
+                "max_contains_volume": "4500 ml",
+                "max_contains_weight": "1000 kg",
+                "max_item_length": "1 km"
+            }
+        ]
+    }
+]

--- a/Kenan-Modpack/easy_containers/items/armor/legs_clothes.json
+++ b/Kenan-Modpack/easy_containers/items/armor/legs_clothes.json
@@ -1,0 +1,334 @@
+[
+    {
+        "type": "ARMOR",
+        "id": "antarvasa",
+        "copy-from": "antarvasa",
+        "name": {
+            "str": "antarvasa"
+        },
+        "pocket_data": [
+            {
+                "max_contains_volume": "1200 ml",
+                "max_contains_weight": "1000 kg",
+                "max_item_length": "1 km"
+            }
+        ]
+    },
+    {
+        "type": "ARMOR",
+        "id": "b_shorts",
+        "copy-from": "b_shorts",
+        "name": {
+            "str_sp": "basketball shorts"
+        },
+        "pocket_data": [
+            {
+                "max_contains_volume": "1000 ml",
+                "max_contains_weight": "1000 kg",
+                "max_item_length": "1 km"
+            }
+        ]
+    },
+    {
+        "type": "ARMOR",
+        "id": "fishing_waders",
+        "copy-from": "fishing_waders",
+        "name": {
+            "str": "pair of fishing waders",
+            "str_pl": "pairs of fishing waders"
+        },
+        "pocket_data": [
+            {
+                "max_contains_volume": "1500 ml",
+                "max_contains_weight": "1000 kg",
+                "max_item_length": "1 km"
+            }
+        ]
+    },
+    {
+        "type": "ARMOR",
+        "id": "jeans",
+        "copy-from": "jeans",
+        "name": {
+            "str_sp": "jeans"
+        },
+        "pocket_data": [
+            {
+                "max_contains_volume": "1200 ml",
+                "max_contains_weight": "1000 kg",
+                "max_item_length": "1 km"
+            }
+        ]
+    },
+    {
+        "type": "ARMOR",
+        "id": "jeans_red",
+        "copy-from": "jeans_red",
+        "name": {
+            "str_sp": "red jeans"
+        },
+        "pocket_data": [
+            {
+                "max_contains_volume": "1200 ml",
+                "max_contains_weight": "1000 kg",
+                "max_item_length": "1 km"
+            }
+        ]
+    },
+    {
+        "type": "ARMOR",
+        "id": "kilt",
+        "copy-from": "kilt",
+        "name": {
+            "str": "kilt"
+        },
+        "pocket_data": [
+            {
+                "max_contains_volume": "250 ml",
+                "max_contains_weight": "1000 kg",
+                "max_item_length": "1 km"
+            }
+        ]
+    },
+    {
+        "type": "ARMOR",
+        "id": "kilt_leather",
+        "copy-from": "kilt_leather",
+        "name": {
+            "str": "leather kilt"
+        },
+        "pocket_data": [
+            {
+                "max_contains_volume": "250 ml",
+                "max_contains_weight": "1000 kg",
+                "max_item_length": "1 km"
+            }
+        ]
+    },
+    {
+        "type": "ARMOR",
+        "id": "pants",
+        "copy-from": "pants",
+        "name": {
+            "str_sp": "pants"
+        },
+        "pocket_data": [
+            {
+                "max_contains_volume": "1200 ml",
+                "max_contains_weight": "1000 kg",
+                "max_item_length": "1 km"
+            }
+        ]
+    },
+    {
+        "type": "ARMOR",
+        "id": "pants_army",
+        "copy-from": "pants_army",
+        "name": {
+            "str_sp": "army pants"
+        },
+        "pocket_data": [
+            {
+                "max_contains_volume": "3400 ml",
+                "max_contains_weight": "1000 kg",
+                "max_item_length": "1 km"
+            }
+        ]
+    },
+    {
+        "type": "ARMOR",
+        "id": "pants_cargo",
+        "copy-from": "pants_cargo",
+        "name": {
+            "str_sp": "cargo pants"
+        },
+        "pocket_data": [
+            {
+                "max_contains_volume": "4400 ml",
+                "max_contains_weight": "1000 kg",
+                "max_item_length": "1 km"
+            }
+        ]
+    },
+    {
+        "type": "ARMOR",
+        "id": "pants_checkered",
+        "copy-from": "pants_checkered",
+        "name": {
+            "str_sp": "checkered pants"
+        },
+        "pocket_data": [
+            {
+                "max_contains_volume": "1200 ml",
+                "max_contains_weight": "1000 kg",
+                "max_item_length": "1 km"
+            }
+        ]
+    },
+    {
+        "type": "ARMOR",
+        "id": "pants_fur",
+        "copy-from": "pants_fur",
+        "name": {
+            "str_sp": "fur pants"
+        },
+        "pocket_data": [
+            {
+                "max_contains_volume": "1200 ml",
+                "max_contains_weight": "1000 kg",
+                "max_item_length": "1 km"
+            }
+        ]
+    },
+    {
+        "type": "ARMOR",
+        "id": "pants_leather",
+        "copy-from": "pants_leather",
+        "name": {
+            "str_sp": "leather pants"
+        },
+        "pocket_data": [
+            {
+                "max_contains_volume": "700 ml",
+                "max_contains_weight": "1000 kg",
+                "max_item_length": "1 km"
+            }
+        ]
+    },
+    {
+        "type": "ARMOR",
+        "id": "pants_ski",
+        "copy-from": "pants_ski",
+        "name": {
+            "str_sp": "ski pants"
+        },
+        "pocket_data": [
+            {
+                "max_contains_volume": "1200 ml",
+                "max_contains_weight": "1000 kg",
+                "max_item_length": "1 km"
+            }
+        ]
+    },
+    {
+        "type": "ARMOR",
+        "id": "postman_shorts",
+        "copy-from": "postman_shorts",
+        "name": {
+            "str_sp": "mail carrier shorts"
+        },
+        "pocket_data": [
+            {
+                "max_contains_volume": "1500 ml",
+                "max_contains_weight": "1000 kg",
+                "max_item_length": "1 km"
+            }
+        ]
+    },
+    {
+        "type": "ARMOR",
+        "id": "shorts",
+        "copy-from": "shorts",
+        "name": {
+            "str_sp": "shorts"
+        },
+        "pocket_data": [
+            {
+                "max_contains_volume": "1200 ml",
+                "max_contains_weight": "1000 kg",
+                "max_item_length": "1 km"
+            }
+        ]
+    },
+    {
+        "type": "ARMOR",
+        "id": "shorts_cargo",
+        "copy-from": "shorts_cargo",
+        "name": {
+            "str_sp": "cargo shorts"
+        },
+        "pocket_data": [
+            {
+                "max_contains_volume": "2500 ml",
+                "max_contains_weight": "1000 kg",
+                "max_item_length": "1 km"
+            }
+        ]
+    },
+    {
+        "type": "ARMOR",
+        "id": "shorts_denim",
+        "copy-from": "shorts_denim",
+        "name": {
+            "str_sp": "denim shorts"
+        },
+        "pocket_data": [
+            {
+                "max_contains_volume": "700 ml",
+                "max_contains_weight": "1000 kg",
+                "max_item_length": "1 km"
+            }
+        ]
+    },
+    {
+        "type": "ARMOR",
+        "id": "skirt",
+        "copy-from": "skirt",
+        "name": {
+            "str": "skirt"
+        },
+        "pocket_data": [
+            {
+                "max_contains_volume": "250 ml",
+                "max_contains_weight": "1000 kg",
+                "max_item_length": "1 km"
+            }
+        ]
+    },
+    {
+        "type": "ARMOR",
+        "id": "striped_pants",
+        "copy-from": "striped_pants",
+        "name": {
+            "str_sp": "striped pants"
+        },
+        "pocket_data": [
+            {
+                "max_contains_volume": "1200 ml",
+                "max_contains_weight": "1000 kg",
+                "max_item_length": "1 km"
+            }
+        ]
+    },
+    {
+        "type": "ARMOR",
+        "id": "technician_pants_gray",
+        "copy-from": "technician_pants_gray",
+        "name": {
+            "str": "work pants",
+            "str_pl": "pairs of work pants"
+        },
+        "pocket_data": [
+            {
+                "max_contains_volume": "1900 ml",
+                "max_contains_weight": "1000 kg",
+                "max_item_length": "1 km"
+            }
+        ]
+    },
+    {
+        "type": "ARMOR",
+        "id": "winter_pants_army",
+        "copy-from": "winter_pants_army",
+        "name": {
+            "str_sp": "army winter pants"
+        },
+        "pocket_data": [
+            {
+                "max_contains_volume": "3700 ml",
+                "max_contains_weight": "1000 kg",
+                "max_item_length": "1 km"
+            }
+        ]
+    }
+]

--- a/Kenan-Modpack/easy_containers/items/armor/pets_dog_armor.json
+++ b/Kenan-Modpack/easy_containers/items/armor/pets_dog_armor.json
@@ -1,0 +1,33 @@
+[
+    {
+        "type": "PET_ARMOR",
+        "id": "kevlar_harness",
+        "copy-from": "kevlar_harness",
+        "name": {
+            "str": "Kevlar dog harness",
+            "str_pl": "Kevlar dog harnesses"
+        },
+        "pocket_data": [
+            {
+                "max_contains_volume": "12500 ml",
+                "max_contains_weight": "1000 kg",
+                "max_item_length": "1 km"
+            }
+        ]
+    },
+    {
+        "type": "PET_ARMOR",
+        "id": "superalloy_harness_dog",
+        "copy-from": "superalloy_harness_dog",
+        "name": {
+            "str": "superalloy tactical dog outfit"
+        },
+        "pocket_data": [
+            {
+                "max_contains_volume": "25000 ml",
+                "max_contains_weight": "1000 kg",
+                "max_item_length": "1 km"
+            }
+        ]
+    }
+]

--- a/Kenan-Modpack/easy_containers/items/armor/pets_horse_armor.json
+++ b/Kenan-Modpack/easy_containers/items/armor/pets_horse_armor.json
@@ -1,0 +1,18 @@
+[
+    {
+        "type": "ARMOR",
+        "id": "saddlebag",
+        "copy-from": "saddlebag",
+        "name": {
+            "str": "pair of saddle bags",
+            "str_pl": "pairs of saddle bags"
+        },
+        "pocket_data": [
+            {
+                "max_contains_volume": "30000 ml",
+                "max_contains_weight": "1000 kg",
+                "max_item_length": "1 km"
+            }
+        ]
+    }
+]

--- a/Kenan-Modpack/easy_containers/items/armor/power_armor.json
+++ b/Kenan-Modpack/easy_containers/items/armor/power_armor.json
@@ -1,0 +1,313 @@
+[
+    {
+        "type": "ARMOR",
+        "id": "depowered_armor",
+        "copy-from": "depowered_armor",
+        "name": {
+            "str": "salvaged power armor"
+        },
+        "pocket_data": [
+            {
+                "max_contains_volume": "16000 ml",
+                "max_contains_weight": "1000 kg",
+                "max_item_length": "1 km"
+            },
+            {
+                "pocket_type": "CONTAINER",
+                "rigid": true,
+                "max_contains_volume": "1 L",
+                "max_contains_weight": "1000 kg",
+                "flag_restriction": [
+                    "MAG_COMPACT",
+                    "MAG_BULKY"
+                ],
+                "moves": 60,
+                "max_item_length": "1 km"
+            },
+            {
+                "pocket_type": "CONTAINER",
+                "rigid": true,
+                "max_contains_volume": "1 L",
+                "max_contains_weight": "1000 kg",
+                "flag_restriction": [
+                    "MAG_COMPACT",
+                    "MAG_BULKY"
+                ],
+                "moves": 60,
+                "max_item_length": "1 km"
+            },
+            {
+                "pocket_type": "CONTAINER",
+                "rigid": true,
+                "max_contains_volume": "1 L",
+                "max_contains_weight": "1000 kg",
+                "flag_restriction": [
+                    "MAG_COMPACT",
+                    "MAG_BULKY"
+                ],
+                "moves": 60,
+                "max_item_length": "1 km"
+            },
+            {
+                "pocket_type": "CONTAINER",
+                "rigid": true,
+                "max_contains_volume": "1 L",
+                "max_contains_weight": "1000 kg",
+                "flag_restriction": [
+                    "MAG_COMPACT",
+                    "MAG_BULKY"
+                ],
+                "moves": 60,
+                "max_item_length": "1 km"
+            },
+            {
+                "pocket_type": "CONTAINER",
+                "rigid": true,
+                "max_contains_volume": "750 ml",
+                "max_contains_weight": "1000 kg",
+                "moves": 30,
+                "flag_restriction": [
+                    "GRENADE"
+                ],
+                "max_item_length": "1 km"
+            }
+        ]
+    },
+    {
+        "type": "TOOL_ARMOR",
+        "id": "power_armor_basic",
+        "copy-from": "power_armor_basic",
+        "name": {
+            "str": "combat exoskeleton"
+        },
+        "pocket_data": [
+            {
+                "max_contains_volume": "16000 ml",
+                "max_contains_weight": "1000 kg",
+                "max_item_length": "1 km"
+            },
+            {
+                "pocket_type": "CONTAINER",
+                "rigid": true,
+                "max_contains_volume": "1 L",
+                "max_contains_weight": "1000 kg",
+                "flag_restriction": [
+                    "MAG_COMPACT",
+                    "MAG_BULKY"
+                ],
+                "moves": 60,
+                "max_item_length": "1 km"
+            },
+            {
+                "pocket_type": "CONTAINER",
+                "rigid": true,
+                "max_contains_volume": "1 L",
+                "max_contains_weight": "1000 kg",
+                "flag_restriction": [
+                    "MAG_COMPACT",
+                    "MAG_BULKY"
+                ],
+                "moves": 60,
+                "max_item_length": "1 km"
+            },
+            {
+                "pocket_type": "CONTAINER",
+                "rigid": true,
+                "max_contains_volume": "1 L",
+                "max_contains_weight": "1000 kg",
+                "flag_restriction": [
+                    "MAG_COMPACT",
+                    "MAG_BULKY"
+                ],
+                "moves": 60,
+                "max_item_length": "1 km"
+            },
+            {
+                "pocket_type": "CONTAINER",
+                "rigid": true,
+                "max_contains_volume": "1 L",
+                "max_contains_weight": "1000 kg",
+                "flag_restriction": [
+                    "MAG_COMPACT",
+                    "MAG_BULKY"
+                ],
+                "moves": 60,
+                "max_item_length": "1 km"
+            },
+            {
+                "pocket_type": "CONTAINER",
+                "rigid": true,
+                "max_contains_volume": "750 ml",
+                "max_contains_weight": "1000 kg",
+                "moves": 30,
+                "flag_restriction": [
+                    "GRENADE"
+                ],
+                "max_item_length": "1 km"
+            }
+        ]
+    },
+    {
+        "type": "ARMOR",
+        "id": "power_armor_frame",
+        "copy-from": "power_armor_frame",
+        "name": {
+            "str": "power armor hauling frame"
+        },
+        "pocket_data": [
+            {
+                "max_contains_volume": "30000 ml",
+                "max_contains_weight": "1000 kg",
+                "max_item_length": "1 km"
+            }
+        ]
+    },
+    {
+        "type": "TOOL_ARMOR",
+        "id": "power_armor_heavy",
+        "copy-from": "power_armor_heavy",
+        "name": {
+            "str": "heavy combat exoskeleton"
+        },
+        "pocket_data": [
+            {
+                "max_contains_volume": "16000 ml",
+                "max_contains_weight": "1000 kg",
+                "max_item_length": "1 km"
+            },
+            {
+                "pocket_type": "CONTAINER",
+                "rigid": true,
+                "max_contains_volume": "1 L",
+                "max_contains_weight": "1000 kg",
+                "flag_restriction": [
+                    "MAG_COMPACT",
+                    "MAG_BULKY"
+                ],
+                "moves": 60,
+                "max_item_length": "1 km"
+            },
+            {
+                "pocket_type": "CONTAINER",
+                "rigid": true,
+                "max_contains_volume": "1 L",
+                "max_contains_weight": "1000 kg",
+                "flag_restriction": [
+                    "MAG_COMPACT",
+                    "MAG_BULKY"
+                ],
+                "moves": 60,
+                "max_item_length": "1 km"
+            },
+            {
+                "pocket_type": "CONTAINER",
+                "rigid": true,
+                "max_contains_volume": "1 L",
+                "max_contains_weight": "1000 kg",
+                "flag_restriction": [
+                    "MAG_COMPACT",
+                    "MAG_BULKY"
+                ],
+                "moves": 60,
+                "max_item_length": "1 km"
+            },
+            {
+                "pocket_type": "CONTAINER",
+                "rigid": true,
+                "max_contains_volume": "1 L",
+                "max_contains_weight": "1000 kg",
+                "flag_restriction": [
+                    "MAG_COMPACT",
+                    "MAG_BULKY"
+                ],
+                "moves": 60,
+                "max_item_length": "1 km"
+            },
+            {
+                "pocket_type": "CONTAINER",
+                "rigid": true,
+                "max_contains_volume": "750 ml",
+                "max_contains_weight": "1000 kg",
+                "moves": 30,
+                "flag_restriction": [
+                    "GRENADE"
+                ],
+                "max_item_length": "1 km"
+            }
+        ]
+    },
+    {
+        "type": "TOOL_ARMOR",
+        "id": "power_armor_light",
+        "copy-from": "power_armor_light",
+        "name": {
+            "str": "field combat exoskeleton"
+        },
+        "pocket_data": [
+            {
+                "max_contains_volume": "16000 ml",
+                "max_contains_weight": "1000 kg",
+                "max_item_length": "1 km"
+            },
+            {
+                "pocket_type": "CONTAINER",
+                "rigid": true,
+                "max_contains_volume": "1 L",
+                "max_contains_weight": "1000 kg",
+                "flag_restriction": [
+                    "MAG_COMPACT",
+                    "MAG_BULKY"
+                ],
+                "moves": 60,
+                "max_item_length": "1 km"
+            },
+            {
+                "pocket_type": "CONTAINER",
+                "rigid": true,
+                "max_contains_volume": "1 L",
+                "max_contains_weight": "1000 kg",
+                "flag_restriction": [
+                    "MAG_COMPACT",
+                    "MAG_BULKY"
+                ],
+                "moves": 60,
+                "max_item_length": "1 km"
+            },
+            {
+                "pocket_type": "CONTAINER",
+                "rigid": true,
+                "max_contains_volume": "1 L",
+                "max_contains_weight": "1000 kg",
+                "flag_restriction": [
+                    "MAG_COMPACT",
+                    "MAG_BULKY"
+                ],
+                "moves": 60,
+                "max_item_length": "1 km"
+            },
+            {
+                "pocket_type": "CONTAINER",
+                "rigid": true,
+                "max_contains_volume": "1 L",
+                "max_contains_weight": "1000 kg",
+                "flag_restriction": [
+                    "MAG_COMPACT",
+                    "MAG_BULKY"
+                ],
+                "moves": 60,
+                "max_item_length": "1 km"
+            },
+            {
+                "pocket_type": "CONTAINER",
+                "rigid": true,
+                "max_contains_volume": "750 ml",
+                "max_contains_weight": "1000 kg",
+                "moves": 30,
+                "flag_restriction": [
+                    "GRENADE"
+                ],
+                "max_item_length": "1 km"
+            }
+        ]
+    }
+]

--- a/Kenan-Modpack/easy_containers/items/armor/sheath.json
+++ b/Kenan-Modpack/easy_containers/items/armor/sheath.json
@@ -1,0 +1,192 @@
+[
+    {
+        "type": "ARMOR",
+        "id": "axe_ring",
+        "copy-from": "axe_ring",
+        "name": {
+            "str": "axe ring holster"
+        },
+        "pocket_data": [
+            {
+                "moves": 30,
+                "max_contains_volume": "3250 ml",
+                "max_contains_weight": "1000 kg",
+                "max_item_length": "1 km",
+                "holster": true,
+                "flag_restriction": [
+                    "SHEATH_AXE"
+                ]
+            }
+        ]
+    },
+    {
+        "type": "ARMOR",
+        "id": "baldric",
+        "copy-from": "baldric",
+        "name": {
+            "str": "baldric"
+        },
+        "pocket_data": [
+            {
+                "magazine_well": "1500 ml",
+                "max_contains_volume": "3 L",
+                "max_contains_weight": "1000 kg",
+                "max_item_length": "1 km",
+                "moves": 30,
+                "holster": true,
+                "flag_restriction": [
+                    "SHEATH_SWORD"
+                ]
+            }
+        ]
+    },
+    {
+        "type": "ARMOR",
+        "id": "bootsheath",
+        "copy-from": "bootsheath",
+        "name": {
+            "str": "ankle sheath"
+        },
+        "pocket_data": [
+            {
+                "magazine_well": "200 ml",
+                "holster": true,
+                "flag_restriction": [
+                    "SHEATH_KNIFE"
+                ],
+                "moves": 30,
+                "max_contains_volume": "500 ml",
+                "max_contains_weight": "1000 kg",
+                "max_item_length": "1 km"
+            }
+        ]
+    },
+    {
+        "type": "ARMOR",
+        "id": "bootsheath_birchbark",
+        "copy-from": "bootsheath_birchbark",
+        "name": {
+            "str": "birchbark ankle sheath",
+            "str_pl": "birchbark ankle sheathes"
+        },
+        "pocket_data": [
+            {
+                "magazine_well": "200 ml",
+                "holster": true,
+                "flag_restriction": [
+                    "SHEATH_KNIFE"
+                ],
+                "moves": 35,
+                "max_contains_volume": "500 ml",
+                "max_contains_weight": "1000 kg",
+                "max_item_length": "1 km"
+            }
+        ]
+    },
+    {
+        "type": "ARMOR",
+        "id": "bscabbard",
+        "copy-from": "bscabbard",
+        "name": {
+            "str": "back scabbard"
+        },
+        "pocket_data": [
+            {
+                "magazine_well": "1750 ml",
+                "max_contains_volume": "3750 ml",
+                "max_contains_weight": "1000 kg",
+                "max_item_length": "1 km",
+                "holster": true,
+                "moves": 60,
+                "flag_restriction": [
+                    "SHEATH_SWORD"
+                ]
+            }
+        ]
+    },
+    {
+        "type": "ARMOR",
+        "id": "scabbard",
+        "copy-from": "scabbard",
+        "name": {
+            "str": "scabbard"
+        },
+        "pocket_data": [
+            {
+                "magazine_well": "1250 ml",
+                "max_contains_volume": "2 L",
+                "max_contains_weight": "1000 kg",
+                "max_item_length": "1 km",
+                "holster": true,
+                "moves": 30,
+                "flag_restriction": [
+                    "SHEATH_SWORD"
+                ]
+            }
+        ]
+    },
+    {
+        "type": "ARMOR",
+        "id": "sheath",
+        "copy-from": "sheath",
+        "name": {
+            "str": "sheath",
+            "str_pl": "sheathes"
+        },
+        "pocket_data": [
+            {
+                "magazine_well": "350 ml",
+                "holster": true,
+                "max_contains_volume": "750 ml",
+                "max_contains_weight": "1000 kg",
+                "max_item_length": "1 km",
+                "moves": 20,
+                "flag_restriction": [
+                    "SHEATH_KNIFE"
+                ]
+            }
+        ]
+    },
+    {
+        "type": "ARMOR",
+        "id": "sheath_birchbark",
+        "copy-from": "sheath_birchbark",
+        "name": {
+            "str": "birchbark sheath",
+            "str_pl": "birchbark sheathes"
+        },
+        "pocket_data": [
+            {
+                "magazine_well": "350 ml",
+                "holster": true,
+                "max_contains_volume": "750 ml",
+                "max_contains_weight": "1000 kg",
+                "max_item_length": "1 km",
+                "moves": 25,
+                "flag_restriction": [
+                    "SHEATH_KNIFE"
+                ]
+            }
+        ]
+    },
+    {
+        "type": "ARMOR",
+        "id": "spearsling",
+        "copy-from": "spearsling",
+        "name": {
+            "str": "spear strap"
+        },
+        "pocket_data": [
+            {
+                "holster": true,
+                "moves": 30,
+                "flag_restriction": [
+                    "SHEATH_SPEAR"
+                ],
+                "max_contains_volume": "4000 ml",
+                "max_contains_weight": "1000 kg",
+                "max_item_length": "1 km"
+            }
+        ]
+    }
+]

--- a/Kenan-Modpack/easy_containers/items/armor/storage.json
+++ b/Kenan-Modpack/easy_containers/items/armor/storage.json
@@ -1,0 +1,842 @@
+[
+    {
+        "type": "ARMOR",
+        "id": "backpack",
+        "copy-from": "backpack",
+        "name": {
+            "str": "backpack"
+        },
+        "pocket_data": [
+            {
+                "max_contains_volume": "25000 ml",
+                "max_contains_weight": "1000 kg",
+                "max_item_length": "1 km"
+            }
+        ]
+    },
+    {
+        "type": "ARMOR",
+        "id": "backpack_hiking",
+        "copy-from": "backpack_hiking",
+        "name": {
+            "str": "hiking backpack"
+        },
+        "pocket_data": [
+            {
+                "max_contains_volume": "58000 ml",
+                "max_contains_weight": "1000 kg",
+                "max_item_length": "1 km"
+            },
+            {
+                "pocket_type": "CONTAINER",
+                "max_contains_volume": "750 ml",
+                "max_contains_weight": "1000 kg",
+                "max_item_length": "1 km",
+                "moves": 3,
+                "flag_restriction": [
+                    "SHEATH_KNIFE",
+                    "SHEATH_SWORD"
+                ]
+            },
+            {
+                "pocket_type": "CONTAINER",
+                "max_contains_volume": "750 ml",
+                "max_contains_weight": "1000 kg",
+                "max_item_length": "1 km",
+                "moves": 3,
+                "flag_restriction": [
+                    "SHEATH_KNIFE",
+                    "SHEATH_SWORD"
+                ]
+            }
+        ]
+    },
+    {
+        "type": "ARMOR",
+        "id": "backpack_giant",
+        "copy-from": "backpack_giant",
+        "name": {
+            "str": "giant novelty backpack"
+        },
+        "pocket_data": [
+            {
+                "max_contains_volume": "80000 ml",
+                "max_contains_weight": "1000 kg",
+                "max_item_length": "1 km"
+            }
+        ]
+    },
+    {
+        "type": "ARMOR",
+        "id": "backpack_leather",
+        "copy-from": "backpack_leather",
+        "name": {
+            "str": "leather backpack"
+        },
+        "pocket_data": [
+            {
+                "max_contains_volume": "25000 ml",
+                "max_contains_weight": "1000 kg",
+                "max_item_length": "1 km"
+            }
+        ]
+    },
+    {
+        "type": "ARMOR",
+        "id": "backpack_tactical_large",
+        "copy-from": "backpack_tactical_large",
+        "name": {
+            "str": "large tactical backpack"
+        },
+        "pocket_data": [
+            {
+                "max_contains_volume": "66000 ml",
+                "max_contains_weight": "1000 kg",
+                "max_item_length": "1 km"
+            }
+        ]
+    },
+    {
+        "type": "ARMOR",
+        "id": "basket_laundry",
+        "copy-from": "basket_laundry",
+        "name": {
+            "str": "laundry basket"
+        },
+        "pocket_data": [
+            {
+                "max_contains_volume": "50000 ml",
+                "max_contains_weight": "1000 kg",
+                "max_item_length": "1 km"
+            }
+        ]
+    },
+    {
+        "type": "ARMOR",
+        "id": "bigback",
+        "copy-from": "bigback",
+        "name": {
+            "str": "high-volume rucksack"
+        },
+        "pocket_data": [
+            {
+                "max_contains_volume": "81000 ml",
+                "max_contains_weight": "1000 kg",
+                "max_item_length": "1 km"
+            }
+        ]
+    },
+    {
+        "type": "ARMOR",
+        "id": "bindle",
+        "copy-from": "bindle",
+        "name": {
+            "str": "bindle"
+        },
+        "pocket_data": [
+            {
+                "max_contains_volume": "5000 ml",
+                "max_contains_weight": "1000 kg",
+                "max_item_length": "1 km"
+            }
+        ]
+    },
+    {
+        "type": "ARMOR",
+        "id": "boxpack",
+        "copy-from": "boxpack",
+        "name": {
+            "str": "box backpack"
+        },
+        "pocket_data": [
+            {
+                "max_contains_volume": "15000 ml",
+                "max_contains_weight": "1000 kg",
+                "max_item_length": "1 km"
+            }
+        ]
+    },
+    {
+        "type": "ARMOR",
+        "id": "briefcase",
+        "copy-from": "briefcase",
+        "name": {
+            "str": "briefcase"
+        },
+        "pocket_data": [
+            {
+                "max_contains_volume": "15000 ml",
+                "max_contains_weight": "1000 kg",
+                "max_item_length": "1 km"
+            }
+        ]
+    },
+    {
+        "type": "ARMOR",
+        "id": "case_violin",
+        "copy-from": "case_violin",
+        "name": {
+            "str": "violin case"
+        },
+        "pocket_data": [
+            {
+                "max_contains_volume": "10000 ml",
+                "max_contains_weight": "1000 kg",
+                "max_item_length": "1 km"
+            }
+        ]
+    },
+    {
+        "type": "ARMOR",
+        "id": "daypack",
+        "copy-from": "daypack",
+        "name": {
+            "str": "daypack"
+        },
+        "pocket_data": [
+            {
+                "max_contains_volume": "24000 ml",
+                "max_contains_weight": "1000 kg",
+                "max_item_length": "1 km"
+            }
+        ]
+    },
+    {
+        "type": "ARMOR",
+        "id": "dive_bag",
+        "copy-from": "dive_bag",
+        "name": {
+            "str": "dive bag"
+        },
+        "pocket_data": [
+            {
+                "max_contains_volume": "30000 ml",
+                "max_contains_weight": "1000 kg",
+                "max_item_length": "1 km"
+            }
+        ]
+    },
+    {
+        "type": "ARMOR",
+        "id": "duffelbag",
+        "copy-from": "duffelbag",
+        "name": {
+            "str": "duffel bag"
+        },
+        "pocket_data": [
+            {
+                "max_contains_volume": "35000 ml",
+                "max_contains_weight": "1000 kg",
+                "max_item_length": "1 km"
+            }
+        ]
+    },
+    {
+        "type": "ARMOR",
+        "id": "dump_pouch",
+        "copy-from": "dump_pouch",
+        "name": {
+            "str": "tactical dump pouch",
+            "str_pl": "tactical dump pouches"
+        },
+        "pocket_data": [
+            {
+                "max_contains_volume": "2000 ml",
+                "max_contains_weight": "1000 kg",
+                "max_item_length": "1 km"
+            }
+        ]
+    },
+    {
+        "type": "ARMOR",
+        "id": "fanny",
+        "copy-from": "fanny",
+        "name": {
+            "str": "fanny pack"
+        },
+        "pocket_data": [
+            {
+                "max_contains_volume": "2500 ml",
+                "max_contains_weight": "1000 kg",
+                "max_item_length": "1 km"
+            }
+        ]
+    },
+    {
+        "type": "ARMOR",
+        "id": "golf_bag",
+        "copy-from": "golf_bag",
+        "name": {
+            "str": "golf bag"
+        },
+        "pocket_data": [
+            {
+                "max_contains_volume": "43380 ml",
+                "max_contains_weight": "1000 kg",
+                "max_item_length": "1 km"
+            }
+        ]
+    },
+    {
+        "type": "COMESTIBLE",
+        "id": "hide_bag",
+        "copy-from": "hide_bag",
+        "name": {
+            "str": "hide bag"
+        },
+        "pocket_data": [
+            {
+                "max_contains_volume": "15000 ml",
+                "max_contains_weight": "1000 kg",
+                "max_item_length": "1 km"
+            }
+        ]
+    },
+    {
+        "type": "COMESTIBLE",
+        "id": "hide_tainted_bag",
+        "copy-from": "hide_tainted_bag",
+        "name": {
+            "str": "tainted hide bag"
+        },
+        "pocket_data": [
+            {
+                "max_contains_volume": "15000 ml",
+                "max_contains_weight": "1000 kg",
+                "max_item_length": "1 km"
+            }
+        ]
+    },
+    {
+        "type": "ARMOR",
+        "id": "hk_briefcase",
+        "copy-from": "hk_briefcase",
+        "name": {
+            "str": "H&K operational briefcase (empty)",
+            "str_pl": "H&K operational briefcases (empty)"
+        },
+        "pocket_data": [
+            {
+                "max_contains_volume": "14000 ml",
+                "max_contains_weight": "1000 kg",
+                "max_item_length": "1 km"
+            }
+        ]
+    },
+    {
+        "type": "ARMOR",
+        "id": "jerrypack",
+        "copy-from": "jerrypack",
+        "name": {
+            "str": "jerrypack"
+        },
+        "pocket_data": [
+            {
+                "max_contains_volume": "10 L",
+                "max_contains_weight": "1000 kg",
+                "max_item_volume": "65 ml",
+                "watertight": true,
+                "rigid": true,
+                "max_item_length": "1 km"
+            }
+        ]
+    },
+    {
+        "type": "ARMOR",
+        "id": "leather_pouch",
+        "copy-from": "leather_pouch",
+        "name": {
+            "str": "leather pouch",
+            "str_pl": "leather pouches"
+        },
+        "pocket_data": [
+            {
+                "max_contains_volume": "1500 ml",
+                "max_contains_weight": "1000 kg",
+                "max_item_length": "1 km"
+            }
+        ]
+    },
+    {
+        "type": "ARMOR",
+        "id": "legrig",
+        "copy-from": "legrig",
+        "name": {
+            "str": "pair of drop leg pouches",
+            "str_pl": "pairs of drop leg pouches"
+        },
+        "pocket_data": [
+            {
+                "max_contains_volume": "4500 ml",
+                "max_contains_weight": "1000 kg",
+                "max_item_length": "1 km"
+            }
+        ]
+    },
+    {
+        "type": "ARMOR",
+        "id": "makeshift_knapsack",
+        "copy-from": "makeshift_knapsack",
+        "name": {
+            "str": "makeshift knapsack"
+        },
+        "pocket_data": [
+            {
+                "max_contains_volume": "5000 ml",
+                "max_contains_weight": "1000 kg",
+                "max_item_length": "1 km"
+            }
+        ]
+    },
+    {
+        "type": "ARMOR",
+        "id": "makeshift_sling",
+        "copy-from": "makeshift_sling",
+        "name": {
+            "str": "makeshift sling"
+        },
+        "pocket_data": [
+            {
+                "max_contains_volume": "10000 ml",
+                "max_contains_weight": "1000 kg",
+                "max_item_length": "1 km"
+            }
+        ]
+    },
+    {
+        "type": "ARMOR",
+        "id": "mbag",
+        "copy-from": "mbag",
+        "name": {
+            "str": "messenger bag"
+        },
+        "pocket_data": [
+            {
+                "max_contains_volume": "15000 ml",
+                "max_contains_weight": "1000 kg",
+                "max_item_length": "1 km"
+            }
+        ]
+    },
+    {
+        "type": "ARMOR",
+        "id": "molle_pack",
+        "copy-from": "molle_pack",
+        "name": {
+            "str": "MOLLE pack"
+        },
+        "pocket_data": [
+            {
+                "max_contains_volume": "27000 ml",
+                "max_contains_weight": "1000 kg",
+                "max_item_length": "1 km"
+            }
+        ]
+    },
+    {
+        "type": "ARMOR",
+        "id": "net_backpack",
+        "copy-from": "net_backpack",
+        "name": {
+            "str": "net backpack"
+        },
+        "pocket_data": [
+            {
+                "max_contains_volume": "15000 ml",
+                "max_contains_weight": "1000 kg",
+                "max_item_length": "1 km"
+            }
+        ]
+    },
+    {
+        "type": "ARMOR",
+        "id": "petpack",
+        "copy-from": "petpack",
+        "name": {
+            "str": "petpack"
+        },
+        "pocket_data": [
+            {
+                "max_contains_volume": "35000 ml",
+                "max_contains_weight": "1000 kg",
+                "max_item_length": "1 km"
+            }
+        ]
+    },
+    {
+        "type": "ARMOR",
+        "id": "plastic_shopping_bag",
+        "copy-from": "plastic_shopping_bag",
+        "name": {
+            "str": "plastic shopping bag"
+        },
+        "pocket_data": [
+            {
+                "max_contains_volume": "5000 ml",
+                "max_contains_weight": "1000 kg",
+                "max_item_length": "1 km"
+            }
+        ]
+    },
+    {
+        "type": "ARMOR",
+        "id": "purse",
+        "copy-from": "purse",
+        "name": {
+            "str": "purse"
+        },
+        "pocket_data": [
+            {
+                "max_contains_volume": "5000 ml",
+                "max_contains_weight": "1000 kg",
+                "max_item_length": "1 km"
+            }
+        ]
+    },
+    {
+        "type": "ARMOR",
+        "id": "ragpouch",
+        "copy-from": "ragpouch",
+        "name": {
+            "str": "pouch",
+            "str_pl": "pouches"
+        },
+        "pocket_data": [
+            {
+                "max_contains_volume": "2250 ml",
+                "max_contains_weight": "1000 kg",
+                "max_item_length": "1 km"
+            }
+        ]
+    },
+    {
+        "type": "ARMOR",
+        "id": "rucksack",
+        "copy-from": "rucksack",
+        "name": {
+            "str": "military rucksack"
+        },
+        "pocket_data": [
+            {
+                "max_contains_volume": "51000 ml",
+                "max_contains_weight": "1000 kg",
+                "max_item_length": "1 km"
+            }
+        ]
+    },
+    {
+        "type": "ARMOR",
+        "id": "runner_bag",
+        "copy-from": "runner_bag",
+        "name": {
+            "str": "runner pack"
+        },
+        "pocket_data": [
+            {
+                "max_contains_volume": "7000 ml",
+                "max_contains_weight": "1000 kg",
+                "max_item_length": "1 km"
+            }
+        ]
+    },
+    {
+        "type": "ARMOR",
+        "id": "slingpack",
+        "copy-from": "slingpack",
+        "name": {
+            "str": "sling pack"
+        },
+        "pocket_data": [
+            {
+                "max_contains_volume": "8000 ml",
+                "max_contains_weight": "1000 kg",
+                "max_item_length": "1 km"
+            }
+        ]
+    },
+    {
+        "type": "ARMOR",
+        "id": "straw_basket",
+        "copy-from": "straw_basket",
+        "name": {
+            "str": "straw basket"
+        },
+        "pocket_data": [
+            {
+                "max_contains_volume": "10000 ml",
+                "max_contains_weight": "1000 kg",
+                "max_item_length": "1 km"
+            }
+        ]
+    },
+    {
+        "type": "ARMOR",
+        "id": "suitcase_l",
+        "copy-from": "suitcase_l",
+        "name": {
+            "str": "suitcase"
+        },
+        "pocket_data": [
+            {
+                "max_contains_volume": "110000 ml",
+                "max_contains_weight": "1000 kg",
+                "max_item_length": "1 km"
+            }
+        ]
+    },
+    {
+        "type": "ARMOR",
+        "id": "suitcase_m",
+        "copy-from": "suitcase_m",
+        "name": {
+            "str": "suitcase"
+        },
+        "pocket_data": [
+            {
+                "max_contains_volume": "45000 ml",
+                "max_contains_weight": "1000 kg",
+                "max_item_length": "1 km"
+            }
+        ]
+    },
+    {
+        "type": "ARMOR",
+        "id": "survivor_duffel_bag",
+        "copy-from": "survivor_duffel_bag",
+        "name": {
+            "str": "survivor duffel bag"
+        },
+        "pocket_data": [
+            {
+                "max_contains_volume": "38000 ml",
+                "max_contains_weight": "1000 kg",
+                "max_item_length": "1 km"
+            }
+        ]
+    },
+    {
+        "type": "ARMOR",
+        "id": "survivor_pack",
+        "copy-from": "survivor_pack",
+        "name": {
+            "str": "survivor backpack"
+        },
+        "pocket_data": [
+            {
+                "max_contains_volume": "30000 ml",
+                "max_contains_weight": "1000 kg",
+                "max_item_length": "1 km"
+            }
+        ]
+    },
+    {
+        "type": "ARMOR",
+        "id": "survivor_rucksack",
+        "copy-from": "survivor_rucksack",
+        "name": {
+            "str": "survivor rucksack"
+        },
+        "pocket_data": [
+            {
+                "max_contains_volume": "35000 ml",
+                "max_contains_weight": "1000 kg",
+                "max_item_length": "1 km"
+            }
+        ]
+    },
+    {
+        "type": "ARMOR",
+        "id": "survivor_runner_pack",
+        "copy-from": "survivor_runner_pack",
+        "name": {
+            "str": "survivor runner pack"
+        },
+        "pocket_data": [
+            {
+                "max_contains_volume": "20000 ml",
+                "max_contains_weight": "1000 kg",
+                "max_item_length": "1 km"
+            }
+        ]
+    },
+    {
+        "type": "ARMOR",
+        "id": "swag_bag",
+        "copy-from": "swag_bag",
+        "name": {
+            "str": "swag bag"
+        },
+        "pocket_data": [
+            {
+                "max_contains_volume": "25000 ml",
+                "max_contains_weight": "1000 kg",
+                "max_item_length": "1 km"
+            }
+        ]
+    },
+    {
+        "type": "ARMOR",
+        "id": "travelpack",
+        "copy-from": "travelpack",
+        "name": {
+            "str": "travelpack"
+        },
+        "pocket_data": [
+            {
+                "max_contains_volume": "31000 ml",
+                "max_contains_weight": "1000 kg",
+                "max_item_length": "1 km"
+            }
+        ]
+    },
+    {
+        "type": "ARMOR",
+        "id": "vest",
+        "copy-from": "vest",
+        "name": {
+            "str": "utility vest"
+        },
+        "pocket_data": [
+            {
+                "max_contains_volume": "3000 ml",
+                "max_contains_weight": "1000 kg",
+                "max_item_length": "1 km"
+            }
+        ]
+    },
+    {
+        "type": "ARMOR",
+        "id": "wicker_backpack",
+        "copy-from": "wicker_backpack",
+        "name": {
+            "str": "wicker backpack"
+        },
+        "pocket_data": [
+            {
+                "max_contains_volume": "15000 ml",
+                "max_contains_weight": "1000 kg",
+                "max_item_length": "1 km"
+            }
+        ]
+    },
+    {
+        "type": "ARMOR",
+        "id": "debug_backpack",
+        "copy-from": "debug_backpack",
+        "name": {
+            "str": "debug pocket universe"
+        },
+        "pocket_data": [
+            {
+                "max_contains_volume": "100000000 ml",
+                "max_contains_weight": "1000 kg",
+                "max_item_length": "1 km"
+            }
+        ]
+    },
+    {
+        "type": "ARMOR",
+        "id": "long_duffelbag",
+        "copy-from": "long_duffelbag",
+        "name": {
+            "str": "longarm bag"
+        },
+        "pocket_data": [
+            {
+                "max_contains_volume": "50000 ml",
+                "max_contains_weight": "1000 kg",
+                "max_item_length": "1 km"
+            }
+        ]
+    },
+    {
+        "type": "ARMOR",
+        "id": "rifle_case_soft",
+        "copy-from": "rifle_case_soft",
+        "name": {
+            "str": "rifle case"
+        },
+        "pocket_data": [
+            {
+                "max_contains_volume": "7000 ml",
+                "max_contains_weight": "1000 kg",
+                "max_item_length": "1 km"
+            }
+        ]
+    },
+    {
+        "type": "ARMOR",
+        "id": "rifle_case_soft_leather",
+        "copy-from": "rifle_case_soft_leather",
+        "name": {
+            "str": "leather rifle case"
+        },
+        "pocket_data": [
+            {
+                "max_contains_volume": "7000 ml",
+                "max_contains_weight": "1000 kg",
+                "max_item_length": "1 km"
+            }
+        ]
+    },
+    {
+        "type": "ARMOR",
+        "id": "rifle_case_soft_2",
+        "copy-from": "rifle_case_soft_2",
+        "name": {
+            "str": "double rifle case"
+        },
+        "pocket_data": [
+            {
+                "max_contains_volume": "19000 ml",
+                "max_contains_weight": "1000 kg",
+                "max_item_length": "1 km"
+            }
+        ]
+    },
+    {
+        "type": "ARMOR",
+        "id": "rifle_case_soft_leather_2",
+        "copy-from": "rifle_case_soft_leather_2",
+        "name": {
+            "str": "leather double rifle case"
+        },
+        "pocket_data": [
+            {
+                "max_contains_volume": "19000 ml",
+                "max_contains_weight": "1000 kg",
+                "max_item_length": "1 km"
+            }
+        ]
+    },
+    {
+        "type": "ARMOR",
+        "id": "rifle_case_xl_soft_leather",
+        "copy-from": "rifle_case_xl_soft_leather",
+        "name": {
+            "str": "long leather rifle case"
+        },
+        "pocket_data": [
+            {
+                "max_contains_volume": "13000 ml",
+                "max_contains_weight": "1000 kg",
+                "max_item_length": "1 km"
+            }
+        ]
+    },
+    {
+        "type": "ARMOR",
+        "id": "camera_bag",
+        "copy-from": "camera_bag",
+        "name": {
+            "str": "camera bag"
+        },
+        "pocket_data": [
+            {
+                "max_contains_volume": "4500 ml",
+                "max_contains_weight": "1000 kg",
+                "max_item_length": "1 km"
+            }
+        ]
+    }
+]

--- a/Kenan-Modpack/easy_containers/items/armor/suits_clothes.json
+++ b/Kenan-Modpack/easy_containers/items/armor/suits_clothes.json
@@ -1,0 +1,92 @@
+[
+    {
+        "type": "ARMOR",
+        "id": "clown_suit",
+        "copy-from": "clown_suit",
+        "name": {
+            "str": "clown suit"
+        },
+        "pocket_data": [
+            {
+                "max_contains_volume": "3250 ml",
+                "max_contains_weight": "1000 kg",
+                "max_item_length": "1 km"
+            }
+        ]
+    },
+    {
+        "type": "ARMOR",
+        "id": "dinosuit",
+        "copy-from": "dinosuit",
+        "name": {
+            "str": "dinosaur suit"
+        },
+        "pocket_data": [
+            {
+                "max_contains_volume": "1000 ml",
+                "max_contains_weight": "1000 kg",
+                "max_item_length": "1 km"
+            }
+        ]
+    },
+    {
+        "type": "ARMOR",
+        "id": "jumpsuit",
+        "copy-from": "jumpsuit",
+        "name": {
+            "str": "jumpsuit"
+        },
+        "pocket_data": [
+            {
+                "max_contains_volume": "1900 ml",
+                "max_contains_weight": "1000 kg",
+                "max_item_length": "1 km"
+            }
+        ]
+    },
+    {
+        "type": "ARMOR",
+        "id": "jumpsuit_xl",
+        "copy-from": "jumpsuit_xl",
+        "name": {
+            "str": "XL jumpsuit"
+        },
+        "pocket_data": [
+            {
+                "max_contains_volume": "2500 ml",
+                "max_contains_weight": "1000 kg",
+                "max_item_length": "1 km"
+            }
+        ]
+    },
+    {
+        "type": "ARMOR",
+        "id": "subsuit_xl",
+        "copy-from": "subsuit_xl",
+        "name": {
+            "str": "subject suit"
+        },
+        "pocket_data": [
+            {
+                "max_contains_volume": "1000 ml",
+                "max_contains_weight": "1000 kg",
+                "max_item_length": "1 km"
+            }
+        ]
+    },
+    {
+        "type": "ARMOR",
+        "id": "wolfsuit",
+        "copy-from": "wolfsuit",
+        "name": {
+            "str": "wolf suit"
+        },
+        "pocket_data": [
+            {
+                "max_contains_volume": "1000 ml",
+                "max_contains_weight": "1000 kg",
+                "max_item_length": "1 km"
+            }
+        ]
+    }
+]

--- a/Kenan-Modpack/easy_containers/items/armor/suits_protection.json
+++ b/Kenan-Modpack/easy_containers/items/armor/suits_protection.json
@@ -1,0 +1,302 @@
+[
+    {
+        "type": "ARMOR",
+        "id": "aep_suit",
+        "copy-from": "aep_suit",
+        "name": {
+            "str": "AEP suit"
+        },
+        "pocket_data": [
+            {
+                "max_contains_volume": "4000 ml",
+                "max_contains_weight": "1000 kg",
+                "max_item_length": "1 km"
+            }
+        ]
+    },
+    {
+        "type": "ARMOR",
+        "id": "armor_blarmor",
+        "copy-from": "armor_blarmor",
+        "name": {
+            "str": "boiled leather armor"
+        },
+        "pocket_data": [
+            {
+                "max_contains_volume": "1000 ml",
+                "max_contains_weight": "1000 kg",
+                "max_item_length": "1 km"
+            }
+        ]
+    },
+    {
+        "type": "ARMOR",
+        "id": "armor_farmor",
+        "copy-from": "armor_farmor",
+        "name": {
+            "str": "fur body armor"
+        },
+        "pocket_data": [
+            {
+                "max_contains_volume": "1000 ml",
+                "max_contains_weight": "1000 kg",
+                "max_item_length": "1 km"
+            }
+        ]
+    },
+    {
+        "type": "ARMOR",
+        "id": "armor_larmor",
+        "copy-from": "armor_larmor",
+        "name": {
+            "str": "leather body armor"
+        },
+        "pocket_data": [
+            {
+                "max_contains_volume": "2000 ml",
+                "max_contains_weight": "1000 kg",
+                "max_item_length": "1 km"
+            }
+        ]
+    },
+    {
+        "type": "ARMOR",
+        "id": "armor_nomad",
+        "copy-from": "armor_nomad",
+        "name": {
+            "str": "nomad gear"
+        },
+        "pocket_data": [
+            {
+                "max_contains_volume": "21500 ml",
+                "max_contains_weight": "1000 kg",
+                "max_item_length": "1 km"
+            }
+        ]
+    },
+    {
+        "type": "ARMOR",
+        "id": "armor_nomad_light",
+        "copy-from": "armor_nomad_light",
+        "name": {
+            "str": "light nomad gear"
+        },
+        "pocket_data": [
+            {
+                "max_contains_volume": "13500 ml",
+                "max_contains_weight": "1000 kg",
+                "max_item_length": "1 km"
+            }
+        ]
+    },
+    {
+        "type": "ARMOR",
+        "id": "armor_plarmor",
+        "copy-from": "armor_plarmor",
+        "name": {
+            "str": "plated leather armor"
+        },
+        "pocket_data": [
+            {
+                "max_contains_volume": "1900 ml",
+                "max_contains_weight": "1000 kg",
+                "max_item_length": "1 km"
+            }
+        ]
+    },
+    {
+        "type": "ARMOR",
+        "id": "armor_scavenger",
+        "copy-from": "armor_scavenger",
+        "name": {
+            "str": "scavenger gear"
+        },
+        "pocket_data": [
+            {
+                "max_contains_volume": "20000 ml",
+                "max_contains_weight": "1000 kg",
+                "max_item_length": "1 km"
+            }
+        ]
+    },
+    {
+        "type": "ARMOR",
+        "id": "beekeeping_suit",
+        "copy-from": "beekeeping_suit",
+        "name": {
+            "str": "beekeeping suit"
+        },
+        "pocket_data": [
+            {
+                "max_contains_volume": "1900 ml",
+                "max_contains_weight": "1000 kg",
+                "max_item_length": "1 km"
+            }
+        ]
+    },
+    {
+        "type": "ARMOR",
+        "id": "fsurvivor_suit",
+        "copy-from": "fsurvivor_suit",
+        "name": {
+            "str": "survivor firesuit"
+        },
+        "pocket_data": [
+            {
+                "max_contains_volume": "10000 ml",
+                "max_contains_weight": "1000 kg",
+                "max_item_length": "1 km"
+            }
+        ]
+    },
+    {
+        "type": "ARMOR",
+        "id": "hsurvivor_suit",
+        "copy-from": "hsurvivor_suit",
+        "name": {
+            "str": "heavy survivor suit"
+        },
+        "pocket_data": [
+            {
+                "max_contains_volume": "6000 ml",
+                "max_contains_weight": "1000 kg",
+                "max_item_length": "1 km"
+            }
+        ]
+    },
+    {
+        "type": "ARMOR",
+        "id": "lsurvivor_suit",
+        "copy-from": "lsurvivor_suit",
+        "name": {
+            "str": "light survivor suit"
+        },
+        "pocket_data": [
+            {
+                "max_contains_volume": "7000 ml",
+                "max_contains_weight": "1000 kg",
+                "max_item_length": "1 km"
+            }
+        ]
+    },
+    {
+        "type": "ARMOR",
+        "id": "robofac_enviro_suit",
+        "copy-from": "robofac_enviro_suit",
+        "name": {
+            "str": "Hub 01 environmental suit"
+        },
+        "pocket_data": [
+            {
+                "max_contains_volume": "4900 ml",
+                "max_contains_weight": "1000 kg",
+                "max_item_length": "1 km"
+            }
+        ]
+    },
+    {
+        "type": "ARMOR",
+        "id": "suit",
+        "copy-from": "suit",
+        "name": {
+            "str": "suit"
+        },
+        "pocket_data": [
+            {
+                "max_contains_volume": "3100 ml",
+                "max_contains_weight": "1000 kg",
+                "max_item_length": "1 km"
+            }
+        ]
+    },
+    {
+        "type": "ARMOR",
+        "id": "survivor_suit",
+        "copy-from": "survivor_suit",
+        "name": {
+            "str": "survivor suit"
+        },
+        "pocket_data": [
+            {
+                "max_contains_volume": "7000 ml",
+                "max_contains_weight": "1000 kg",
+                "max_item_length": "1 km"
+            }
+        ]
+    },
+    {
+        "type": "ARMOR",
+        "id": "swat_armor",
+        "copy-from": "swat_armor",
+        "name": {
+            "str": "SWAT armor"
+        },
+        "pocket_data": [
+            {
+                "max_contains_volume": "5000 ml",
+                "max_contains_weight": "1000 kg",
+                "max_item_length": "1 km"
+            }
+        ]
+    },
+    {
+        "type": "ARMOR",
+        "id": "touring_suit",
+        "copy-from": "touring_suit",
+        "name": {
+            "str": "leather touring suit"
+        },
+        "pocket_data": [
+            {
+                "max_contains_volume": "250 ml",
+                "max_contains_weight": "1000 kg",
+                "max_item_length": "1 km"
+            }
+        ]
+    },
+    {
+        "type": "ARMOR",
+        "id": "wsurvivor_suit",
+        "copy-from": "wsurvivor_suit",
+        "name": {
+            "str": "winter survivor suit"
+        },
+        "pocket_data": [
+            {
+                "max_contains_volume": "5000 ml",
+                "max_contains_weight": "1000 kg",
+                "max_item_length": "1 km"
+            }
+        ]
+    },
+    {
+        "type": "ARMOR",
+        "id": "xlsurvivor_suit",
+        "copy-from": "xlsurvivor_suit",
+        "name": {
+            "str": "XL survivor suit"
+        },
+        "pocket_data": [
+            {
+                "max_contains_volume": "8000 ml",
+                "max_contains_weight": "1000 kg",
+                "max_item_length": "1 km"
+            }
+        ]
+    },
+    {
+        "type": "ARMOR",
+        "id": "xlhsurvivor_suit",
+        "copy-from": "xlhsurvivor_suit",
+        "name": {
+            "str": "XL heavy survivor suit"
+        },
+        "pocket_data": [
+            {
+                "max_contains_volume": "7000 ml",
+                "max_contains_weight": "1000 kg",
+                "max_item_length": "1 km"
+            }
+        ]
+    }
+]

--- a/Kenan-Modpack/easy_containers/items/armor/swimming.json
+++ b/Kenan-Modpack/easy_containers/items/armor/swimming.json
@@ -1,0 +1,47 @@
+[
+    {
+        "type": "ARMOR",
+        "id": "wetsuit",
+        "copy-from": "wetsuit",
+        "name": {
+            "str": "wetsuit"
+        },
+        "pocket_data": [
+            {
+                "max_contains_volume": "1200 ml",
+                "max_contains_weight": "1000 kg",
+                "max_item_length": "1 km"
+            }
+        ]
+    },
+    {
+        "type": "ARMOR",
+        "id": "h20survivor_suit",
+        "copy-from": "h20survivor_suit",
+        "name": {
+            "str": "survivor wetsuit"
+        },
+        "pocket_data": [
+            {
+                "max_contains_volume": "10000 ml",
+                "max_contains_weight": "1000 kg",
+                "max_item_length": "1 km"
+            }
+        ]
+    },
+    {
+        "type": "ARMOR",
+        "id": "wetsuit_spring",
+        "copy-from": "wetsuit_spring",
+        "name": {
+            "str": "spring suit"
+        },
+        "pocket_data": [
+            {
+                "max_contains_volume": "1200 ml",
+                "max_contains_weight": "1000 kg",
+                "max_item_length": "1 km"
+            }
+        ]
+    }
+]

--- a/Kenan-Modpack/easy_containers/items/armor/torso_armor.json
+++ b/Kenan-Modpack/easy_containers/items/armor/torso_armor.json
@@ -1,0 +1,62 @@
+[
+    {
+        "type": "ARMOR",
+        "id": "jacket_leather_mod",
+        "copy-from": "jacket_leather_mod",
+        "name": {
+            "str": "armored leather jacket"
+        },
+        "pocket_data": [
+            {
+                "max_contains_volume": "1200 ml",
+                "max_contains_weight": "1000 kg",
+                "max_item_length": "1 km"
+            }
+        ]
+    },
+    {
+        "type": "ARMOR",
+        "id": "lsurvivor_armor",
+        "copy-from": "lsurvivor_armor",
+        "name": {
+            "str": "light survivor body armor"
+        },
+        "pocket_data": [
+            {
+                "max_contains_volume": "2900 ml",
+                "max_contains_weight": "1000 kg",
+                "max_item_length": "1 km"
+            }
+        ]
+    },
+    {
+        "type": "ARMOR",
+        "id": "motorbike_armor",
+        "copy-from": "motorbike_armor",
+        "name": {
+            "str": "motorcycle armor"
+        },
+        "pocket_data": [
+            {
+                "max_contains_volume": "500 ml",
+                "max_contains_weight": "1000 kg",
+                "max_item_length": "1 km"
+            }
+        ]
+    },
+    {
+        "type": "ARMOR",
+        "id": "vest_leather_mod",
+        "copy-from": "vest_leather_mod",
+        "name": {
+            "str": "armored leather vest"
+        },
+        "pocket_data": [
+            {
+                "max_contains_volume": "1900 ml",
+                "max_contains_weight": "1000 kg",
+                "max_item_length": "1 km"
+            }
+        ]
+    }
+]

--- a/Kenan-Modpack/easy_containers/items/armor/torso_clothes.json
+++ b/Kenan-Modpack/easy_containers/items/armor/torso_clothes.json
@@ -1,0 +1,167 @@
+[
+    {
+        "type": "ARMOR",
+        "id": "apron_leather",
+        "copy-from": "apron_leather",
+        "name": {
+            "str": "leather apron"
+        },
+        "pocket_data": [
+            {
+                "max_contains_volume": "2000 ml",
+                "max_contains_weight": "1000 kg",
+                "max_item_length": "1 km"
+            }
+        ]
+    },
+    {
+        "type": "ARMOR",
+        "id": "blazer",
+        "copy-from": "blazer",
+        "name": {
+            "str": "blazer"
+        },
+        "pocket_data": [
+            {
+                "max_contains_volume": "1000 ml",
+                "max_contains_weight": "1000 kg",
+                "max_item_length": "1 km"
+            }
+        ]
+    },
+    {
+        "type": "ARMOR",
+        "id": "dress_shirt",
+        "copy-from": "dress_shirt",
+        "name": {
+            "str": "dress shirt"
+        },
+        "pocket_data": [
+            {
+                "max_contains_volume": "250 ml",
+                "max_contains_weight": "1000 kg",
+                "max_item_length": "1 km"
+            }
+        ]
+    },
+    {
+        "type": "ARMOR",
+        "id": "hoodie",
+        "copy-from": "hoodie",
+        "name": {
+            "str": "hoodie"
+        },
+        "pocket_data": [
+            {
+                "max_contains_volume": "2500 ml",
+                "max_contains_weight": "1000 kg",
+                "max_item_length": "1 km"
+            }
+        ]
+    },
+    {
+        "type": "ARMOR",
+        "id": "maid_dress",
+        "copy-from": "maid_dress",
+        "name": {
+            "str_sp": "French maid clothes"
+        },
+        "pocket_data": [
+            {
+                "max_contains_volume": "500 ml",
+                "max_contains_weight": "1000 kg",
+                "max_item_length": "1 km"
+            }
+        ]
+    },
+    {
+        "type": "ARMOR",
+        "id": "postman_shirt",
+        "copy-from": "postman_shirt",
+        "name": {
+            "str": "mail carrier shirt"
+        },
+        "pocket_data": [
+            {
+                "max_contains_volume": "1000 ml",
+                "max_contains_weight": "1000 kg",
+                "max_item_length": "1 km"
+            }
+        ]
+    },
+    {
+        "type": "ARMOR",
+        "id": "sheriffshirt",
+        "copy-from": "sheriffshirt",
+        "name": {
+            "str": "sheriff's shirt"
+        },
+        "pocket_data": [
+            {
+                "max_contains_volume": "500 ml",
+                "max_contains_weight": "1000 kg",
+                "max_item_length": "1 km"
+            }
+        ]
+    },
+    {
+        "type": "ARMOR",
+        "id": "technician_shirt_gray",
+        "copy-from": "technician_shirt_gray",
+        "name": {
+            "str": "work t-shirt"
+        },
+        "pocket_data": [
+            {
+                "max_contains_volume": "250 ml",
+                "max_contains_weight": "1000 kg",
+                "max_item_length": "1 km"
+            }
+        ]
+    },
+    {
+        "type": "ARMOR",
+        "id": "uttarasanga",
+        "copy-from": "uttarasanga",
+        "name": {
+            "str": "uttarasanga"
+        },
+        "pocket_data": [
+            {
+                "max_contains_volume": "250 ml",
+                "max_contains_weight": "1000 kg",
+                "max_item_length": "1 km"
+            }
+        ]
+    },
+    {
+        "type": "ARMOR",
+        "id": "vest_leather",
+        "copy-from": "vest_leather",
+        "name": {
+            "str": "leather vest"
+        },
+        "pocket_data": [
+            {
+                "max_contains_volume": "1200 ml",
+                "max_contains_weight": "1000 kg",
+                "max_item_length": "1 km"
+            }
+        ]
+    },
+    {
+        "type": "ARMOR",
+        "id": "wool_hoodie",
+        "copy-from": "wool_hoodie",
+        "name": {
+            "str": "wool hoodie"
+        },
+        "pocket_data": [
+            {
+                "max_contains_volume": "2500 ml",
+                "max_contains_weight": "1000 kg",
+                "max_item_length": "1 km"
+            }
+        ]
+    }
+]

--- a/Kenan-Modpack/easy_containers/items/battery.json
+++ b/Kenan-Modpack/easy_containers/items/battery.json
@@ -1,0 +1,321 @@
+[
+    {
+        "type": "MAGAZINE",
+        "id": "light_minus_battery_cell",
+        "copy-from": "light_minus_battery_cell",
+        "name": {
+            "str": "ultra-light battery",
+            "str_pl": "ultra-light batteries"
+        },
+        "pocket_data": [
+            {
+                "pocket_type": "MAGAZINE",
+                "rigid": true,
+                "ammo_restriction": {
+                    "battery": 50
+                },
+                "max_contains_weight": "1000 kg",
+                "max_item_length": "1 km"
+            }
+        ]
+    },
+    {
+        "type": "MAGAZINE",
+        "id": "light_minus_atomic_battery_cell",
+        "copy-from": "light_minus_atomic_battery_cell",
+        "name": {
+            "str": "ultra-light plutonium fuel battery",
+            "str_pl": "ultra-light plutonium fuel batteries"
+        },
+        "pocket_data": [
+            {
+                "pocket_type": "MAGAZINE",
+                "rigid": true,
+                "ammo_restriction": {
+                    "battery": 500
+                },
+                "max_contains_weight": "1000 kg",
+                "max_item_length": "1 km"
+            }
+        ]
+    },
+    {
+        "type": "MAGAZINE",
+        "id": "light_minus_disposable_cell",
+        "copy-from": "light_minus_disposable_cell",
+        "name": {
+            "str": "ultra-light disposable battery",
+            "str_pl": "ultra-light disposable batteries"
+        },
+        "pocket_data": [
+            {
+                "pocket_type": "MAGAZINE",
+                "rigid": true,
+                "ammo_restriction": {
+                    "battery": 100
+                },
+                "max_contains_weight": "1000 kg",
+                "max_item_length": "1 km"
+            }
+        ]
+    },
+    {
+        "type": "MAGAZINE",
+        "id": "light_battery_cell",
+        "copy-from": "light_battery_cell",
+        "name": {
+            "str": "light battery",
+            "str_pl": "light batteries"
+        },
+        "pocket_data": [
+            {
+                "pocket_type": "MAGAZINE",
+                "rigid": true,
+                "ammo_restriction": {
+                    "battery": 100
+                },
+                "max_contains_weight": "1000 kg",
+                "max_item_length": "1 km"
+            }
+        ]
+    },
+    {
+        "type": "MAGAZINE",
+        "id": "light_plus_battery_cell",
+        "copy-from": "light_plus_battery_cell",
+        "name": {
+            "str": "light battery (high-capacity)",
+            "str_pl": "light batteries (high-capacity)"
+        },
+        "pocket_data": [
+            {
+                "pocket_type": "MAGAZINE",
+                "rigid": true,
+                "ammo_restriction": {
+                    "battery": 150
+                },
+                "max_contains_weight": "1000 kg",
+                "max_item_length": "1 km"
+            }
+        ]
+    },
+    {
+        "type": "MAGAZINE",
+        "id": "light_atomic_battery_cell",
+        "copy-from": "light_atomic_battery_cell",
+        "name": {
+            "str": "light plutonium fuel battery",
+            "str_pl": "light plutonium fuel batteries"
+        },
+        "pocket_data": [
+            {
+                "pocket_type": "MAGAZINE",
+                "rigid": true,
+                "ammo_restriction": {
+                    "battery": 1000
+                },
+                "max_contains_weight": "1000 kg",
+                "max_item_length": "1 km"
+            }
+        ]
+    },
+    {
+        "type": "MAGAZINE",
+        "id": "light_disposable_cell",
+        "copy-from": "light_disposable_cell",
+        "name": {
+            "str": "light disposable battery",
+            "str_pl": "light disposable batteries"
+        },
+        "pocket_data": [
+            {
+                "pocket_type": "MAGAZINE",
+                "rigid": true,
+                "ammo_restriction": {
+                    "battery": 300
+                },
+                "max_contains_weight": "1000 kg",
+                "max_item_length": "1 km"
+            }
+        ]
+    },
+    {
+        "type": "MAGAZINE",
+        "id": "medium_battery_cell",
+        "copy-from": "medium_battery_cell",
+        "name": {
+            "str": "medium battery",
+            "str_pl": "medium batteries"
+        },
+        "pocket_data": [
+            {
+                "pocket_type": "MAGAZINE",
+                "rigid": true,
+                "ammo_restriction": {
+                    "battery": 500
+                },
+                "max_contains_weight": "1000 kg",
+                "max_item_length": "1 km"
+            }
+        ]
+    },
+    {
+        "type": "MAGAZINE",
+        "id": "medium_plus_battery_cell",
+        "copy-from": "medium_plus_battery_cell",
+        "name": {
+            "str": "medium battery (high-capacity)",
+            "str_pl": "medium batteries (high-capacity)"
+        },
+        "pocket_data": [
+            {
+                "pocket_type": "MAGAZINE",
+                "rigid": true,
+                "ammo_restriction": {
+                    "battery": 600
+                },
+                "max_contains_weight": "1000 kg",
+                "max_item_length": "1 km"
+            }
+        ]
+    },
+    {
+        "type": "MAGAZINE",
+        "id": "medium_atomic_battery_cell",
+        "copy-from": "medium_atomic_battery_cell",
+        "name": {
+            "str": "medium plutonium fuel battery",
+            "str_pl": "medium plutonium fuel batteries"
+        },
+        "pocket_data": [
+            {
+                "pocket_type": "MAGAZINE",
+                "rigid": true,
+                "ammo_restriction": {
+                    "battery": 5000
+                },
+                "max_contains_weight": "1000 kg",
+                "max_item_length": "1 km"
+            }
+        ]
+    },
+    {
+        "type": "MAGAZINE",
+        "id": "medium_disposable_cell",
+        "copy-from": "medium_disposable_cell",
+        "name": {
+            "str": "medium disposable battery",
+            "str_pl": "medium disposable batteries"
+        },
+        "pocket_data": [
+            {
+                "pocket_type": "MAGAZINE",
+                "rigid": true,
+                "ammo_restriction": {
+                    "battery": 1200
+                },
+                "max_contains_weight": "1000 kg",
+                "max_item_length": "1 km"
+            }
+        ]
+    },
+    {
+        "type": "MAGAZINE",
+        "id": "heavy_battery_cell",
+        "copy-from": "heavy_battery_cell",
+        "name": {
+            "str": "heavy battery",
+            "str_pl": "heavy batteries"
+        },
+        "pocket_data": [
+            {
+                "pocket_type": "MAGAZINE",
+                "rigid": true,
+                "ammo_restriction": {
+                    "battery": 1000
+                },
+                "max_contains_weight": "1000 kg",
+                "max_item_length": "1 km"
+            }
+        ]
+    },
+    {
+        "type": "MAGAZINE",
+        "id": "heavy_plus_battery_cell",
+        "copy-from": "heavy_plus_battery_cell",
+        "name": {
+            "str": "heavy battery (high-capacity)",
+            "str_pl": "heavy batteries (high-capacity)"
+        },
+        "pocket_data": [
+            {
+                "pocket_type": "MAGAZINE",
+                "rigid": true,
+                "ammo_restriction": {
+                    "battery": 1250
+                },
+                "max_contains_weight": "1000 kg",
+                "max_item_length": "1 km"
+            }
+        ]
+    },
+    {
+        "type": "MAGAZINE",
+        "id": "heavy_atomic_battery_cell",
+        "copy-from": "heavy_atomic_battery_cell",
+        "name": {
+            "str": "heavy plutonium fuel battery",
+            "str_pl": "heavy plutonium fuel batteries"
+        },
+        "pocket_data": [
+            {
+                "pocket_type": "MAGAZINE",
+                "rigid": true,
+                "ammo_restriction": {
+                    "battery": 10000
+                },
+                "max_contains_weight": "1000 kg",
+                "max_item_length": "1 km"
+            }
+        ]
+    },
+    {
+        "type": "MAGAZINE",
+        "id": "huge_atomic_battery_cell",
+        "copy-from": "huge_atomic_battery_cell",
+        "name": {
+            "str": "military plutonium fuel cell"
+        },
+        "pocket_data": [
+            {
+                "pocket_type": "MAGAZINE",
+                "rigid": true,
+                "ammo_restriction": {
+                    "battery": 100000
+                },
+                "max_contains_weight": "1000 kg",
+                "max_item_length": "1 km"
+            }
+        ]
+    },
+    {
+        "type": "MAGAZINE",
+        "id": "heavy_disposable_cell",
+        "copy-from": "heavy_disposable_cell",
+        "name": {
+            "str": "heavy disposable battery",
+            "str_pl": "heavy disposable batteries"
+        },
+        "pocket_data": [
+            {
+                "pocket_type": "MAGAZINE",
+                "rigid": true,
+                "ammo_restriction": {
+                    "battery": 2500
+                },
+                "max_contains_weight": "1000 kg",
+                "max_item_length": "1 km"
+            }
+        ]
+    }
+]

--- a/Kenan-Modpack/easy_containers/items/containers.json
+++ b/Kenan-Modpack/easy_containers/items/containers.json
@@ -1,0 +1,1321 @@
+[
+    {
+        "type": "GENERIC",
+        "id": "2lcanteen",
+        "copy-from": "2lcanteen",
+        "name": {
+            "str": "2.5L canteen"
+        },
+        "pocket_data": [
+            {
+                "pocket_type": "CONTAINER",
+                "watertight": true,
+                "rigid": true,
+                "max_contains_volume": "2500 ml",
+                "max_item_volume": "32 ml",
+                "max_contains_weight": "1000 kg",
+                "max_item_length": "1 km"
+            }
+        ]
+    },
+    {
+        "type": "GENERIC",
+        "id": "30gal_barrel",
+        "copy-from": "30gal_barrel",
+        "name": {
+            "str": "30 gallon barrel"
+        },
+        "pocket_data": [
+            {
+                "pocket_type": "CONTAINER",
+                "watertight": true,
+                "rigid": true,
+                "max_contains_volume": "112500 ml",
+                "max_contains_weight": "1000 kg",
+                "max_item_length": "1 km"
+            }
+        ]
+    },
+    {
+        "type": "GENERIC",
+        "id": "30gal_drum",
+        "copy-from": "30gal_drum",
+        "name": {
+            "str": "steel drum (100L)",
+            "str_pl": "steel drums (100L)"
+        },
+        "pocket_data": [
+            {
+                "pocket_type": "CONTAINER",
+                "watertight": true,
+                "rigid": true,
+                "max_contains_volume": "100 L",
+                "max_contains_weight": "1000 kg",
+                "max_item_length": "1 km"
+            }
+        ]
+    },
+    {
+        "type": "GENERIC",
+        "id": "55gal_drum",
+        "copy-from": "55gal_drum",
+        "name": {
+            "str": "steel drum (200L)",
+            "str_pl": "steel drums (200L)"
+        },
+        "pocket_data": [
+            {
+                "pocket_type": "CONTAINER",
+                "watertight": true,
+                "rigid": true,
+                "max_contains_volume": "200 L",
+                "max_contains_weight": "1000 kg",
+                "max_item_length": "1 km"
+            }
+        ]
+    },
+    {
+        "type": "GENERIC",
+        "id": "bag_canvas",
+        "copy-from": "bag_canvas",
+        "name": {
+            "str": "canvas sack"
+        },
+        "pocket_data": [
+            {
+                "max_contains_volume": "15000 ml",
+                "max_contains_weight": "1000 kg",
+                "max_item_length": "1 km"
+            }
+        ]
+    },
+    {
+        "type": "GENERIC",
+        "id": "bag_canvas_small",
+        "copy-from": "bag_canvas_small",
+        "name": {
+            "str": "canvas bag"
+        },
+        "pocket_data": [
+            {
+                "max_contains_volume": "1000 ml",
+                "max_contains_weight": "1000 kg",
+                "max_item_length": "1 km"
+            }
+        ]
+    },
+    {
+        "type": "GENERIC",
+        "id": "bag_plastic",
+        "copy-from": "bag_plastic",
+        "name": {
+            "str": "plastic bag"
+        },
+        "pocket_data": [
+            {
+                "max_contains_volume": "6000 ml",
+                "max_contains_weight": "1000 kg",
+                "max_item_length": "1 km"
+            }
+        ]
+    },
+    {
+        "type": "GENERIC",
+        "id": "bag_paper_powder_small",
+        "copy-from": "bag_paper_powder_small",
+        "name": {
+            "str": "small powder paper bag"
+        },
+        "pocket_data": [
+            {
+                "pocket_type": "CONTAINER",
+                "watertight": false,
+                "max_contains_volume": "2 L",
+                "max_contains_weight": "1000 kg",
+                "moves": 200,
+                "max_item_length": "1 km"
+            }
+        ]
+    },
+    {
+        "type": "GENERIC",
+        "id": "bag_zipper",
+        "copy-from": "bag_zipper",
+        "name": {
+            "str": "zipper bag"
+        },
+        "pocket_data": [
+            {
+                "pocket_type": "CONTAINER",
+                "watertight": true,
+                "max_contains_volume": "250 ml",
+                "max_contains_weight": "1000 kg",
+                "spoil_multiplier": 0.8,
+                "moves": 400,
+                "max_item_length": "1 km"
+            }
+        ]
+    },
+    {
+        "type": "GENERIC",
+        "id": "bag_body_bag",
+        "copy-from": "bag_body_bag",
+        "name": {
+            "str": "body bag"
+        },
+        "pocket_data": [
+            {
+                "pocket_type": "CONTAINER",
+                "watertight": true,
+                "max_contains_volume": "100 L",
+                "max_contains_weight": "1000 kg",
+                "max_item_length": "1 km",
+                "moves": 400
+            }
+        ]
+    },
+    {
+        "type": "GENERIC",
+        "id": "bag_iv",
+        "copy-from": "bag_iv",
+        "name": {
+            "str": "IV bag"
+        },
+        "pocket_data": [
+            {
+                "pocket_type": "CONTAINER",
+                "watertight": true,
+                "max_contains_volume": "500 ml",
+                "max_contains_weight": "1000 kg",
+                "moves": 400,
+                "max_item_length": "1 km"
+            }
+        ]
+    },
+    {
+        "type": "GENERIC",
+        "id": "bottle_glass",
+        "copy-from": "bottle_glass",
+        "name": {
+            "str": "glass bottle"
+        },
+        "pocket_data": [
+            {
+                "pocket_type": "CONTAINER",
+                "watertight": true,
+                "rigid": true,
+                "max_contains_volume": "750 ml",
+                "max_item_volume": "17 ml",
+                "max_contains_weight": "1000 kg",
+                "moves": 400,
+                "max_item_length": "1 km"
+            }
+        ]
+    },
+    {
+        "type": "GENERIC",
+        "id": "bottle_plastic",
+        "copy-from": "bottle_plastic",
+        "name": {
+            "str": "plastic bottle"
+        },
+        "pocket_data": [
+            {
+                "pocket_type": "CONTAINER",
+                "airtight": true,
+                "watertight": true,
+                "rigid": true,
+                "max_contains_volume": "500 ml",
+                "max_item_volume": "17 ml",
+                "max_contains_weight": "1000 kg",
+                "sealed_data": {
+                    "spoil_multiplier": 0.5
+                },
+                "moves": 400,
+                "max_item_length": "1 km"
+            }
+        ]
+    },
+    {
+        "type": "GENERIC",
+        "id": "condiment_bottle_sealed",
+        "copy-from": "condiment_bottle_sealed",
+        "name": {
+            "str": "condiment bottle"
+        },
+        "pocket_data": [
+            {
+                "pocket_type": "CONTAINER",
+                "watertight": true,
+                "rigid": true,
+                "max_contains_volume": "500 ml",
+                "max_item_volume": "17 ml",
+                "max_contains_weight": "1000 kg",
+                "spoil_multiplier": 0.5,
+                "sealed_data": {
+                    "spoil_multiplier": 0.0
+                },
+                "moves": 400,
+                "max_item_length": "1 km"
+            }
+        ]
+    },
+    {
+        "type": "GENERIC",
+        "id": "bottle_plastic_small",
+        "copy-from": "bottle_plastic_small",
+        "name": {
+            "str": "small plastic bottle"
+        },
+        "pocket_data": [
+            {
+                "pocket_type": "CONTAINER",
+                "watertight": true,
+                "rigid": true,
+                "max_contains_volume": "250 ml",
+                "max_item_volume": "17 ml",
+                "max_contains_weight": "1000 kg",
+                "moves": 400,
+                "max_item_length": "1 km"
+            }
+        ]
+    },
+    {
+        "type": "GENERIC",
+        "id": "bottle_twoliter",
+        "copy-from": "bottle_twoliter",
+        "name": {
+            "str": "large plastic bottle"
+        },
+        "pocket_data": [
+            {
+                "pocket_type": "CONTAINER",
+                "watertight": true,
+                "rigid": true,
+                "max_contains_volume": "2 L",
+                "max_item_volume": "17 ml",
+                "max_contains_weight": "1000 kg",
+                "moves": 400,
+                "max_item_length": "1 km"
+            }
+        ]
+    },
+    {
+        "type": "GENERIC",
+        "id": "bowl_clay",
+        "copy-from": "bowl_clay",
+        "name": {
+            "str": "clay bowl"
+        },
+        "pocket_data": [
+            {
+                "pocket_type": "CONTAINER",
+                "watertight": true,
+                "rigid": true,
+                "max_contains_volume": "250 ml",
+                "max_contains_weight": "1000 kg",
+                "max_item_length": "1 km"
+            }
+        ]
+    },
+    {
+        "type": "GENERIC",
+        "id": "box_cigarette",
+        "copy-from": "box_cigarette",
+        "name": {
+            "str": "pack"
+        },
+        "pocket_data": [
+            {
+                "max_contains_volume": "90 ml",
+                "max_contains_weight": "1000 kg",
+                "max_item_length": "1 km"
+            }
+        ]
+    },
+    {
+        "type": "GENERIC",
+        "id": "box_small",
+        "copy-from": "box_small",
+        "name": {
+            "str": "small cardboard box",
+            "str_pl": "small cardboard boxes"
+        },
+        "pocket_data": [
+            {
+                "max_contains_volume": "2000 ml",
+                "max_contains_weight": "1000 kg",
+                "max_item_length": "1 km"
+            }
+        ]
+    },
+    {
+        "type": "GENERIC",
+        "id": "box_medium",
+        "copy-from": "box_medium",
+        "name": {
+            "str": "cardboard box",
+            "str_pl": "cardboard boxes"
+        },
+        "pocket_data": [
+            {
+                "max_contains_volume": "50000 ml",
+                "max_contains_weight": "1000 kg",
+                "max_item_length": "1 km"
+            }
+        ]
+    },
+    {
+        "type": "GENERIC",
+        "id": "box_large",
+        "copy-from": "box_large",
+        "name": {
+            "str": "large cardboard box",
+            "str_pl": "large cardboard boxes"
+        },
+        "pocket_data": [
+            {
+                "max_contains_volume": "324000 ml",
+                "max_contains_weight": "1000 kg",
+                "max_item_length": "1 km"
+            }
+        ]
+    },
+    {
+        "type": "GENERIC",
+        "id": "bucket",
+        "copy-from": "bucket",
+        "name": {
+            "str": "bucket"
+        },
+        "pocket_data": [
+            {
+                "pocket_type": "CONTAINER",
+                "rigid": true,
+                "watertight": true,
+                "open_container": true,
+                "max_contains_volume": "5000 ml",
+                "max_contains_weight": "1000 kg",
+                "max_item_length": "1 km"
+            }
+        ]
+    },
+    {
+        "type": "GENERIC",
+        "id": "camelbak",
+        "copy-from": "camelbak",
+        "name": {
+            "str": "hydration pack"
+        },
+        "pocket_data": [
+            {
+                "pocket_type": "CONTAINER",
+                "rigid": true,
+                "watertight": true,
+                "max_contains_volume": "2500 ml",
+                "max_item_volume": "32 ml",
+                "max_contains_weight": "1000 kg",
+                "max_item_length": "1 km"
+            }
+        ]
+    },
+    {
+        "type": "GENERIC",
+        "id": "can_drink",
+        "copy-from": "can_drink",
+        "name": {
+            "str": "aluminum can"
+        },
+        "pocket_data": [
+            {
+                "pocket_type": "CONTAINER",
+                "rigid": true,
+                "watertight": true,
+                "open_container": true,
+                "max_contains_volume": "250 ml",
+                "max_item_volume": "10 ml",
+                "max_contains_weight": "1000 kg",
+                "sealed_data": {
+                    "spoil_multiplier": 0.0
+                },
+                "max_item_length": "1 km"
+            }
+        ]
+    },
+    {
+        "type": "GENERIC",
+        "id": "carton_sealed",
+        "copy-from": "carton_sealed",
+        "name": {
+            "str": "paper carton"
+        },
+        "pocket_data": [
+            {
+                "pocket_type": "CONTAINER",
+                "rigid": true,
+                "watertight": true,
+                "max_contains_volume": "2 L",
+                "max_contains_weight": "1000 kg",
+                "max_item_length": "1 km"
+            }
+        ]
+    },
+    {
+        "type": "GENERIC",
+        "id": "carton_egg",
+        "copy-from": "carton_egg",
+        "name": {
+            "str": "egg carton"
+        },
+        "pocket_data": [
+            {
+                "pocket_type": "CONTAINER",
+                "rigid": true,
+                "watertight": false,
+                "max_contains_volume": "600 ml",
+                "max_contains_weight": "1000 kg",
+                "max_item_length": "1 km"
+            }
+        ]
+    },
+    {
+        "type": "GENERIC",
+        "id": "plastic_bag_vac",
+        "copy-from": "plastic_bag_vac",
+        "name": {
+            "str": "vacuum-packed bag"
+        },
+        "pocket_data": [
+            {
+                "pocket_type": "CONTAINER",
+                "open_container": true,
+                "max_contains_volume": "500 ml",
+                "max_contains_weight": "1000 kg",
+                "sealed_data": {
+                    "spoil_multiplier": 0.0
+                },
+                "max_item_length": "1 km"
+            }
+        ]
+    },
+    {
+        "type": "GENERIC",
+        "id": "can_food",
+        "copy-from": "can_food",
+        "name": {
+            "str": "small tin can"
+        },
+        "pocket_data": [
+            {
+                "pocket_type": "CONTAINER",
+                "rigid": true,
+                "watertight": true,
+                "open_container": true,
+                "max_contains_volume": "250 ml",
+                "max_contains_weight": "1000 kg",
+                "sealed_data": {
+                    "spoil_multiplier": 0.0
+                },
+                "max_item_length": "1 km"
+            }
+        ]
+    },
+    {
+        "type": "GENERIC",
+        "id": "can_medium",
+        "copy-from": "can_medium",
+        "name": {
+            "str": "medium tin can"
+        },
+        "pocket_data": [
+            {
+                "pocket_type": "CONTAINER",
+                "rigid": true,
+                "watertight": true,
+                "open_container": true,
+                "max_contains_volume": "500 ml",
+                "max_contains_weight": "1000 kg",
+                "sealed_data": {
+                    "spoil_multiplier": 0.0
+                },
+                "max_item_length": "1 km"
+            }
+        ]
+    },
+    {
+        "type": "GENERIC",
+        "id": "canteen",
+        "copy-from": "canteen",
+        "name": {
+            "str": "plastic canteen"
+        },
+        "pocket_data": [
+            {
+                "pocket_type": "CONTAINER",
+                "rigid": true,
+                "watertight": true,
+                "max_contains_volume": "1500 ml",
+                "max_item_volume": "32 ml",
+                "max_contains_weight": "1000 kg",
+                "max_item_length": "1 km"
+            }
+        ]
+    },
+    {
+        "type": "GENERIC",
+        "id": "thermos",
+        "copy-from": "thermos",
+        "name": {
+            "str": "thermos",
+            "str_pl": "thermoses"
+        },
+        "pocket_data": [
+            {
+                "pocket_type": "CONTAINER",
+                "rigid": true,
+                "watertight": true,
+                "max_contains_volume": "1 L",
+                "max_contains_weight": "1000 kg",
+                "max_item_length": "1 km"
+            }
+        ]
+    },
+    {
+        "type": "GENERIC",
+        "id": "clay_canister",
+        "copy-from": "clay_canister",
+        "name": {
+            "str": "clay canister"
+        },
+        "pocket_data": [
+            {
+                "pocket_type": "CONTAINER",
+                "rigid": true,
+                "watertight": true,
+                "max_contains_volume": "250 ml",
+                "max_contains_weight": "1000 kg",
+                "max_item_length": "1 km"
+            }
+        ]
+    },
+    {
+        "type": "GENERIC",
+        "id": "clay_hydria",
+        "copy-from": "clay_hydria",
+        "name": {
+            "str": "clay hydria"
+        },
+        "pocket_data": [
+            {
+                "pocket_type": "CONTAINER",
+                "rigid": true,
+                "watertight": true,
+                "max_contains_volume": "15 L",
+                "max_contains_weight": "1000 kg",
+                "max_item_length": "1 km"
+            }
+        ]
+    },
+    {
+        "type": "GENERIC",
+        "id": "clay_watercont",
+        "copy-from": "clay_watercont",
+        "name": {
+            "str": "large clay pot"
+        },
+        "pocket_data": [
+            {
+                "pocket_type": "CONTAINER",
+                "rigid": true,
+                "watertight": true,
+                "max_contains_volume": "37490 ml",
+                "max_contains_weight": "1000 kg",
+                "max_item_length": "1 km"
+            }
+        ]
+    },
+    {
+        "type": "GENERIC",
+        "id": "cup_plastic",
+        "copy-from": "cup_plastic",
+        "name": {
+            "str": "plastic cup"
+        },
+        "pocket_data": [
+            {
+                "pocket_type": "CONTAINER",
+                "rigid": true,
+                "watertight": true,
+                "open_container": true,
+                "sealed_data": {
+                    "spoil_multiplier": 0.0
+                },
+                "max_contains_volume": "250 ml",
+                "max_contains_weight": "1000 kg",
+                "max_item_length": "1 km"
+            }
+        ]
+    },
+    {
+        "type": "GENERIC",
+        "id": "flask_glass",
+        "copy-from": "flask_glass",
+        "name": {
+            "str": "glass flask"
+        },
+        "pocket_data": [
+            {
+                "pocket_type": "CONTAINER",
+                "rigid": true,
+                "watertight": true,
+                "max_contains_volume": "250 ml",
+                "max_contains_weight": "1000 kg",
+                "max_item_length": "1 km"
+            }
+        ]
+    },
+    {
+        "type": "GENERIC",
+        "id": "test_tube",
+        "copy-from": "test_tube",
+        "name": {
+            "str": "test tube"
+        },
+        "pocket_data": [
+            {
+                "pocket_type": "CONTAINER",
+                "rigid": true,
+                "watertight": true,
+                "max_contains_volume": "10 ml",
+                "max_contains_weight": "1000 kg",
+                "max_item_length": "1 km"
+            }
+        ]
+    },
+    {
+        "type": "GENERIC",
+        "id": "beaker",
+        "copy-from": "beaker",
+        "name": {
+            "str": "beaker"
+        },
+        "pocket_data": [
+            {
+                "pocket_type": "CONTAINER",
+                "rigid": true,
+                "watertight": true,
+                "open_container": true,
+                "max_contains_volume": "250 ml",
+                "max_contains_weight": "1000 kg",
+                "max_item_length": "1 km"
+            }
+        ]
+    },
+    {
+        "type": "GENERIC",
+        "id": "gradcylinder",
+        "copy-from": "gradcylinder",
+        "name": {
+            "str": "graduated cylinder"
+        },
+        "pocket_data": [
+            {
+                "pocket_type": "CONTAINER",
+                "rigid": true,
+                "watertight": true,
+                "open_container": true,
+                "//": "sealed_data is here so the container can be sealed to avoid spilling",
+                "sealed_data": {
+                    "spoil_multiplier": 1.0
+                },
+                "max_contains_volume": "100 ml",
+                "max_contains_weight": "1000 kg",
+                "max_item_length": "1 km"
+            }
+        ]
+    },
+    {
+        "type": "GENERIC",
+        "id": "test_tube_micro",
+        "copy-from": "test_tube_micro",
+        "name": {
+            "str": "microcentrifuge tube"
+        },
+        "pocket_data": [
+            {
+                "pocket_type": "CONTAINER",
+                "rigid": true,
+                "watertight": true,
+                "max_contains_volume": "1 ml",
+                "max_contains_weight": "1000 kg",
+                "max_item_length": "1 km"
+            }
+        ]
+    },
+    {
+        "type": "GENERIC",
+        "id": "flask_hip",
+        "copy-from": "flask_hip",
+        "name": {
+            "str": "hip flask"
+        },
+        "pocket_data": [
+            {
+                "pocket_type": "CONTAINER",
+                "rigid": true,
+                "watertight": true,
+                "max_contains_volume": "250 ml",
+                "max_item_volume": "17 ml",
+                "max_contains_weight": "1000 kg",
+                "max_item_length": "1 km"
+            }
+        ]
+    },
+    {
+        "type": "GENERIC",
+        "id": "jar_3l_glass_sealed",
+        "copy-from": "jar_3l_glass_sealed",
+        "name": {
+            "str": "3L glass jar"
+        },
+        "pocket_data": [
+            {
+                "pocket_type": "CONTAINER",
+                "rigid": true,
+                "watertight": true,
+                "max_contains_volume": "3 L",
+                "max_contains_weight": "1000 kg",
+                "sealed_data": {
+                    "spoil_multiplier": 0.0
+                },
+                "max_item_length": "1 km"
+            }
+        ]
+    },
+    {
+        "type": "GENERIC",
+        "id": "jar_glass_sealed",
+        "copy-from": "jar_glass_sealed",
+        "name": {
+            "str": "glass jar"
+        },
+        "pocket_data": [
+            {
+                "pocket_type": "CONTAINER",
+                "rigid": true,
+                "watertight": true,
+                "max_contains_volume": "500 ml",
+                "max_contains_weight": "1000 kg",
+                "sealed_data": {
+                    "spoil_multiplier": 0.0
+                },
+                "max_item_length": "1 km"
+            }
+        ]
+    },
+    {
+        "type": "GENERIC",
+        "id": "jerrycan",
+        "copy-from": "jerrycan",
+        "name": {
+            "str": "plastic jerrycan"
+        },
+        "pocket_data": [
+            {
+                "pocket_type": "CONTAINER",
+                "rigid": true,
+                "watertight": true,
+                "max_contains_volume": "10 L",
+                "max_item_volume": "32 ml",
+                "max_contains_weight": "1000 kg",
+                "max_item_length": "1 km"
+            }
+        ]
+    },
+    {
+        "type": "GENERIC",
+        "id": "jerrycan_big",
+        "copy-from": "jerrycan_big",
+        "name": {
+            "str": "steel jerrycan"
+        },
+        "pocket_data": [
+            {
+                "pocket_type": "CONTAINER",
+                "rigid": true,
+                "watertight": true,
+                "max_contains_volume": "20 L",
+                "max_item_volume": "32 ml",
+                "max_contains_weight": "1000 kg",
+                "max_item_length": "1 km"
+            }
+        ]
+    },
+    {
+        "type": "GENERIC",
+        "id": "jug_clay",
+        "copy-from": "jug_clay",
+        "name": {
+            "str": "clay jug"
+        },
+        "pocket_data": [
+            {
+                "pocket_type": "CONTAINER",
+                "rigid": true,
+                "watertight": true,
+                "max_contains_volume": "1 L",
+                "max_contains_weight": "1000 kg",
+                "max_item_length": "1 km"
+            }
+        ]
+    },
+    {
+        "type": "GENERIC",
+        "id": "jug_plastic",
+        "copy-from": "jug_plastic",
+        "name": {
+            "str": "gallon jug"
+        },
+        "pocket_data": [
+            {
+                "pocket_type": "CONTAINER",
+                "rigid": true,
+                "watertight": true,
+                "max_contains_volume": "3750 ml",
+                "max_item_volume": "32 ml",
+                "max_contains_weight": "1000 kg",
+                "sealed_data": {
+                    "spoil_multiplier": 0.5
+                },
+                "max_item_length": "1 km"
+            }
+        ]
+    },
+    {
+        "type": "GENERIC",
+        "id": "keg",
+        "copy-from": "keg",
+        "name": {
+            "str": "aluminum keg"
+        },
+        "pocket_data": [
+            {
+                "pocket_type": "CONTAINER",
+                "rigid": true,
+                "watertight": true,
+                "max_contains_volume": "50 L",
+                "max_item_volume": "50 ml",
+                "max_contains_weight": "1000 kg",
+                "max_item_length": "1 km"
+            }
+        ]
+    },
+    {
+        "type": "GENERIC",
+        "id": "keg_steel",
+        "copy-from": "keg_steel",
+        "name": {
+            "str": "steel keg"
+        },
+        "pocket_data": [
+            {
+                "pocket_type": "CONTAINER",
+                "rigid": true,
+                "watertight": true,
+                "max_contains_volume": "50 L",
+                "max_item_volume": "50 ml",
+                "max_contains_weight": "1000 kg",
+                "max_item_length": "1 km"
+            }
+        ]
+    },
+    {
+        "type": "GENERIC",
+        "id": "large_stomach_sealed",
+        "copy-from": "large_stomach_sealed",
+        "name": {
+            "str": "large sealed stomach"
+        },
+        "pocket_data": [
+            {
+                "pocket_type": "CONTAINER",
+                "watertight": true,
+                "max_contains_volume": "3 L",
+                "max_item_volume": "17 ml",
+                "max_contains_weight": "1000 kg",
+                "max_item_length": "1 km"
+            }
+        ]
+    },
+    {
+        "type": "GENERIC",
+        "id": "metal_tank",
+        "copy-from": "metal_tank",
+        "name": {
+            "str": "metal tank (60L)",
+            "str_pl": "metal tanks (60L)"
+        },
+        "pocket_data": [
+            {
+                "pocket_type": "CONTAINER",
+                "rigid": true,
+                "watertight": true,
+                "max_contains_volume": "60 L",
+                "max_contains_weight": "1000 kg",
+                "max_item_length": "1 km"
+            }
+        ]
+    },
+    {
+        "type": "GENERIC",
+        "id": "metal_tank_little",
+        "copy-from": "metal_tank_little",
+        "name": {
+            "str": "metal tank (2L)",
+            "str_pl": "metal tanks (2L)"
+        },
+        "pocket_data": [
+            {
+                "pocket_type": "CONTAINER",
+                "rigid": true,
+                "watertight": true,
+                "max_contains_volume": "2 L",
+                "max_contains_weight": "1000 kg",
+                "max_item_length": "1 km"
+            }
+        ]
+    },
+    {
+        "type": "GENERIC",
+        "id": "canteen_wood",
+        "copy-from": "canteen_wood",
+        "name": {
+            "str": "wooden canteen"
+        },
+        "pocket_data": [
+            {
+                "pocket_type": "CONTAINER",
+                "rigid": true,
+                "watertight": true,
+                "max_contains_volume": "1500 ml",
+                "max_item_volume": "17 ml",
+                "max_contains_weight": "1000 kg",
+                "max_item_length": "1 km"
+            }
+        ]
+    },
+    {
+        "type": "GENERIC",
+        "id": "stomach_sealed",
+        "copy-from": "stomach_sealed",
+        "name": {
+            "str": "sealed stomach"
+        },
+        "pocket_data": [
+            {
+                "pocket_type": "CONTAINER",
+                "watertight": true,
+                "max_contains_volume": "1500 ml",
+                "max_item_volume": "17 ml",
+                "max_contains_weight": "1000 kg",
+                "max_item_length": "1 km"
+            }
+        ]
+    },
+    {
+        "type": "GENERIC",
+        "id": "waterskin",
+        "copy-from": "waterskin",
+        "name": {
+            "str": "small waterskin"
+        },
+        "pocket_data": [
+            {
+                "pocket_type": "CONTAINER",
+                "watertight": true,
+                "max_contains_volume": "1500 ml",
+                "max_item_volume": "17 ml",
+                "max_contains_weight": "1000 kg",
+                "max_item_length": "1 km"
+            }
+        ]
+    },
+    {
+        "type": "GENERIC",
+        "id": "waterskin2",
+        "copy-from": "waterskin2",
+        "name": {
+            "str": "waterskin"
+        },
+        "pocket_data": [
+            {
+                "pocket_type": "CONTAINER",
+                "watertight": true,
+                "max_contains_volume": "3 L",
+                "max_item_volume": "17 ml",
+                "max_contains_weight": "1000 kg",
+                "max_item_length": "1 km"
+            }
+        ]
+    },
+    {
+        "type": "GENERIC",
+        "id": "waterskin3",
+        "copy-from": "waterskin3",
+        "name": {
+            "str": "large waterskin"
+        },
+        "pocket_data": [
+            {
+                "pocket_type": "CONTAINER",
+                "watertight": true,
+                "max_contains_volume": "5 L",
+                "max_item_volume": "17 ml",
+                "max_contains_weight": "1000 kg",
+                "max_item_length": "1 km"
+            }
+        ]
+    },
+    {
+        "type": "GENERIC",
+        "id": "wooden_barrel",
+        "copy-from": "wooden_barrel",
+        "name": {
+            "str": "wooden barrel"
+        },
+        "pocket_data": [
+            {
+                "pocket_type": "CONTAINER",
+                "watertight": true,
+                "rigid": true,
+                "max_contains_volume": "100 L",
+                "max_contains_weight": "1000 kg",
+                "max_item_length": "1 km"
+            }
+        ]
+    },
+    {
+        "type": "GENERIC",
+        "id": "wrapper",
+        "copy-from": "wrapper",
+        "name": {
+            "str": "paper wrapper"
+        },
+        "pocket_data": [
+            {
+                "max_contains_volume": "2500 ml",
+                "max_contains_weight": "1000 kg",
+                "max_item_length": "1 km"
+            }
+        ]
+    },
+    {
+        "type": "GENERIC",
+        "id": "wrapper_pr",
+        "copy-from": "wrapper_pr",
+        "name": {
+            "str": "wrapper"
+        },
+        "pocket_data": [
+            {
+                "max_contains_volume": "225 ml",
+                "max_contains_weight": "1000 kg",
+                "max_item_length": "1 km"
+            }
+        ]
+    },
+    {
+        "type": "GENERIC",
+        "id": "styrofoam_cup",
+        "copy-from": "styrofoam_cup",
+        "name": {
+            "str": "styrofoam cup"
+        },
+        "pocket_data": [
+            {
+                "pocket_type": "CONTAINER",
+                "watertight": true,
+                "rigid": true,
+                "max_contains_volume": "500 ml",
+                "max_contains_weight": "1000 kg",
+                "max_item_length": "1 km"
+            }
+        ]
+    },
+    {
+        "type": "GENERIC",
+        "id": "plastic_bucket",
+        "copy-from": "plastic_bucket",
+        "name": {
+            "str": "plastic tub"
+        },
+        "pocket_data": [
+            {
+                "pocket_type": "CONTAINER",
+                "watertight": true,
+                "rigid": true,
+                "open_container": true,
+                "max_contains_volume": "4250 ml",
+                "max_contains_weight": "1000 kg",
+                "max_item_length": "1 km"
+            }
+        ]
+    },
+    {
+        "type": "GENERIC",
+        "id": "condom",
+        "copy-from": "condom",
+        "name": {
+            "str": "condom"
+        },
+        "pocket_data": [
+            {
+                "pocket_type": "CONTAINER",
+                "watertight": true,
+                "max_contains_volume": "3750 ml",
+                "max_contains_weight": "1000 kg",
+                "max_item_length": "1 km"
+            }
+        ]
+    },
+    {
+        "type": "GENERIC",
+        "id": "can_food_big",
+        "copy-from": "can_food_big",
+        "name": {
+            "str": "large tin can"
+        },
+        "pocket_data": [
+            {
+                "pocket_type": "CONTAINER",
+                "watertight": true,
+                "rigid": true,
+                "open_container": true,
+                "max_contains_volume": "3 L",
+                "max_contains_weight": "1000 kg",
+                "sealed_data": {
+                    "spoil_multiplier": 0.0
+                },
+                "max_item_length": "1 km"
+            }
+        ]
+    },
+    {
+        "type": "GENERIC",
+        "id": "survival_kit_box",
+        "copy-from": "survival_kit_box",
+        "name": {
+            "str": "survival kit box",
+            "str_pl": "survival kit boxes"
+        },
+        "pocket_data": [
+            {
+                "pocket_type": "CONTAINER",
+                "rigid": true,
+                "watertight": true,
+                "max_contains_volume": "2100 ml",
+                "max_contains_weight": "1000 kg",
+                "max_item_length": "1 km"
+            }
+        ]
+    },
+    {
+        "type": "GENERIC",
+        "id": "large_survival_kit_box",
+        "copy-from": "large_survival_kit_box",
+        "name": {
+            "str": "survival kit box",
+            "str_pl": "survival kit boxes"
+        },
+        "pocket_data": [
+            {
+                "max_contains_volume": "8500 ml",
+                "max_contains_weight": "1000 kg",
+                "max_item_length": "1 km"
+            }
+        ]
+    },
+    {
+        "type": "GENERIC",
+        "id": "box_tea",
+        "copy-from": "box_tea",
+        "name": {
+            "str": "small cardboard box of tea bags",
+            "str_pl": "small cardboard boxes of tea bags"
+        },
+        "pocket_data": [
+            {
+                "max_contains_volume": "100 ml",
+                "max_contains_weight": "1000 kg",
+                "max_item_length": "1 km"
+            }
+        ]
+    },
+    {
+        "type": "GENERIC",
+        "id": "1st_aid_box",
+        "copy-from": "1st_aid_box",
+        "name": {
+            "str": "first aid kit box",
+            "str_pl": "first aid kit boxes"
+        },
+        "pocket_data": [
+            {
+                "max_contains_volume": "2450 ml",
+                "max_contains_weight": "1000 kg",
+                "max_item_length": "1 km"
+            }
+        ]
+    },
+    {
+        "type": "GENERIC",
+        "id": "ifak_pouch",
+        "copy-from": "ifak_pouch",
+        "name": {
+            "str": "IFAK pouch",
+            "str_pl": "IFAK pouches"
+        },
+        "pocket_data": [
+            {
+                "max_contains_volume": "3200 ml",
+                "max_contains_weight": "1000 kg",
+                "max_item_length": "1 km"
+            }
+        ]
+    },
+    {
+        "type": "GENERIC",
+        "id": "rc_car_box",
+        "copy-from": "rc_car_box",
+        "name": {
+            "str": "radio car box",
+            "str_pl": "radio car boxes"
+        },
+        "pocket_data": [
+            {
+                "max_contains_volume": "2900 ml",
+                "max_contains_weight": "1000 kg",
+                "max_item_length": "1 km"
+            }
+        ]
+    },
+    {
+        "type": "GENERIC",
+        "id": "beverage_bag",
+        "copy-from": "beverage_bag",
+        "name": {
+            "str": "plastic beverage bag"
+        },
+        "pocket_data": [
+            {
+                "pocket_type": "CONTAINER",
+                "rigid": false,
+                "watertight": true,
+                "open_container": true,
+                "max_contains_volume": "250 ml",
+                "max_contains_weight": "1000 kg",
+                "max_item_length": "1 km"
+            }
+        ]
+    }
+]

--- a/Kenan-Modpack/easy_containers/items/fake.json
+++ b/Kenan-Modpack/easy_containers/items/fake.json
@@ -1,0 +1,38 @@
+[
+    {
+        "type": "GUN",
+        "id": "reach_bow",
+        "copy-from": "reach_bow",
+        "name": {
+            "str": "reach bow"
+        },
+        "pocket_data": [
+            {
+                "pocket_type": "MAGAZINE",
+                "ammo_restriction": {
+                    "arrow": 1
+                },
+                "max_contains_weight": "1000 kg",
+                "max_item_length": "1 km"
+            }
+        ]
+    },
+    {
+        "type": "TOOL",
+        "id": "pseudo_char_smoker",
+        "copy-from": "pseudo_char_smoker",
+        "name": {
+            "str": "smoking rack"
+        },
+        "pocket_data": [
+            {
+                "pocket_type": "MAGAZINE",
+                "ammo_restriction": {
+                    "charcoal": 2000
+                },
+                "max_contains_weight": "1000 kg",
+                "max_item_length": "1 km"
+            }
+        ]
+    }
+]

--- a/Kenan-Modpack/easy_containers/items/generic.json
+++ b/Kenan-Modpack/easy_containers/items/generic.json
@@ -1,0 +1,216 @@
+[
+    {
+        "type": "GENERIC",
+        "id": "usb_drive",
+        "copy-from": "usb_drive",
+        "name": {
+            "str": "USB drive"
+        },
+        "pocket_data": [
+            {
+                "pocket_type": "SOFTWARE",
+                "max_contains_volume": "1 L",
+                "max_contains_weight": "1000 kg",
+                "max_item_length": "1 km"
+            }
+        ]
+    },
+    {
+        "type": "GENERIC",
+        "id": "data_card",
+        "copy-from": "data_card",
+        "name": {
+            "str": "data card"
+        },
+        "pocket_data": [
+            {
+                "pocket_type": "SOFTWARE",
+                "max_contains_volume": "1 L",
+                "max_contains_weight": "1000 kg",
+                "max_item_length": "1 km"
+            }
+        ]
+    },
+    {
+        "type": "TOOL",
+        "id": "cash_card",
+        "copy-from": "cash_card",
+        "name": {
+            "str": "cash card"
+        },
+        "pocket_data": [
+            {
+                "pocket_type": "MAGAZINE",
+                "rigid": true,
+                "ammo_restriction": {
+                    "money": 200000000
+                },
+                "max_contains_weight": "1000 kg",
+                "max_item_length": "1 km"
+            }
+        ]
+    },
+    {
+        "type": "GENERIC",
+        "id": "wallet",
+        "copy-from": "wallet",
+        "name": {
+            "str": "wallet"
+        },
+        "pocket_data": [
+            {
+                "//": "Folded Sleeve",
+                "pocket_type": "CONTAINER",
+                "rigid": false,
+                "max_contains_weight": "1000 kg",
+                "max_contains_volume": "150 ml",
+                "moves": 100,
+                "item_restriction": [
+                    "FMCNote",
+                    "signed_chit",
+                    "family_photo",
+                    "money_one",
+                    "money_ten",
+                    "money_twenty",
+                    "condom"
+                ],
+                "max_item_length": "1 km"
+            },
+            {
+                "//": "Card Sleeves",
+                "pocket_type": "CONTAINER",
+                "rigid": false,
+                "max_contains_weight": "1000 kg",
+                "max_contains_volume": "150 ml",
+                "moves": 100,
+                "item_restriction": [
+                    "cash_card",
+                    "gasdiscount_silver",
+                    "gasdiscount_gold",
+                    "gasdiscount_platinum",
+                    "id_science",
+                    "id_military",
+                    "id_industrial",
+                    "fp_loyalty_card",
+                    "scorecard",
+                    "robofac_test_data",
+                    "icon",
+                    "labmap"
+                ],
+                "max_item_length": "1 km"
+            },
+            {
+                "//": "Coin Purse",
+                "pocket_type": "CONTAINER",
+                "rigid": false,
+                "max_contains_weight": "1000 kg",
+                "max_contains_volume": "150 ml",
+                "moves": 200,
+                "item_restriction": [
+                    "FMCNote",
+                    "RobofacCoin",
+                    "FlatCoin",
+                    "coin_quarter",
+                    "coin_nickel"
+                ],
+                "max_item_length": "1 km"
+            }
+        ]
+    },
+    {
+        "type": "GENERIC",
+        "id": "wallet_large",
+        "copy-from": "wallet_large",
+        "name": {
+            "str": "large wallet"
+        },
+        "pocket_data": [
+            {
+                "//": "Folded Sleeve",
+                "pocket_type": "CONTAINER",
+                "rigid": false,
+                "max_contains_weight": "1000 kg",
+                "max_contains_volume": "175 ml",
+                "moves": 100,
+                "item_restriction": [
+                    "FMCNote",
+                    "signed_chit",
+                    "family_photo",
+                    "money_one",
+                    "money_ten",
+                    "money_twenty",
+                    "condom"
+                ],
+                "max_item_length": "1 km"
+            },
+            {
+                "//": "Card Sleeves",
+                "pocket_type": "CONTAINER",
+                "rigid": false,
+                "max_contains_weight": "1000 kg",
+                "max_contains_volume": "175 ml",
+                "moves": 100,
+                "item_restriction": [
+                    "cash_card",
+                    "gasdiscount_silver",
+                    "gasdiscount_gold",
+                    "gasdiscount_platinum",
+                    "id_science",
+                    "id_military",
+                    "id_industrial",
+                    "fp_loyalty_card",
+                    "scorecard",
+                    "robofac_test_data",
+                    "icon",
+                    "labmap"
+                ],
+                "max_item_length": "1 km"
+            },
+            {
+                "//": "Coin Purse",
+                "pocket_type": "CONTAINER",
+                "rigid": false,
+                "max_contains_weight": "1000 kg",
+                "max_contains_volume": "175 ml",
+                "moves": 200,
+                "item_restriction": [
+                    "FMCNote",
+                    "RobofacCoin",
+                    "FlatCoin",
+                    "coin_quarter",
+                    "coin_nickel"
+                ],
+                "max_item_length": "1 km"
+            }
+        ]
+    },
+    {
+        "type": "TOOL_ARMOR",
+        "id": "wallet_travel",
+        "copy-from": "wallet_travel",
+        "name": {
+            "str": "travel wallet"
+        },
+        "pocket_data": [
+            {
+                "pocket_type": "CONTAINER",
+                "rigid": true,
+                "max_contains_weight": "1000 kg",
+                "max_contains_volume": "500 ml",
+                "moves": 400,
+                "item_restriction": [
+                    "cash_card",
+                    "gasdiscount_silver",
+                    "gasdiscount_gold",
+                    "gasdiscount_platinum",
+                    "id_science",
+                    "id_military",
+                    "id_industrial",
+                    "fp_loyalty_card",
+                    "robofac_test_data"
+                ],
+                "max_item_length": "1 km"
+            }
+        ]
+    }
+]

--- a/Kenan-Modpack/easy_containers/items/generic/bedding.json
+++ b/Kenan-Modpack/easy_containers/items/generic/bedding.json
@@ -1,0 +1,17 @@
+[
+    {
+        "type": "GENERIC",
+        "id": "pillowcase",
+        "copy-from": "pillowcase",
+        "name": {
+            "str": "pillowcase"
+        },
+        "pocket_data": [
+            {
+                "max_contains_volume": "15000 ml",
+                "max_contains_weight": "1000 kg",
+                "max_item_length": "1 km"
+            }
+        ]
+    }
+]

--- a/Kenan-Modpack/easy_containers/items/generic/dining_kitchen.json
+++ b/Kenan-Modpack/easy_containers/items/generic/dining_kitchen.json
@@ -1,0 +1,434 @@
+[
+    {
+        "type": "GENERIC",
+        "id": "ceramic_bowl",
+        "copy-from": "ceramic_bowl",
+        "name": {
+            "str": "ceramic bowl"
+        },
+        "pocket_data": [
+            {
+                "max_contains_volume": "500 ml",
+                "max_contains_weight": "1000 kg",
+                "watertight": true,
+                "open_container": true,
+                "rigid": true,
+                "max_item_length": "1 km"
+            }
+        ]
+    },
+    {
+        "type": "GENERIC",
+        "id": "ceramic_cup",
+        "copy-from": "ceramic_cup",
+        "name": {
+            "str": "ceramic cup"
+        },
+        "pocket_data": [
+            {
+                "max_contains_volume": "250 ml",
+                "max_contains_weight": "1000 kg",
+                "watertight": true,
+                "open_container": true,
+                "rigid": true,
+                "max_item_length": "1 km"
+            }
+        ]
+    },
+    {
+        "type": "GENERIC",
+        "id": "ceramic_mug",
+        "copy-from": "ceramic_mug",
+        "name": {
+            "str": "coffee mug"
+        },
+        "pocket_data": [
+            {
+                "max_contains_volume": "250 ml",
+                "max_contains_weight": "1000 kg",
+                "watertight": true,
+                "open_container": true,
+                "rigid": true,
+                "max_item_length": "1 km"
+            }
+        ]
+    },
+    {
+        "type": "GENERIC",
+        "id": "tin_cup",
+        "copy-from": "tin_cup",
+        "name": {
+            "str": "tin cup"
+        },
+        "pocket_data": [
+            {
+                "max_contains_volume": "250 ml",
+                "max_contains_weight": "1000 kg",
+                "watertight": true,
+                "open_container": true,
+                "rigid": true,
+                "max_item_length": "1 km"
+            }
+        ]
+    },
+    {
+        "type": "GENERIC",
+        "id": "bowl_pewter",
+        "copy-from": "bowl_pewter",
+        "name": {
+            "str": "pewter bowl"
+        },
+        "pocket_data": [
+            {
+                "max_contains_volume": "250 ml",
+                "max_contains_weight": "1000 kg",
+                "watertight": true,
+                "open_container": true,
+                "rigid": true,
+                "max_item_length": "1 km"
+            }
+        ]
+    },
+    {
+        "type": "GENERIC",
+        "id": "glass",
+        "copy-from": "glass",
+        "name": {
+            "str": "drinking glass",
+            "str_pl": "drinking glasses"
+        },
+        "pocket_data": [
+            {
+                "max_contains_volume": "500 ml",
+                "max_contains_weight": "1000 kg",
+                "watertight": true,
+                "open_container": true,
+                "rigid": true,
+                "max_item_length": "1 km"
+            }
+        ]
+    },
+    {
+        "type": "GENERIC",
+        "id": "wine_glass",
+        "copy-from": "wine_glass",
+        "name": {
+            "str": "wine glass",
+            "str_pl": "wine glasses"
+        },
+        "pocket_data": [
+            {
+                "max_contains_volume": "250 ml",
+                "max_contains_weight": "1000 kg",
+                "watertight": true,
+                "open_container": true,
+                "rigid": true,
+                "max_item_length": "1 km"
+            }
+        ]
+    },
+    {
+        "type": "GENERIC",
+        "id": "glass_bowl",
+        "copy-from": "glass_bowl",
+        "name": {
+            "str": "glass bowl"
+        },
+        "pocket_data": [
+            {
+                "max_contains_volume": "500 ml",
+                "max_contains_weight": "1000 kg",
+                "watertight": true,
+                "open_container": true,
+                "rigid": true,
+                "max_item_length": "1 km"
+            }
+        ]
+    },
+    {
+        "type": "GENERIC",
+        "id": "tumbler_plastic",
+        "copy-from": "tumbler_plastic",
+        "name": {
+            "str": "plastic tumbler"
+        },
+        "pocket_data": [
+            {
+                "max_contains_volume": "250 ml",
+                "max_contains_weight": "1000 kg",
+                "watertight": true,
+                "open_container": true,
+                "rigid": true,
+                "max_item_length": "1 km"
+            }
+        ]
+    },
+    {
+        "type": "GENERIC",
+        "id": "bowl_plastic",
+        "copy-from": "bowl_plastic",
+        "name": {
+            "str": "plastic tupperware"
+        },
+        "pocket_data": [
+            {
+                "pocket_type": "CONTAINER",
+                "watertight": true,
+                "rigid": true,
+                "max_contains_volume": "750 ml",
+                "max_contains_weight": "1000 kg",
+                "max_item_length": "1 km"
+            }
+        ]
+    },
+    {
+        "type": "GENERIC",
+        "id": "plastic_bowl_kids",
+        "copy-from": "plastic_bowl_kids",
+        "name": {
+            "str": "kiddie bowl"
+        },
+        "pocket_data": [
+            {
+                "max_contains_volume": "120 ml",
+                "max_contains_weight": "1000 kg",
+                "watertight": true,
+                "open_container": true,
+                "rigid": true,
+                "max_item_length": "1 km"
+            }
+        ]
+    },
+    {
+        "type": "GENERIC",
+        "id": "sippy_cup",
+        "copy-from": "sippy_cup",
+        "name": {
+            "str": "sippy cup"
+        },
+        "pocket_data": [
+            {
+                "max_contains_volume": "120 ml",
+                "max_contains_weight": "1000 kg",
+                "watertight": true,
+                "rigid": true,
+                "max_item_length": "1 km"
+            }
+        ]
+    },
+    {
+        "type": "GENERIC",
+        "id": "pot",
+        "copy-from": "pot",
+        "name": {
+            "str": "pot"
+        },
+        "pocket_data": [
+            {
+                "max_contains_volume": "2 L",
+                "max_contains_weight": "1000 kg",
+                "watertight": true,
+                "open_container": true,
+                "rigid": true,
+                "max_item_length": "1 km"
+            }
+        ]
+    },
+    {
+        "type": "GENERIC",
+        "id": "iron_pot",
+        "copy-from": "iron_pot",
+        "name": {
+            "str": "cast-iron pot"
+        },
+        "pocket_data": [
+            {
+                "max_contains_volume": "2 L",
+                "max_contains_weight": "1000 kg",
+                "watertight": true,
+                "open_container": true,
+                "rigid": true,
+                "max_item_length": "1 km"
+            }
+        ]
+    },
+    {
+        "type": "GENERIC",
+        "id": "pot_copper",
+        "copy-from": "pot_copper",
+        "name": {
+            "str": "copper pot"
+        },
+        "pocket_data": [
+            {
+                "max_contains_volume": "2 L",
+                "max_contains_weight": "1000 kg",
+                "watertight": true,
+                "open_container": true,
+                "rigid": true,
+                "max_item_length": "1 km"
+            }
+        ]
+    },
+    {
+        "type": "GENERIC",
+        "id": "casserole",
+        "copy-from": "casserole",
+        "name": {
+            "str": "casserole"
+        },
+        "pocket_data": [
+            {
+                "max_contains_volume": "2 L",
+                "max_contains_weight": "1000 kg",
+                "watertight": true,
+                "open_container": true,
+                "rigid": true,
+                "max_item_length": "1 km"
+            }
+        ]
+    },
+    {
+        "type": "GENERIC",
+        "id": "stock_pot",
+        "copy-from": "stock_pot",
+        "name": {
+            "str": "stock pot"
+        },
+        "pocket_data": [
+            {
+                "max_contains_volume": "12 L",
+                "max_contains_weight": "1000 kg",
+                "watertight": true,
+                "open_container": true,
+                "rigid": true,
+                "max_item_length": "1 km"
+            }
+        ]
+    },
+    {
+        "type": "GENERIC",
+        "id": "pot_canning",
+        "copy-from": "pot_canning",
+        "name": {
+            "str": "canning pot"
+        },
+        "pocket_data": [
+            {
+                "max_contains_volume": "25 L",
+                "max_contains_weight": "1000 kg",
+                "watertight": true,
+                "open_container": true,
+                "rigid": true,
+                "max_item_length": "1 km"
+            }
+        ]
+    },
+    {
+        "type": "GENERIC",
+        "id": "pan",
+        "copy-from": "pan",
+        "name": {
+            "str": "cast-iron frying pan"
+        },
+        "pocket_data": [
+            {
+                "max_contains_volume": "1 L",
+                "max_contains_weight": "1000 kg",
+                "watertight": true,
+                "open_container": true,
+                "rigid": true,
+                "max_item_length": "1 km"
+            }
+        ]
+    },
+    {
+        "type": "GENERIC",
+        "id": "steel_pan",
+        "copy-from": "steel_pan",
+        "name": {
+            "str": "steel frying pan"
+        },
+        "pocket_data": [
+            {
+                "max_contains_volume": "800 ml",
+                "max_contains_weight": "1000 kg",
+                "watertight": true,
+                "open_container": true,
+                "rigid": true,
+                "max_item_length": "1 km"
+            }
+        ]
+    },
+    {
+        "type": "GENERIC",
+        "id": "copper_pan",
+        "copy-from": "copper_pan",
+        "name": {
+            "str": "copper frying pan"
+        },
+        "pocket_data": [
+            {
+                "max_contains_volume": "1 L",
+                "max_contains_weight": "1000 kg",
+                "watertight": true,
+                "open_container": true,
+                "rigid": true,
+                "max_item_length": "1 km"
+            }
+        ]
+    },
+    {
+        "type": "GENERIC",
+        "id": "pot_makeshift",
+        "copy-from": "pot_makeshift",
+        "name": {
+            "str": "makeshift pot"
+        },
+        "pocket_data": [
+            {
+                "max_contains_volume": "1 L",
+                "max_contains_weight": "1000 kg",
+                "watertight": true,
+                "open_container": true,
+                "rigid": true,
+                "max_item_length": "1 km"
+            }
+        ]
+    },
+    {
+        "type": "GENERIC",
+        "id": "pot_makeshift_copper",
+        "copy-from": "pot_makeshift_copper",
+        "name": {
+            "str": "makeshift copper pot"
+        },
+        "pocket_data": [
+            {
+                "max_contains_volume": "1 L",
+                "max_contains_weight": "1000 kg",
+                "watertight": true,
+                "open_container": true,
+                "rigid": true,
+                "max_item_length": "1 km"
+            }
+        ]
+    },
+    {
+        "type": "GENERIC",
+        "id": "kettle",
+        "copy-from": "kettle",
+        "name": {
+            "str": "kettle"
+        },
+        "pocket_data": [
+            {
+                "max_contains_volume": "1500 ml",
+                "max_contains_weight": "1000 kg",
+                "watertight": true,
+                "rigid": true,
+                "max_item_length": "1 km"
+            }
+        ]
+    }
+]

--- a/Kenan-Modpack/easy_containers/items/generic/string.json
+++ b/Kenan-Modpack/easy_containers/items/generic/string.json
@@ -1,0 +1,38 @@
+[
+    {
+        "type": "GENERIC",
+        "id": "rope_6",
+        "copy-from": "rope_6",
+        "name": {
+            "str": "short rope"
+        },
+        "pocket_data": [
+            {
+                "//": "Universal pocket, can store almost anything sans liquid, at the price of high move and encumbrance cost.",
+                "max_contains_volume": "10 L",
+                "max_contains_weight": "1000 kg",
+                "max_item_length": "1 km",
+                "moves": 2000,
+                "holster": true
+            }
+        ]
+    },
+    {
+        "type": "GENERIC",
+        "id": "rope_30",
+        "copy-from": "rope_30",
+        "name": {
+            "str": "long rope"
+        },
+        "pocket_data": [
+            {
+                "//": "Universal pocket, can store almost anything sans liquid and very small items, at the price of high move and encumbrance cost.",
+                "max_contains_volume": "10 L",
+                "max_contains_weight": "1000 kg",
+                "max_item_length": "1 km",
+                "moves": 3000,
+                "holster": true
+            }
+        ]
+    }
+]

--- a/Kenan-Modpack/easy_containers/items/generic/toys_and_sports.json
+++ b/Kenan-Modpack/easy_containers/items/generic/toys_and_sports.json
@@ -1,0 +1,54 @@
+[
+    {
+        "type": "TOOL",
+        "id": "talking_doll",
+        "copy-from": "talking_doll",
+        "name": {
+            "str": "talking doll"
+        },
+        "pocket_data": [
+            {
+                "pocket_type": "MAGAZINE_WELL",
+                "holster": true,
+                "max_contains_volume": "20 L",
+                "max_contains_weight": "1000 kg",
+                "item_restriction": [
+                    "light_minus_disposable_cell",
+                    "light_disposable_cell",
+                    "light_minus_battery_cell",
+                    "light_battery_cell",
+                    "light_plus_battery_cell",
+                    "light_atomic_battery_cell",
+                    "light_minus_atomic_battery_cell"
+                ],
+                "max_item_length": "1 km"
+            }
+        ]
+    },
+    {
+        "type": "TOOL",
+        "id": "creepy_doll",
+        "copy-from": "creepy_doll",
+        "name": {
+            "str": "talking doll"
+        },
+        "pocket_data": [
+            {
+                "pocket_type": "MAGAZINE_WELL",
+                "holster": true,
+                "max_contains_volume": "20 L",
+                "max_contains_weight": "1000 kg",
+                "item_restriction": [
+                    "light_minus_disposable_cell",
+                    "light_disposable_cell",
+                    "light_minus_battery_cell",
+                    "light_battery_cell",
+                    "light_plus_battery_cell",
+                    "light_atomic_battery_cell",
+                    "light_minus_atomic_battery_cell"
+                ],
+                "max_item_length": "1 km"
+            }
+        ]
+    }
+]

--- a/Kenan-Modpack/easy_containers/items/gun/10mm.json
+++ b/Kenan-Modpack/easy_containers/items/gun/10mm.json
@@ -1,0 +1,219 @@
+[
+    {
+        "type": "GUN",
+        "id": "sw_610",
+        "copy-from": "sw_610",
+        "name": {
+            "str_sp": "S&W 610"
+        },
+        "pocket_data": [
+            {
+                "pocket_type": "MAGAZINE",
+                "holster": true,
+                "ammo_restriction": {
+                    "10mm": 6,
+                    "40": 6
+                },
+                "allowed_speedloaders": [
+                    "40_speedloader6"
+                ],
+                "max_contains_weight": "1000 kg",
+                "max_item_length": "1 km"
+            }
+        ]
+    },
+    {
+        "type": "GUN",
+        "id": "glock_29",
+        "copy-from": "glock_29",
+        "name": {
+            "str": "Glock 29"
+        },
+        "pocket_data": [
+            {
+                "magazine_well": "99 ml",
+                "pocket_type": "MAGAZINE_WELL",
+                "holster": true,
+                "max_contains_volume": "20 L",
+                "max_contains_weight": "1000 kg",
+                "item_restriction": [
+                    "glock_29mag",
+                    "glock_20mag",
+                    "tdi_10mm_mag"
+                ],
+                "max_item_length": "1 km"
+            }
+        ]
+    },
+    {
+        "type": "GUN",
+        "id": "glock_20",
+        "copy-from": "glock_20",
+        "name": {
+            "str": "Glock 20"
+        },
+        "pocket_data": [
+            {
+                "magazine_well": "103 ml",
+                "pocket_type": "MAGAZINE_WELL",
+                "holster": true,
+                "max_contains_volume": "20 L",
+                "max_contains_weight": "1000 kg",
+                "item_restriction": [
+                    "glock_20mag",
+                    "tdi_10mm_mag"
+                ],
+                "max_item_length": "1 km"
+            }
+        ]
+    },
+    {
+        "type": "GUN",
+        "id": "glock_40",
+        "copy-from": "glock_40",
+        "name": {
+            "str": "Glock 40 MOS"
+        },
+        "pocket_data": [
+            {
+                "magazine_well": "103 ml",
+                "pocket_type": "MAGAZINE_WELL",
+                "holster": true,
+                "max_contains_volume": "20 L",
+                "max_contains_weight": "1000 kg",
+                "item_restriction": [
+                    "glock_20mag",
+                    "tdi_10mm_mag"
+                ],
+                "max_item_length": "1 km"
+            }
+        ]
+    },
+    {
+        "type": "GUN",
+        "id": "hk_mp5_10_semi",
+        "copy-from": "hk_mp5_10_semi",
+        "name": {
+            "str": "BA10"
+        },
+        "pocket_data": [
+            {
+                "pocket_type": "MAGAZINE_WELL",
+                "magazine_well": "62 ml",
+                "holster": true,
+                "max_contains_volume": "20 L",
+                "max_contains_weight": "1000 kg",
+                "item_restriction": [
+                    "mp5_10_mag"
+                ],
+                "max_item_length": "1 km"
+            }
+        ]
+    },
+    {
+        "type": "GUN",
+        "id": "m1911_10",
+        "copy-from": "m1911_10",
+        "name": {
+            "str": "Colt Delta Elite"
+        },
+        "pocket_data": [
+            {
+                "magazine_well": "60 ml",
+                "pocket_type": "MAGAZINE_WELL",
+                "holster": true,
+                "max_contains_volume": "20 L",
+                "max_contains_weight": "1000 kg",
+                "item_restriction": [
+                    "m1911_10mag"
+                ],
+                "max_item_length": "1 km"
+            }
+        ]
+    },
+    {
+        "type": "GUN",
+        "id": "witness_10",
+        "copy-from": "witness_10",
+        "name": {
+            "str": "EAA Witness 10mm"
+        },
+        "pocket_data": [
+            {
+                "magazine_well": "84 ml",
+                "pocket_type": "MAGAZINE_WELL",
+                "holster": true,
+                "max_contains_volume": "20 L",
+                "max_contains_weight": "1000 kg",
+                "item_restriction": [
+                    "witness_mag_10"
+                ],
+                "max_item_length": "1 km"
+            }
+        ]
+    },
+    {
+        "type": "GUN",
+        "id": "p220_10",
+        "copy-from": "p220_10",
+        "name": {
+            "str": "SIG P220 10mm"
+        },
+        "pocket_data": [
+            {
+                "magazine_well": "60 ml",
+                "pocket_type": "MAGAZINE_WELL",
+                "holster": true,
+                "max_contains_volume": "20 L",
+                "max_contains_weight": "1000 kg",
+                "item_restriction": [
+                    "p220_10_mag"
+                ],
+                "max_item_length": "1 km"
+            }
+        ]
+    },
+    {
+        "type": "GUN",
+        "id": "xd_10",
+        "copy-from": "xd_10",
+        "name": {
+            "str": "XD(M) Competition 10mm"
+        },
+        "pocket_data": [
+            {
+                "magazine_well": "81 ml",
+                "pocket_type": "MAGAZINE_WELL",
+                "holster": true,
+                "max_contains_volume": "20 L",
+                "max_contains_weight": "1000 kg",
+                "item_restriction": [
+                    "xd_10_mag"
+                ],
+                "max_item_length": "1 km"
+            }
+        ]
+    },
+    {
+        "type": "GUN",
+        "id": "TDI_10",
+        "copy-from": "TDI_10",
+        "name": {
+            "str": "Vector SDP 10mm"
+        },
+        "pocket_data": [
+            {
+                "pocket_type": "MAGAZINE_WELL",
+                "magazine_well": "103 ml",
+                "holster": true,
+                "max_contains_volume": "20 L",
+                "max_contains_weight": "1000 kg",
+                "item_restriction": [
+                    "glock_20mag",
+                    "tdi_10mm_mag"
+                ],
+                "max_item_length": "1 km"
+            }
+        ]
+    }
+]

--- a/Kenan-Modpack/easy_containers/items/gun/12mm.json
+++ b/Kenan-Modpack/easy_containers/items/gun/12mm.json
@@ -1,0 +1,23 @@
+[
+    {
+        "type": "GUN",
+        "id": "hk_g80",
+        "copy-from": "hk_g80",
+        "name": {
+            "str": "H&K G80 railgun"
+        },
+        "pocket_data": [
+            {
+                "pocket_type": "MAGAZINE_WELL",
+                "holster": true,
+                "magazine_well": "250 ml",
+                "max_contains_volume": "20 L",
+                "max_contains_weight": "1000 kg",
+                "item_restriction": [
+                    "hk_g80mag"
+                ],
+                "max_item_length": "1 km"
+            }
+        ]
+    }
+]

--- a/Kenan-Modpack/easy_containers/items/gun/20x66mm.json
+++ b/Kenan-Modpack/easy_containers/items/gun/20x66mm.json
@@ -1,0 +1,64 @@
+[
+    {
+        "type": "GUN",
+        "id": "rm120c",
+        "copy-from": "rm120c",
+        "name": {
+            "str": "RM120c shotgun"
+        },
+        "pocket_data": [
+            {
+                "pocket_type": "MAGAZINE",
+                "rigid": true,
+                "ammo_restriction": {
+                    "20x66mm": 5
+                },
+                "max_contains_weight": "1000 kg",
+                "max_item_length": "1 km"
+            }
+        ]
+    },
+    {
+        "type": "GUN",
+        "id": "rm20",
+        "copy-from": "rm20",
+        "name": {
+            "str": "RM20 autoshotgun"
+        },
+        "pocket_data": [
+            {
+                "magazine_well": "500 ml",
+                "pocket_type": "MAGAZINE_WELL",
+                "holster": true,
+                "max_contains_volume": "20 L",
+                "max_contains_weight": "1000 kg",
+                "item_restriction": [
+                    "20x66_20_mag",
+                    "20x66_40_mag"
+                ],
+                "max_item_length": "1 km"
+            }
+        ]
+    },
+    {
+        "type": "GUN",
+        "id": "rm228",
+        "copy-from": "rm228",
+        "name": {
+            "str": "RM228 PDW"
+        },
+        "pocket_data": [
+            {
+                "magazine_well": "250 ml",
+                "pocket_type": "MAGAZINE_WELL",
+                "holster": true,
+                "max_contains_volume": "20 L",
+                "max_contains_weight": "1000 kg",
+                "item_restriction": [
+                    "20x66_10_mag"
+                ],
+                "max_item_length": "1 km"
+            }
+        ]
+    }
+]

--- a/Kenan-Modpack/easy_containers/items/gun/22.json
+++ b/Kenan-Modpack/easy_containers/items/gun/22.json
@@ -1,0 +1,215 @@
+[
+    {
+        "type": "GUN",
+        "id": "american_180",
+        "copy-from": "american_180",
+        "name": {
+            "str_sp": "American-180"
+        },
+        "pocket_data": [
+            {
+                "pocket_type": "MAGAZINE_WELL",
+                "holster": true,
+                "max_contains_volume": "20 L",
+                "max_contains_weight": "1000 kg",
+                "item_restriction": [
+                    "a180mag",
+                    "a180mag1",
+                    "a180mag2",
+                    "a180mag3",
+                    "a180mag4"
+                ],
+                "max_item_length": "1 km"
+            }
+        ]
+    },
+    {
+        "type": "GUN",
+        "id": "marlin_9a",
+        "copy-from": "marlin_9a",
+        "name": {
+            "str_sp": "Marlin 39A"
+        },
+        "pocket_data": [
+            {
+                "pocket_type": "MAGAZINE",
+                "ammo_restriction": {
+                    "22": 19
+                },
+                "allowed_speedloaders": [
+                    "marlin_tubeloader"
+                ],
+                "max_contains_weight": "1000 kg",
+                "max_item_length": "1 km"
+            }
+        ]
+    },
+    {
+        "type": "GUN",
+        "id": "moss_brownie",
+        "copy-from": "moss_brownie",
+        "name": {
+            "str_sp": "Mossberg Brownie"
+        },
+        "pocket_data": [
+            {
+                "pocket_type": "MAGAZINE",
+                "rigid": true,
+                "ammo_restriction": {
+                    "22": 4
+                },
+                "max_contains_weight": "1000 kg",
+                "max_item_length": "1 km"
+            }
+        ]
+    },
+    {
+        "type": "GUN",
+        "id": "rifle_22",
+        "copy-from": "rifle_22",
+        "name": {
+            "str": "pipe rifle: .22",
+            "str_pl": "pipe rifles: .22"
+        },
+        "pocket_data": [
+            {
+                "pocket_type": "MAGAZINE",
+                "rigid": true,
+                "ammo_restriction": {
+                    "22": 1
+                },
+                "max_contains_weight": "1000 kg",
+                "max_item_length": "1 km"
+            }
+        ]
+    },
+    {
+        "type": "GUN",
+        "id": "ruger_1022",
+        "copy-from": "ruger_1022",
+        "name": {
+            "str_sp": "Ruger 10/22"
+        },
+        "pocket_data": [
+            {
+                "magazine_well": "250 ml",
+                "pocket_type": "MAGAZINE_WELL",
+                "holster": true,
+                "max_contains_volume": "20 L",
+                "max_contains_weight": "1000 kg",
+                "item_restriction": [
+                    "ruger1022mag",
+                    "ruger1022bigmag"
+                ],
+                "max_item_length": "1 km"
+            }
+        ]
+    },
+    {
+        "type": "GUN",
+        "id": "ruger_lcr_22",
+        "copy-from": "ruger_lcr_22",
+        "name": {
+            "str_sp": "Ruger LCR .22"
+        },
+        "pocket_data": [
+            {
+                "pocket_type": "MAGAZINE",
+                "holster": true,
+                "rigid": true,
+                "ammo_restriction": {
+                    "22": 8
+                },
+                "allowed_speedloaders": [
+                    "22_speedloader8"
+                ],
+                "max_contains_weight": "1000 kg",
+                "max_item_length": "1 km"
+            }
+        ]
+    },
+    {
+        "type": "GUN",
+        "id": "sig_mosquito",
+        "copy-from": "sig_mosquito",
+        "name": {
+            "str_sp": "SIG Mosquito"
+        },
+        "pocket_data": [
+            {
+                "magazine_well": "250 ml",
+                "pocket_type": "MAGAZINE_WELL",
+                "holster": true,
+                "max_contains_volume": "20 L",
+                "max_contains_weight": "1000 kg",
+                "item_restriction": [
+                    "mosquitomag"
+                ],
+                "max_item_length": "1 km"
+            }
+        ]
+    },
+    {
+        "type": "GUN",
+        "id": "sw_22",
+        "copy-from": "sw_22",
+        "name": {
+            "str_sp": "S&W 22A"
+        },
+        "pocket_data": [
+            {
+                "magazine_well": "250 ml",
+                "pocket_type": "MAGAZINE_WELL",
+                "holster": true,
+                "max_contains_volume": "20 L",
+                "max_contains_weight": "1000 kg",
+                "item_restriction": [
+                    "sw22mag"
+                ],
+                "max_item_length": "1 km"
+            }
+        ]
+    },
+    {
+        "type": "GUN",
+        "id": "j22",
+        "copy-from": "j22",
+        "name": {
+            "str": "Jennings J-22"
+        },
+        "pocket_data": [
+            {
+                "magazine_well": "27 ml",
+                "pocket_type": "MAGAZINE_WELL",
+                "holster": true,
+                "max_contains_volume": "20 L",
+                "max_contains_weight": "1000 kg",
+                "item_restriction": [
+                    "j22mag"
+                ],
+                "max_item_length": "1 km"
+            }
+        ]
+    },
+    {
+        "type": "GUN",
+        "id": "walther_p22",
+        "copy-from": "walther_p22",
+        "name": {
+            "str": "Walther P22"
+        },
+        "pocket_data": [
+            {
+                "magazine_well": "126 ml",
+                "pocket_type": "MAGAZINE_WELL",
+                "holster": true,
+                "max_contains_volume": "20 L",
+                "max_contains_weight": "1000 kg",
+                "item_restriction": [
+                    "wp22mag"
+                ],
+                "max_item_length": "1 km"
+            }
+        ]
+    }
+]

--- a/Kenan-Modpack/easy_containers/items/gun/223.json
+++ b/Kenan-Modpack/easy_containers/items/gun/223.json
@@ -1,0 +1,465 @@
+[
+    {
+        "type": "GUN",
+        "id": "acr",
+        "copy-from": "acr",
+        "name": {
+            "str": "Remington ACR"
+        },
+        "pocket_data": [
+            {
+                "pocket_type": "MAGAZINE_WELL",
+                "holster": true,
+                "max_contains_volume": "20 L",
+                "max_contains_weight": "1000 kg",
+                "item_restriction": [
+                    "stanag30",
+                    "stanag5",
+                    "stanag10",
+                    "stanag20",
+                    "stanag40",
+                    "stanag50",
+                    "stanag60",
+                    "stanag60drum",
+                    "stanag90",
+                    "stanag100",
+                    "stanag100drum",
+                    "stanag150",
+                    "survivor223mag"
+                ],
+                "max_item_length": "1 km"
+            }
+        ]
+    },
+    {
+        "type": "GUN",
+        "id": "ar15",
+        "copy-from": "ar15",
+        "name": {
+            "str": "AR-15"
+        },
+        "pocket_data": [
+            {
+                "pocket_type": "MAGAZINE_WELL",
+                "holster": true,
+                "max_contains_volume": "20 L",
+                "max_contains_weight": "1000 kg",
+                "item_restriction": [
+                    "stanag30",
+                    "stanag5",
+                    "stanag10",
+                    "stanag20",
+                    "stanag40",
+                    "stanag50",
+                    "stanag60",
+                    "stanag60drum",
+                    "stanag90",
+                    "stanag100",
+                    "stanag100drum",
+                    "stanag150",
+                    "survivor223mag"
+                ],
+                "max_item_length": "1 km"
+            }
+        ]
+    },
+    {
+        "type": "GUN",
+        "id": "ar_pistol",
+        "copy-from": "ar_pistol",
+        "name": {
+            "str": "AR pistol"
+        },
+        "pocket_data": [
+            {
+                "pocket_type": "MAGAZINE_WELL",
+                "holster": true,
+                "max_contains_volume": "20 L",
+                "max_contains_weight": "1000 kg",
+                "item_restriction": [
+                    "stanag30",
+                    "stanag5",
+                    "stanag10",
+                    "stanag20",
+                    "stanag40",
+                    "stanag50",
+                    "stanag60",
+                    "stanag60drum",
+                    "stanag90",
+                    "stanag100",
+                    "stanag100drum",
+                    "stanag150",
+                    "survivor223mag"
+                ],
+                "max_item_length": "1 km"
+            }
+        ]
+    },
+    {
+        "type": "GUN",
+        "id": "famas",
+        "copy-from": "famas",
+        "name": {
+            "str_sp": "MAS .223"
+        },
+        "pocket_data": [
+            {
+                "pocket_type": "MAGAZINE_WELL",
+                "holster": true,
+                "max_contains_volume": "20 L",
+                "max_contains_weight": "1000 kg",
+                "item_restriction": [
+                    "famasmag"
+                ],
+                "max_item_length": "1 km"
+            }
+        ]
+    },
+    {
+        "type": "GUN",
+        "id": "fs2000",
+        "copy-from": "fs2000",
+        "name": {
+            "str": "FS2000"
+        },
+        "pocket_data": [
+            {
+                "pocket_type": "MAGAZINE_WELL",
+                "holster": true,
+                "max_contains_volume": "20 L",
+                "max_contains_weight": "1000 kg",
+                "item_restriction": [
+                    "stanag30"
+                ],
+                "max_item_length": "1 km"
+            }
+        ]
+    },
+    {
+        "type": "GUN",
+        "id": "h&k416a5",
+        "copy-from": "h&k416a5",
+        "name": {
+            "str": "HK416 A5"
+        },
+        "pocket_data": [
+            {
+                "pocket_type": "MAGAZINE_WELL",
+                "holster": true,
+                "max_contains_volume": "20 L",
+                "max_contains_weight": "1000 kg",
+                "item_restriction": [
+                    "stanag30",
+                    "stanag5",
+                    "stanag10",
+                    "stanag20",
+                    "stanag40",
+                    "stanag50",
+                    "stanag60",
+                    "stanag60drum",
+                    "stanag90",
+                    "stanag100",
+                    "stanag100drum",
+                    "stanag150",
+                    "survivor223mag"
+                ],
+                "max_item_length": "1 km"
+            }
+        ]
+    },
+    {
+        "type": "GUN",
+        "id": "hk_g36",
+        "copy-from": "hk_g36",
+        "name": {
+            "str": "H&K G36"
+        },
+        "pocket_data": [
+            {
+                "pocket_type": "MAGAZINE_WELL",
+                "holster": true,
+                "max_contains_volume": "20 L",
+                "max_contains_weight": "1000 kg",
+                "item_restriction": [
+                    "g36mag_30rd",
+                    "g36mag_100rd"
+                ],
+                "max_item_length": "1 km"
+            }
+        ]
+    },
+    {
+        "type": "GUN",
+        "id": "m249",
+        "copy-from": "m249",
+        "name": {
+            "str": "M249"
+        },
+        "pocket_data": [
+            {
+                "pocket_type": "MAGAZINE_WELL",
+                "holster": true,
+                "max_contains_volume": "20 L",
+                "max_contains_weight": "1000 kg",
+                "item_restriction": [
+                    "belt223",
+                    "stanag30",
+                    "stanag5",
+                    "stanag10",
+                    "stanag20",
+                    "stanag40",
+                    "stanag50",
+                    "stanag60",
+                    "stanag60drum",
+                    "stanag90",
+                    "stanag100",
+                    "stanag100drum",
+                    "stanag150",
+                    "survivor223mag"
+                ],
+                "max_item_length": "1 km"
+            }
+        ]
+    },
+    {
+        "type": "GUN",
+        "id": "m27iar",
+        "copy-from": "m27iar",
+        "name": {
+            "str": "M27 IAR"
+        },
+        "pocket_data": [
+            {
+                "pocket_type": "MAGAZINE_WELL",
+                "holster": true,
+                "max_contains_volume": "20 L",
+                "max_contains_weight": "1000 kg",
+                "item_restriction": [
+                    "stanag30",
+                    "stanag5",
+                    "stanag10",
+                    "stanag20",
+                    "stanag40",
+                    "stanag50",
+                    "stanag60",
+                    "stanag60drum",
+                    "stanag90",
+                    "stanag100",
+                    "stanag100drum",
+                    "stanag150",
+                    "survivor223mag"
+                ],
+                "max_item_length": "1 km"
+            }
+        ]
+    },
+    {
+        "type": "GUN",
+        "id": "m4a1",
+        "copy-from": "m4a1",
+        "name": {
+            "str": "M4A1"
+        },
+        "pocket_data": [
+            {
+                "pocket_type": "MAGAZINE_WELL",
+                "holster": true,
+                "max_contains_volume": "20 L",
+                "max_contains_weight": "1000 kg",
+                "item_restriction": [
+                    "stanag30",
+                    "stanag5",
+                    "stanag10",
+                    "stanag20",
+                    "stanag40",
+                    "stanag50",
+                    "stanag60",
+                    "stanag60drum",
+                    "stanag90",
+                    "stanag100",
+                    "stanag100drum",
+                    "stanag150",
+                    "survivor223mag"
+                ],
+                "max_item_length": "1 km"
+            }
+        ]
+    },
+    {
+        "type": "GUN",
+        "id": "m16a4",
+        "copy-from": "m16a4",
+        "name": {
+            "str": "M16A4"
+        },
+        "pocket_data": [
+            {
+                "pocket_type": "MAGAZINE_WELL",
+                "holster": true,
+                "max_contains_volume": "20 L",
+                "max_contains_weight": "1000 kg",
+                "item_restriction": [
+                    "stanag30",
+                    "stanag5",
+                    "stanag10",
+                    "stanag20",
+                    "stanag40",
+                    "stanag50",
+                    "stanag60",
+                    "stanag60drum",
+                    "stanag90",
+                    "stanag100",
+                    "stanag100drum",
+                    "stanag150",
+                    "survivor223mag"
+                ],
+                "max_item_length": "1 km"
+            }
+        ]
+    },
+    {
+        "type": "GUN",
+        "id": "oa93",
+        "copy-from": "oa93",
+        "name": {
+            "str": "OA-93"
+        },
+        "pocket_data": [
+            {
+                "pocket_type": "MAGAZINE_WELL",
+                "holster": true,
+                "max_contains_volume": "20 L",
+                "max_contains_weight": "1000 kg",
+                "item_restriction": [
+                    "stanag30",
+                    "stanag5",
+                    "stanag10",
+                    "stanag20",
+                    "stanag40",
+                    "stanag50",
+                    "stanag60",
+                    "stanag60drum",
+                    "stanag90",
+                    "stanag100",
+                    "stanag100drum",
+                    "stanag150",
+                    "survivor223mag"
+                ],
+                "max_item_length": "1 km"
+            }
+        ]
+    },
+    {
+        "type": "GUN",
+        "id": "ruger_mini",
+        "copy-from": "ruger_mini",
+        "name": {
+            "str": "Ruger Mini-14"
+        },
+        "pocket_data": [
+            {
+                "pocket_type": "MAGAZINE_WELL",
+                "holster": true,
+                "max_contains_volume": "20 L",
+                "max_contains_weight": "1000 kg",
+                "item_restriction": [
+                    "ruger20",
+                    "ruger5",
+                    "ruger10",
+                    "ruger30",
+                    "ruger90",
+                    "ruger100",
+                    "ruger_makeshiftmag"
+                ],
+                "max_item_length": "1 km"
+            }
+        ]
+    },
+    {
+        "type": "GUN",
+        "id": "scar_l",
+        "copy-from": "scar_l",
+        "name": {
+            "str": "FN SCAR-L"
+        },
+        "pocket_data": [
+            {
+                "pocket_type": "MAGAZINE_WELL",
+                "holster": true,
+                "max_contains_volume": "20 L",
+                "max_contains_weight": "1000 kg",
+                "item_restriction": [
+                    "stanag30",
+                    "stanag5",
+                    "stanag10",
+                    "stanag20",
+                    "stanag40",
+                    "stanag50",
+                    "stanag60",
+                    "stanag60drum",
+                    "stanag90",
+                    "stanag100",
+                    "stanag100drum",
+                    "stanag150",
+                    "survivor223mag"
+                ],
+                "max_item_length": "1 km"
+            }
+        ]
+    },
+    {
+        "type": "GUN",
+        "id": "sig552",
+        "copy-from": "sig552",
+        "name": {
+            "str": "SIG 552"
+        },
+        "pocket_data": [
+            {
+                "pocket_type": "MAGAZINE_WELL",
+                "holster": true,
+                "max_contains_volume": "20 L",
+                "max_contains_weight": "1000 kg",
+                "item_restriction": [
+                    "stanag30",
+                    "stanag5",
+                    "stanag10",
+                    "stanag20",
+                    "stanag40",
+                    "stanag50",
+                    "stanag60",
+                    "stanag60drum",
+                    "stanag90",
+                    "stanag100",
+                    "stanag100drum",
+                    "stanag150",
+                    "survivor223mag"
+                ],
+                "max_item_length": "1 km"
+            }
+        ]
+    },
+    {
+        "type": "GUN",
+        "id": "steyr_aug",
+        "copy-from": "steyr_aug",
+        "name": {
+            "str": "Steyr AUG"
+        },
+        "pocket_data": [
+            {
+                "pocket_type": "MAGAZINE_WELL",
+                "holster": true,
+                "max_contains_volume": "20 L",
+                "max_contains_weight": "1000 kg",
+                "item_restriction": [
+                    "augmag_30rd",
+                    "augmag_10rd",
+                    "augmag_42rd",
+                    "augmag_100rd"
+                ],
+                "max_item_length": "1 km"
+            }
+        ]
+    }
+]

--- a/Kenan-Modpack/easy_containers/items/gun/270win.json
+++ b/Kenan-Modpack/easy_containers/items/gun/270win.json
@@ -1,0 +1,21 @@
+[
+    {
+        "type": "GUN",
+        "id": "remington700_270",
+        "copy-from": "remington700_270",
+        "name": {
+            "str_sp": "Remington 700 .270 Win"
+        },
+        "pocket_data": [
+            {
+                "pocket_type": "MAGAZINE",
+                "rigid": true,
+                "ammo_restriction": {
+                    "270win": 4
+                },
+                "max_contains_weight": "1000 kg",
+                "max_item_length": "1 km"
+            }
+        ]
+    }
+]

--- a/Kenan-Modpack/easy_containers/items/gun/300.json
+++ b/Kenan-Modpack/easy_containers/items/gun/300.json
@@ -1,0 +1,60 @@
+[
+    {
+        "type": "GUN",
+        "id": "m2010",
+        "copy-from": "m2010",
+        "name": {
+            "str_sp": "M2010 ESR"
+        },
+        "pocket_data": [
+            {
+                "pocket_type": "MAGAZINE_WELL",
+                "holster": true,
+                "max_contains_volume": "20 L",
+                "max_contains_weight": "1000 kg",
+                "item_restriction": [
+                    "m2010mag"
+                ],
+                "max_item_length": "1 km"
+            }
+        ]
+    },
+    {
+        "type": "GUN",
+        "id": "weatherby_5",
+        "copy-from": "weatherby_5",
+        "name": {
+            "str_sp": "Weatherby Mark V"
+        },
+        "pocket_data": [
+            {
+                "pocket_type": "MAGAZINE",
+                "rigid": true,
+                "ammo_restriction": {
+                    "300": 3
+                },
+                "max_contains_weight": "1000 kg",
+                "max_item_length": "1 km"
+            }
+        ]
+    },
+    {
+        "type": "GUN",
+        "id": "win70",
+        "copy-from": "win70",
+        "name": {
+            "str_sp": "Winchester Model 70"
+        },
+        "pocket_data": [
+            {
+                "pocket_type": "MAGAZINE",
+                "rigid": true,
+                "ammo_restriction": {
+                    "300": 3
+                },
+                "max_contains_weight": "1000 kg",
+                "max_item_length": "1 km"
+            }
+        ]
+    }
+]

--- a/Kenan-Modpack/easy_containers/items/gun/3006.json
+++ b/Kenan-Modpack/easy_containers/items/gun/3006.json
@@ -1,0 +1,103 @@
+[
+    {
+        "type": "GUN",
+        "id": "browning_blr",
+        "copy-from": "browning_blr",
+        "name": {
+            "str_sp": "Browning BLR"
+        },
+        "pocket_data": [
+            {
+                "pocket_type": "MAGAZINE_WELL",
+                "holster": true,
+                "max_contains_volume": "20 L",
+                "max_contains_weight": "1000 kg",
+                "item_restriction": [
+                    "blrmag"
+                ],
+                "max_item_length": "1 km"
+            }
+        ]
+    },
+    {
+        "type": "GUN",
+        "id": "garand",
+        "copy-from": "garand",
+        "name": {
+            "str": "M1 Garand"
+        },
+        "pocket_data": [
+            {
+                "pocket_type": "MAGAZINE_WELL",
+                "holster": true,
+                "max_contains_volume": "20 L",
+                "max_contains_weight": "1000 kg",
+                "item_restriction": [
+                    "garandclip"
+                ],
+                "max_item_length": "1 km"
+            }
+        ]
+    },
+    {
+        "type": "GUN",
+        "id": "m1903",
+        "copy-from": "m1903",
+        "name": {
+            "str": "M1903 Springfield"
+        },
+        "pocket_data": [
+            {
+                "pocket_type": "MAGAZINE",
+                "ammo_restriction": {
+                    "3006": 5
+                },
+                "allowed_speedloaders": [
+                    "3006_clip"
+                ],
+                "max_contains_weight": "1000 kg",
+                "max_item_length": "1 km"
+            }
+        ]
+    },
+    {
+        "type": "GUN",
+        "id": "m1918",
+        "copy-from": "m1918",
+        "name": {
+            "str": "Browning Automatic Rifle"
+        },
+        "pocket_data": [
+            {
+                "pocket_type": "MAGAZINE_WELL",
+                "holster": true,
+                "max_contains_volume": "20 L",
+                "max_contains_weight": "1000 kg",
+                "item_restriction": [
+                    "m1918mag",
+                    "m1918bigmag"
+                ],
+                "max_item_length": "1 km"
+            }
+        ]
+    },
+    {
+        "type": "GUN",
+        "id": "remington_700",
+        "copy-from": "remington_700",
+        "name": {
+            "str_sp": "Remington 700 .30-06"
+        },
+        "pocket_data": [
+            {
+                "pocket_type": "MAGAZINE",
+                "rigid": true,
+                "ammo_restriction": {
+                    "3006": 4
+                },
+                "max_contains_weight": "1000 kg",
+                "max_item_length": "1 km"
+            }
+        ]
+    }
+]

--- a/Kenan-Modpack/easy_containers/items/gun/300BLK.json
+++ b/Kenan-Modpack/easy_containers/items/gun/300BLK.json
@@ -1,0 +1,98 @@
+[
+    {
+        "type": "GUN",
+        "id": "acr_300blk",
+        "copy-from": "acr_300blk",
+        "name": {
+            "str": "Remington ACR .300BLK"
+        },
+        "pocket_data": [
+            {
+                "pocket_type": "MAGAZINE_WELL",
+                "holster": true,
+                "max_contains_volume": "20 L",
+                "max_contains_weight": "1000 kg",
+                "item_restriction": [
+                    "stanag30",
+                    "stanag5",
+                    "stanag10",
+                    "stanag20",
+                    "stanag40",
+                    "stanag50",
+                    "stanag60",
+                    "stanag60drum",
+                    "stanag90",
+                    "stanag100",
+                    "stanag100drum",
+                    "stanag150",
+                    "survivor223mag"
+                ],
+                "max_item_length": "1 km"
+            }
+        ]
+    },
+    {
+        "type": "GUN",
+        "id": "iwi_tavor_x95_300blk",
+        "copy-from": "iwi_tavor_x95_300blk",
+        "name": {
+            "str": "IWI Tavor X95 .300BLK"
+        },
+        "pocket_data": [
+            {
+                "pocket_type": "MAGAZINE_WELL",
+                "holster": true,
+                "max_contains_volume": "20 L",
+                "max_contains_weight": "1000 kg",
+                "item_restriction": [
+                    "stanag30",
+                    "stanag5",
+                    "stanag10",
+                    "stanag20",
+                    "stanag40",
+                    "stanag50",
+                    "stanag60",
+                    "stanag60drum",
+                    "stanag90",
+                    "stanag100",
+                    "stanag100drum",
+                    "stanag150",
+                    "survivor223mag"
+                ],
+                "max_item_length": "1 km"
+            }
+        ]
+    },
+    {
+        "type": "GUN",
+        "id": "sig_mcx_rattler_sbr",
+        "copy-from": "sig_mcx_rattler_sbr",
+        "name": {
+            "str": "SIG MCX Rattler SBR"
+        },
+        "pocket_data": [
+            {
+                "pocket_type": "MAGAZINE_WELL",
+                "holster": true,
+                "max_contains_volume": "20 L",
+                "max_contains_weight": "1000 kg",
+                "item_restriction": [
+                    "stanag30",
+                    "stanag5",
+                    "stanag10",
+                    "stanag20",
+                    "stanag40",
+                    "stanag50",
+                    "stanag60",
+                    "stanag60drum",
+                    "stanag90",
+                    "stanag100",
+                    "stanag100drum",
+                    "stanag150",
+                    "survivor223mag"
+                ],
+                "max_item_length": "1 km"
+            }
+        ]
+    }
+]

--- a/Kenan-Modpack/easy_containers/items/gun/308.json
+++ b/Kenan-Modpack/easy_containers/items/gun/308.json
@@ -1,0 +1,254 @@
+[
+    {
+        "type": "GUN",
+        "id": "fn_fal",
+        "copy-from": "fn_fal",
+        "name": {
+            "str_sp": "FN FAL"
+        },
+        "pocket_data": [
+            {
+                "pocket_type": "MAGAZINE_WELL",
+                "holster": true,
+                "max_contains_volume": "20 L",
+                "max_contains_weight": "1000 kg",
+                "item_restriction": [
+                    "falmag",
+                    "falbigmag",
+                    "fal_makeshiftmag"
+                ],
+                "max_item_length": "1 km"
+            }
+        ]
+    },
+    {
+        "type": "GUN",
+        "id": "hk_g3",
+        "copy-from": "hk_g3",
+        "name": {
+            "str_sp": "H&K G3"
+        },
+        "pocket_data": [
+            {
+                "pocket_type": "MAGAZINE_WELL",
+                "holster": true,
+                "max_contains_volume": "20 L",
+                "max_contains_weight": "1000 kg",
+                "item_restriction": [
+                    "g3mag",
+                    "g3bigmag",
+                    "g3_makeshiftmag"
+                ],
+                "max_item_length": "1 km"
+            }
+        ]
+    },
+    {
+        "type": "GUN",
+        "id": "m134",
+        "copy-from": "m134",
+        "name": {
+            "str": "M134D-H Minigun"
+        },
+        "pocket_data": [
+            {
+                "pocket_type": "MAGAZINE_WELL",
+                "holster": true,
+                "max_contains_volume": "20 L",
+                "max_contains_weight": "1000 kg",
+                "item_restriction": [
+                    "belt308"
+                ],
+                "max_item_length": "1 km"
+            }
+        ]
+    },
+    {
+        "type": "GUN",
+        "id": "m1a",
+        "copy-from": "m1a",
+        "name": {
+            "str_sp": "M1A"
+        },
+        "pocket_data": [
+            {
+                "pocket_type": "MAGAZINE_WELL",
+                "holster": true,
+                "max_contains_volume": "20 L",
+                "max_contains_weight": "1000 kg",
+                "item_restriction": [
+                    "m14mag",
+                    "m14smallmag",
+                    "m14_makeshiftmag"
+                ],
+                "max_item_length": "1 km"
+            }
+        ]
+    },
+    {
+        "type": "GUN",
+        "id": "m240",
+        "copy-from": "m240",
+        "name": {
+            "str": "M240"
+        },
+        "pocket_data": [
+            {
+                "pocket_type": "MAGAZINE_WELL",
+                "holster": true,
+                "max_contains_volume": "20 L",
+                "max_contains_weight": "1000 kg",
+                "item_restriction": [
+                    "belt308"
+                ],
+                "max_item_length": "1 km"
+            }
+        ]
+    },
+    {
+        "type": "GUN",
+        "id": "m60",
+        "copy-from": "m60",
+        "name": {
+            "str": "M60"
+        },
+        "pocket_data": [
+            {
+                "pocket_type": "MAGAZINE_WELL",
+                "holster": true,
+                "max_contains_volume": "20 L",
+                "max_contains_weight": "1000 kg",
+                "item_restriction": [
+                    "belt308"
+                ],
+                "max_item_length": "1 km"
+            }
+        ]
+    },
+    {
+        "type": "GUN",
+        "id": "savage_111f",
+        "copy-from": "savage_111f",
+        "name": {
+            "str_sp": "Savage 111F"
+        },
+        "pocket_data": [
+            {
+                "pocket_type": "MAGAZINE",
+                "rigid": true,
+                "ammo_restriction": {
+                    "308": 3
+                },
+                "max_contains_weight": "1000 kg",
+                "max_item_length": "1 km"
+            }
+        ]
+    },
+    {
+        "type": "GUN",
+        "id": "scar_h",
+        "copy-from": "scar_h",
+        "name": {
+            "str_sp": "FN SCAR-H"
+        },
+        "pocket_data": [
+            {
+                "pocket_type": "MAGAZINE_WELL",
+                "holster": true,
+                "max_contains_volume": "20 L",
+                "max_contains_weight": "1000 kg",
+                "item_restriction": [
+                    "scarhmag",
+                    "scarhbigmag",
+                    "scarhmag_30rd",
+                    "scarh_makeshiftmag"
+                ],
+                "max_item_length": "1 km"
+            }
+        ]
+    },
+    {
+        "type": "GUN",
+        "id": "M24",
+        "copy-from": "M24",
+        "name": {
+            "str_sp": "M24"
+        },
+        "pocket_data": [
+            {
+                "pocket_type": "MAGAZINE",
+                "rigid": true,
+                "ammo_restriction": {
+                    "308": 5
+                },
+                "max_contains_weight": "1000 kg",
+                "max_item_length": "1 km"
+            }
+        ]
+    },
+    {
+        "type": "GUN",
+        "id": "hk417_13",
+        "copy-from": "hk417_13",
+        "name": {
+            "str": "HK417 A2"
+        },
+        "pocket_data": [
+            {
+                "pocket_type": "MAGAZINE_WELL",
+                "holster": true,
+                "max_contains_volume": "20 L",
+                "max_contains_weight": "1000 kg",
+                "item_restriction": [
+                    "hk417mag_20rd",
+                    "hk417mag_10rd",
+                    "hk417_makeshiftmag"
+                ],
+                "max_item_length": "1 km"
+            }
+        ]
+    },
+    {
+        "type": "GUN",
+        "id": "m110a1",
+        "copy-from": "m110a1",
+        "name": {
+            "str": "M110A1"
+        },
+        "pocket_data": [
+            {
+                "pocket_type": "MAGAZINE_WELL",
+                "holster": true,
+                "max_contains_volume": "20 L",
+                "max_contains_weight": "1000 kg",
+                "item_restriction": [
+                    "hk417mag_20rd",
+                    "hk417mag_10rd",
+                    "hk417_makeshiftmag"
+                ],
+                "max_item_length": "1 km"
+            }
+        ]
+    },
+    {
+        "type": "GUN",
+        "id": "ar10",
+        "copy-from": "ar10",
+        "name": {
+            "str": "AR-10"
+        },
+        "pocket_data": [
+            {
+                "pocket_type": "MAGAZINE_WELL",
+                "holster": true,
+                "max_contains_volume": "20 L",
+                "max_contains_weight": "1000 kg",
+                "item_restriction": [
+                    "ar10mag_20rd",
+                    "ar10_makeshiftmag"
+                ],
+                "max_item_length": "1 km"
+            }
+        ]
+    }
+]

--- a/Kenan-Modpack/easy_containers/items/gun/32.json
+++ b/Kenan-Modpack/easy_containers/items/gun/32.json
@@ -1,0 +1,85 @@
+[
+    {
+        "type": "GUN",
+        "id": "sig_p230",
+        "copy-from": "sig_p230",
+        "name": {
+            "str_sp": "SIG Sauer P230"
+        },
+        "pocket_data": [
+            {
+                "magazine_well": "250 ml",
+                "pocket_type": "MAGAZINE_WELL",
+                "holster": true,
+                "max_contains_volume": "20 L",
+                "max_contains_weight": "1000 kg",
+                "item_restriction": [
+                    "sigp230mag"
+                ],
+                "max_item_length": "1 km"
+            }
+        ]
+    },
+    {
+        "type": "GUN",
+        "id": "skorpion_61",
+        "copy-from": "skorpion_61",
+        "name": {
+            "str": "Skorpion Vz. 61"
+        },
+        "pocket_data": [
+            {
+                "pocket_type": "MAGAZINE_WELL",
+                "holster": true,
+                "max_contains_volume": "20 L",
+                "max_contains_weight": "1000 kg",
+                "item_restriction": [
+                    "skorpion61mag"
+                ],
+                "max_item_length": "1 km"
+            }
+        ]
+    },
+    {
+        "type": "GUN",
+        "id": "walther_ppk",
+        "copy-from": "walther_ppk",
+        "name": {
+            "str_sp": "Walther PPK"
+        },
+        "pocket_data": [
+            {
+                "magazine_well": "250 ml",
+                "pocket_type": "MAGAZINE_WELL",
+                "holster": true,
+                "max_contains_volume": "20 L",
+                "max_contains_weight": "1000 kg",
+                "item_restriction": [
+                    "ppkmag"
+                ],
+                "max_item_length": "1 km"
+            }
+        ]
+    },
+    {
+        "type": "GUN",
+        "id": "kp32",
+        "copy-from": "kp32",
+        "name": {
+            "str": "Kel-Tec P32"
+        },
+        "pocket_data": [
+            {
+                "magazine_well": "41 ml",
+                "pocket_type": "MAGAZINE_WELL",
+                "holster": true,
+                "max_contains_volume": "20 L",
+                "max_contains_weight": "1000 kg",
+                "item_restriction": [
+                    "kp32mag"
+                ],
+                "max_item_length": "1 km"
+            }
+        ]
+    }
+]

--- a/Kenan-Modpack/easy_containers/items/gun/357sig.json
+++ b/Kenan-Modpack/easy_containers/items/gun/357sig.json
@@ -1,0 +1,66 @@
+[
+    {
+        "type": "GUN",
+        "id": "p226_357sig",
+        "copy-from": "p226_357sig",
+        "name": {
+            "str": "SIG P226"
+        },
+        "pocket_data": [
+            {
+                "magazine_well": "250 ml",
+                "pocket_type": "MAGAZINE_WELL",
+                "holster": true,
+                "max_contains_volume": "20 L",
+                "max_contains_weight": "1000 kg",
+                "item_restriction": [
+                    "p226mag_12rd_357sig"
+                ],
+                "max_item_length": "1 km"
+            }
+        ]
+    },
+    {
+        "type": "GUN",
+        "id": "glock_31",
+        "copy-from": "glock_31",
+        "name": {
+            "str": "Glock 31"
+        },
+        "pocket_data": [
+            {
+                "magazine_well": "250 ml",
+                "pocket_type": "MAGAZINE_WELL",
+                "holster": true,
+                "max_contains_volume": "20 L",
+                "max_contains_weight": "1000 kg",
+                "item_restriction": [
+                    "glock40mag",
+                    "glock40bigmag"
+                ],
+                "max_item_length": "1 km"
+            }
+        ]
+    },
+    {
+        "type": "GUN",
+        "id": "p320_357sig",
+        "copy-from": "p320_357sig",
+        "name": {
+            "str": "SIG P320 Compact"
+        },
+        "pocket_data": [
+            {
+                "magazine_well": "250 ml",
+                "pocket_type": "MAGAZINE_WELL",
+                "holster": true,
+                "max_contains_volume": "20 L",
+                "max_contains_weight": "1000 kg",
+                "item_restriction": [
+                    "p320mag_13rd_357sig"
+                ],
+                "max_item_length": "1 km"
+            }
+        ]
+    }
+]

--- a/Kenan-Modpack/easy_containers/items/gun/36paper.json
+++ b/Kenan-Modpack/easy_containers/items/gun/36paper.json
@@ -1,0 +1,21 @@
+[
+    {
+        "type": "GUN",
+        "id": "colt_navy",
+        "copy-from": "colt_navy",
+        "name": {
+            "str_sp": "Colt M1861 Navy"
+        },
+        "pocket_data": [
+            {
+                "pocket_type": "MAGAZINE",
+                "rigid": true,
+                "ammo_restriction": {
+                    "36paper": 6
+                },
+                "max_contains_weight": "1000 kg",
+                "max_item_length": "1 km"
+            }
+        ]
+    }
+]

--- a/Kenan-Modpack/easy_containers/items/gun/38.json
+++ b/Kenan-Modpack/easy_containers/items/gun/38.json
@@ -1,0 +1,131 @@
+[
+    {
+        "type": "GUN",
+        "id": "2_shot_special",
+        "copy-from": "2_shot_special",
+        "name": {
+            "str": "2 Shot Special"
+        },
+        "pocket_data": [
+            {
+                "pocket_type": "MAGAZINE",
+                "rigid": true,
+                "ammo_restriction": {
+                    "38": 2
+                },
+                "max_contains_weight": "1000 kg",
+                "max_item_length": "1 km"
+            }
+        ]
+    },
+    {
+        "type": "GUN",
+        "id": "cop_38",
+        "copy-from": "cop_38",
+        "name": {
+            "str": "COP .357 Derringer"
+        },
+        "pocket_data": [
+            {
+                "pocket_type": "MAGAZINE",
+                "rigid": true,
+                "ammo_restriction": {
+                    "357mag": 4,
+                    "38": 4
+                },
+                "max_contains_weight": "1000 kg",
+                "max_item_length": "1 km"
+            }
+        ]
+    },
+    {
+        "type": "GUN",
+        "id": "model_10_revolver",
+        "copy-from": "model_10_revolver",
+        "name": {
+            "str_sp": "S&W Model 10"
+        },
+        "pocket_data": [
+            {
+                "pocket_type": "MAGAZINE",
+                "holster": true,
+                "rigid": true,
+                "ammo_restriction": {
+                    "38": 6
+                },
+                "allowed_speedloaders": [
+                    "38_speedloader6"
+                ],
+                "max_contains_weight": "1000 kg",
+                "max_item_length": "1 km"
+            }
+        ]
+    },
+    {
+        "type": "GUN",
+        "id": "rifle_38",
+        "copy-from": "rifle_38",
+        "name": {
+            "str": "pipe rifle: .38 Special",
+            "str_pl": "pipe rifles: .38 Special"
+        },
+        "pocket_data": [
+            {
+                "pocket_type": "MAGAZINE",
+                "rigid": true,
+                "ammo_restriction": {
+                    "38": 1
+                },
+                "max_contains_weight": "1000 kg",
+                "max_item_length": "1 km"
+            }
+        ]
+    },
+    {
+        "type": "GUN",
+        "id": "ruger_lcr_38",
+        "copy-from": "ruger_lcr_38",
+        "name": {
+            "str_sp": "Ruger LCR .38"
+        },
+        "pocket_data": [
+            {
+                "pocket_type": "MAGAZINE",
+                "holster": true,
+                "rigid": true,
+                "ammo_restriction": {
+                    "38": 5
+                },
+                "allowed_speedloaders": [
+                    "38_speedloader5"
+                ],
+                "max_contains_weight": "1000 kg",
+                "max_item_length": "1 km"
+            }
+        ]
+    },
+    {
+        "type": "GUN",
+        "id": "sw_619",
+        "copy-from": "sw_619",
+        "name": {
+            "str_sp": "S&W 619"
+        },
+        "pocket_data": [
+            {
+                "pocket_type": "MAGAZINE",
+                "holster": true,
+                "rigid": true,
+                "ammo_restriction": {
+                    "357mag": 7,
+                    "38": 7
+                },
+                "allowed_speedloaders": [
+                    "38_speedloader"
+                ],
+                "max_contains_weight": "1000 kg",
+                "max_item_length": "1 km"
+            }
+        ]
+    }
+]

--- a/Kenan-Modpack/easy_containers/items/gun/380.json
+++ b/Kenan-Modpack/easy_containers/items/gun/380.json
@@ -1,0 +1,128 @@
+[
+    {
+        "type": "GUN",
+        "id": "mac_11",
+        "copy-from": "mac_11",
+        "name": {
+            "str": "MAC-11"
+        },
+        "pocket_data": [
+            {
+                "pocket_type": "MAGAZINE_WELL",
+                "holster": true,
+                "max_contains_volume": "20 L",
+                "max_contains_weight": "1000 kg",
+                "item_restriction": [
+                    "mac11mag"
+                ],
+                "max_item_length": "1 km"
+            }
+        ]
+    },
+    {
+        "type": "GUN",
+        "id": "kp3at",
+        "copy-from": "kp3at",
+        "name": {
+            "str": "Kel-Tec P3AT"
+        },
+        "pocket_data": [
+            {
+                "magazine_well": "44 ml",
+                "pocket_type": "MAGAZINE_WELL",
+                "holster": true,
+                "max_contains_volume": "20 L",
+                "max_contains_weight": "1000 kg",
+                "item_restriction": [
+                    "kp3atmag"
+                ],
+                "max_item_length": "1 km"
+            }
+        ]
+    },
+    {
+        "type": "GUN",
+        "id": "fn1910",
+        "copy-from": "fn1910",
+        "name": {
+            "str": "FN 1910 .380"
+        },
+        "pocket_data": [
+            {
+                "magazine_well": "60 ml",
+                "pocket_type": "MAGAZINE_WELL",
+                "holster": true,
+                "max_contains_volume": "20 L",
+                "max_contains_weight": "1000 kg",
+                "item_restriction": [
+                    "fn1910mag"
+                ],
+                "max_item_length": "1 km"
+            }
+        ]
+    },
+    {
+        "type": "GUN",
+        "id": "rugerlcp",
+        "copy-from": "rugerlcp",
+        "name": {
+            "str": "Ruger LCP"
+        },
+        "pocket_data": [
+            {
+                "magazine_well": "60 ml",
+                "pocket_type": "MAGAZINE_WELL",
+                "holster": true,
+                "max_contains_volume": "20 L",
+                "max_contains_weight": "1000 kg",
+                "item_restriction": [
+                    "rugerlcpmag"
+                ],
+                "max_item_length": "1 km"
+            }
+        ]
+    },
+    {
+        "type": "GUN",
+        "id": "hptcf380",
+        "copy-from": "hptcf380",
+        "name": {
+            "str": "Hi-Point CF-380"
+        },
+        "pocket_data": [
+            {
+                "magazine_well": "236 ml",
+                "pocket_type": "MAGAZINE_WELL",
+                "holster": true,
+                "max_contains_volume": "20 L",
+                "max_contains_weight": "1000 kg",
+                "item_restriction": [
+                    "hptcf380mag_8rd",
+                    "hptcf380mag_10rd"
+                ],
+                "max_item_length": "1 km"
+            }
+        ]
+    },
+    {
+        "type": "GUN",
+        "id": "taurus_spectrum",
+        "copy-from": "taurus_spectrum",
+        "name": {
+            "str_sp": "Taurus Spectrum"
+        },
+        "pocket_data": [
+            {
+                "magazine_well": "74 ml",
+                "pocket_type": "MAGAZINE_WELL",
+                "holster": true,
+                "max_contains_volume": "20 L",
+                "max_contains_weight": "1000 kg",
+                "item_restriction": [
+                    "taurus_spectrum_mag"
+                ],
+                "max_item_length": "1 km"
+            }
+        ]
+    }
+]

--- a/Kenan-Modpack/easy_containers/items/gun/38super.json
+++ b/Kenan-Modpack/easy_containers/items/gun/38super.json
@@ -1,0 +1,44 @@
+[
+    {
+        "type": "GUN",
+        "id": "af2011a1_38super",
+        "copy-from": "af2011a1_38super",
+        "name": {
+            "str_sp": "AF2011A1 .38 Super"
+        },
+        "pocket_data": [
+            {
+                "magazine_well": "500 ml",
+                "pocket_type": "MAGAZINE_WELL",
+                "holster": true,
+                "max_contains_volume": "20 L",
+                "max_contains_weight": "1000 kg",
+                "item_restriction": [
+                    "af2011a1mag"
+                ],
+                "max_item_length": "1 km"
+            }
+        ]
+    },
+    {
+        "type": "GUN",
+        "id": "m1911a1_38super",
+        "copy-from": "m1911a1_38super",
+        "name": {
+            "str": "M1911A1"
+        },
+        "pocket_data": [
+            {
+                "magazine_well": "250 ml",
+                "pocket_type": "MAGAZINE_WELL",
+                "holster": true,
+                "max_contains_volume": "20 L",
+                "max_contains_weight": "1000 kg",
+                "item_restriction": [
+                    "m1911mag_10rd_38super"
+                ],
+                "max_item_length": "1 km"
+            }
+        ]
+    }
+]

--- a/Kenan-Modpack/easy_containers/items/gun/40.json
+++ b/Kenan-Modpack/easy_containers/items/gun/40.json
@@ -1,0 +1,212 @@
+[
+    {
+        "type": "GUN",
+        "id": "90two40",
+        "copy-from": "90two40",
+        "name": {
+            "str": "Beretta 90-two .40 S&W"
+        },
+        "pocket_data": [
+            {
+                "magazine_well": "250 ml",
+                "pocket_type": "MAGAZINE_WELL",
+                "holster": true,
+                "max_contains_volume": "20 L",
+                "max_contains_weight": "1000 kg",
+                "item_restriction": [
+                    "90two40mag"
+                ],
+                "max_item_length": "1 km"
+            }
+        ]
+    },
+    {
+        "type": "GUN",
+        "id": "glock_22",
+        "copy-from": "glock_22",
+        "name": {
+            "str_sp": "Glock 22"
+        },
+        "pocket_data": [
+            {
+                "pocket_type": "MAGAZINE_WELL",
+                "holster": true,
+                "magazine_well": "250 ml",
+                "max_contains_volume": "20 L",
+                "max_contains_weight": "1000 kg",
+                "item_restriction": [
+                    "glock40mag",
+                    "glock40bigmag"
+                ],
+                "max_item_length": "1 km"
+            }
+        ]
+    },
+    {
+        "type": "GUN",
+        "id": "px4_40",
+        "copy-from": "px4_40",
+        "name": {
+            "str": "Beretta Px4 Storm .40 S&W"
+        },
+        "pocket_data": [
+            {
+                "pocket_type": "MAGAZINE_WELL",
+                "holster": true,
+                "magazine_well": "250 ml",
+                "max_contains_volume": "20 L",
+                "max_contains_weight": "1000 kg",
+                "item_restriction": [
+                    "px4_40mag"
+                ],
+                "max_item_length": "1 km"
+            }
+        ]
+    },
+    {
+        "type": "GUN",
+        "id": "rifle_40",
+        "copy-from": "rifle_40",
+        "name": {
+            "str": "pipe rifle: .40 S&W",
+            "str_pl": "pipe rifles: .40 S&W"
+        },
+        "pocket_data": [
+            {
+                "pocket_type": "MAGAZINE",
+                "rigid": true,
+                "ammo_restriction": {
+                    "40": 1
+                },
+                "max_contains_weight": "1000 kg",
+                "max_item_length": "1 km"
+            }
+        ]
+    },
+    {
+        "type": "GUN",
+        "id": "sig_40",
+        "copy-from": "sig_40",
+        "name": {
+            "str_sp": "SIG Pro .40"
+        },
+        "pocket_data": [
+            {
+                "pocket_type": "MAGAZINE_WELL",
+                "holster": true,
+                "max_contains_volume": "20 L",
+                "magazine_well": "250 ml",
+                "max_contains_weight": "1000 kg",
+                "item_restriction": [
+                    "sig40mag"
+                ],
+                "max_item_length": "1 km"
+            }
+        ]
+    },
+    {
+        "type": "GUN",
+        "id": "smg_40",
+        "copy-from": "smg_40",
+        "name": {
+            "str": "Luty SMG: .40 S&W",
+            "str_pl": "Luty SMGs: .40 S&W"
+        },
+        "pocket_data": [
+            {
+                "pocket_type": "MAGAZINE_WELL",
+                "holster": true,
+                "max_contains_volume": "20 L",
+                "max_contains_weight": "1000 kg",
+                "item_restriction": [
+                    "smg_40_mag"
+                ],
+                "max_item_length": "1 km"
+            }
+        ]
+    },
+    {
+        "type": "GUN",
+        "id": "surv_six_shooter",
+        "copy-from": "surv_six_shooter",
+        "name": {
+            "str": "handmade six-shooter"
+        },
+        "pocket_data": [
+            {
+                "pocket_type": "MAGAZINE",
+                "rigid": true,
+                "ammo_restriction": {
+                    "40": 6
+                },
+                "max_contains_weight": "1000 kg",
+                "max_item_length": "1 km"
+            }
+        ]
+    },
+    {
+        "type": "GUN",
+        "id": "hi_power_40",
+        "copy-from": "hi_power_40",
+        "name": {
+            "str": "Browning Hi-Power .40 S&W"
+        },
+        "pocket_data": [
+            {
+                "magazine_well": "185 ml",
+                "pocket_type": "MAGAZINE_WELL",
+                "holster": true,
+                "max_contains_volume": "20 L",
+                "max_contains_weight": "1000 kg",
+                "item_restriction": [
+                    "bhp40mag"
+                ],
+                "max_item_length": "1 km"
+            }
+        ]
+    },
+    {
+        "type": "GUN",
+        "id": "walther_ppq_40",
+        "copy-from": "walther_ppq_40",
+        "name": {
+            "str": "Walther PPQ .40 S&W"
+        },
+        "pocket_data": [
+            {
+                "magazine_well": "200 ml",
+                "pocket_type": "MAGAZINE_WELL",
+                "holster": true,
+                "max_contains_volume": "20 L",
+                "max_contains_weight": "1000 kg",
+                "item_restriction": [
+                    "ppq40mag_10rd",
+                    "ppq40mag_12rd",
+                    "ppq40mag_14rd"
+                ],
+                "max_item_length": "1 km"
+            }
+        ]
+    },
+    {
+        "type": "GUN",
+        "id": "hptjcp",
+        "copy-from": "hptjcp",
+        "name": {
+            "str": "Hi-Point Model JCP"
+        },
+        "pocket_data": [
+            {
+                "magazine_well": "312 ml",
+                "pocket_type": "MAGAZINE_WELL",
+                "holster": true,
+                "max_contains_volume": "20 L",
+                "max_contains_weight": "1000 kg",
+                "item_restriction": [
+                    "hptjcpmag"
+                ],
+                "max_item_length": "1 km"
+            }
+        ]
+    }
+]

--- a/Kenan-Modpack/easy_containers/items/gun/40x46mm.json
+++ b/Kenan-Modpack/easy_containers/items/gun/40x46mm.json
@@ -1,0 +1,135 @@
+[
+    {
+        "type": "GUN",
+        "id": "launcher_simple",
+        "copy-from": "launcher_simple",
+        "name": {
+            "str": "tube 40mm launcher"
+        },
+        "pocket_data": [
+            {
+                "pocket_type": "MAGAZINE",
+                "rigid": true,
+                "ammo_restriction": {
+                    "40x46mm": 1
+                },
+                "max_contains_weight": "1000 kg",
+                "max_item_length": "1 km"
+            }
+        ]
+    },
+    {
+        "type": "GUN",
+        "id": "m320",
+        "copy-from": "m320",
+        "name": {
+            "str": "M320 standalone launcher"
+        },
+        "pocket_data": [
+            {
+                "pocket_type": "MAGAZINE",
+                "rigid": true,
+                "ammo_restriction": {
+                    "40x46mm": 1
+                },
+                "max_contains_weight": "1000 kg",
+                "max_item_length": "1 km"
+            }
+        ]
+    },
+    {
+        "type": "GUN",
+        "id": "m79",
+        "copy-from": "m79",
+        "name": {
+            "str": "M79 launcher"
+        },
+        "pocket_data": [
+            {
+                "pocket_type": "MAGAZINE",
+                "rigid": true,
+                "ammo_restriction": {
+                    "40x46mm": 1
+                },
+                "max_contains_weight": "1000 kg",
+                "max_item_length": "1 km"
+            }
+        ]
+    },
+    {
+        "type": "GUN",
+        "id": "mgl",
+        "copy-from": "mgl",
+        "name": {
+            "str_sp": "Milkor MGL"
+        },
+        "pocket_data": [
+            {
+                "pocket_type": "MAGAZINE",
+                "rigid": true,
+                "ammo_restriction": {
+                    "40x46mm": 6
+                },
+                "max_contains_weight": "1000 kg",
+                "max_item_length": "1 km"
+            }
+        ]
+    },
+    {
+        "type": "GUN",
+        "id": "rm802",
+        "copy-from": "rm802",
+        "name": {
+            "str": "RM802 grenade launcher"
+        },
+        "pocket_data": [
+            {
+                "pocket_type": "MAGAZINE",
+                "rigid": true,
+                "ammo_restriction": {
+                    "40x46mm": 4
+                },
+                "max_contains_weight": "1000 kg",
+                "max_item_length": "1 km"
+            }
+        ]
+    },
+    {
+        "type": "GUN",
+        "id": "triple_launcher_simple",
+        "copy-from": "triple_launcher_simple",
+        "name": {
+            "str": "triple-barrel 40mm launcher"
+        },
+        "pocket_data": [
+            {
+                "pocket_type": "MAGAZINE",
+                "rigid": true,
+                "ammo_restriction": {
+                    "40x46mm": 3
+                },
+                "max_contains_weight": "1000 kg",
+                "max_item_length": "1 km"
+            }
+        ]
+    },
+    {
+        "type": "GUN",
+        "id": "pseudo_m203",
+        "copy-from": "pseudo_m203",
+        "name": {
+            "str": "M203 array"
+        },
+        "pocket_data": [
+            {
+                "pocket_type": "MAGAZINE",
+                "rigid": true,
+                "ammo_restriction": {
+                    "40x46mm": 6
+                },
+                "max_contains_weight": "1000 kg",
+                "max_item_length": "1 km"
+            }
+        ]
+    }
+]

--- a/Kenan-Modpack/easy_containers/items/gun/40x53mm.json
+++ b/Kenan-Modpack/easy_containers/items/gun/40x53mm.json
@@ -1,0 +1,22 @@
+[
+    {
+        "type": "GUN",
+        "id": "mark19",
+        "copy-from": "mark19",
+        "name": {
+            "str": "Mark 19 grenade launcher"
+        },
+        "pocket_data": [
+            {
+                "pocket_type": "MAGAZINE_WELL",
+                "holster": true,
+                "max_contains_volume": "20 L",
+                "max_contains_weight": "1000 kg",
+                "item_restriction": [
+                    "belt40mm"
+                ],
+                "max_item_length": "1 km"
+            }
+        ]
+    }
+]

--- a/Kenan-Modpack/easy_containers/items/gun/410shot.json
+++ b/Kenan-Modpack/easy_containers/items/gun/410shot.json
@@ -1,0 +1,42 @@
+[
+    {
+        "type": "GUN",
+        "id": "saiga_410",
+        "copy-from": "saiga_410",
+        "name": {
+            "str": "Saiga-410"
+        },
+        "pocket_data": [
+            {
+                "pocket_type": "MAGAZINE_WELL",
+                "holster": true,
+                "max_contains_volume": "20 L",
+                "max_contains_weight": "1000 kg",
+                "item_restriction": [
+                    "saiga410mag_10rd",
+                    "saiga410mag_30rd"
+                ],
+                "max_item_length": "1 km"
+            }
+        ]
+    },
+    {
+        "type": "GUN",
+        "id": "shotgun_410",
+        "copy-from": "shotgun_410",
+        "name": {
+            "str": "Winchester M37 .410"
+        },
+        "pocket_data": [
+            {
+                "pocket_type": "MAGAZINE",
+                "rigid": true,
+                "ammo_restriction": {
+                    "410shot": 1
+                },
+                "max_contains_weight": "1000 kg",
+                "max_item_length": "1 km"
+            }
+        ]
+    }
+]

--- a/Kenan-Modpack/easy_containers/items/gun/44.json
+++ b/Kenan-Modpack/easy_containers/items/gun/44.json
@@ -1,0 +1,108 @@
+[
+    {
+        "type": "GUN",
+        "id": "deagle_44",
+        "copy-from": "deagle_44",
+        "name": {
+            "str_sp": "Desert Eagle .44"
+        },
+        "pocket_data": [
+            {
+                "magazine_well": "250 ml",
+                "pocket_type": "MAGAZINE_WELL",
+                "holster": true,
+                "max_contains_volume": "20 L",
+                "max_contains_weight": "1000 kg",
+                "item_restriction": [
+                    "deaglemag"
+                ],
+                "max_item_length": "1 km"
+            }
+        ]
+    },
+    {
+        "type": "GUN",
+        "id": "henry_big_boy",
+        "copy-from": "henry_big_boy",
+        "name": {
+            "str_sp": "Henry Big Boy .44"
+        },
+        "pocket_data": [
+            {
+                "pocket_type": "MAGAZINE",
+                "rigid": true,
+                "ammo_restriction": {
+                    "44": 10
+                },
+                "max_contains_weight": "1000 kg",
+                "max_item_length": "1 km"
+            }
+        ]
+    },
+    {
+        "type": "GUN",
+        "id": "rifle_44",
+        "copy-from": "rifle_44",
+        "name": {
+            "str": "pipe rifle: .44 Magnum",
+            "str_pl": "pipe rifles: .44 Magnum"
+        },
+        "pocket_data": [
+            {
+                "pocket_type": "MAGAZINE",
+                "rigid": true,
+                "ammo_restriction": {
+                    "44": 1
+                },
+                "max_contains_weight": "1000 kg",
+                "max_item_length": "1 km"
+            }
+        ]
+    },
+    {
+        "type": "GUN",
+        "id": "ruger_redhawk",
+        "copy-from": "ruger_redhawk",
+        "name": {
+            "str_sp": "Ruger Redhawk"
+        },
+        "pocket_data": [
+            {
+                "pocket_type": "MAGAZINE",
+                "holster": true,
+                "rigid": true,
+                "ammo_restriction": {
+                    "44": 6
+                },
+                "allowed_speedloaders": [
+                    "44_speedloader6"
+                ],
+                "max_contains_weight": "1000 kg",
+                "max_item_length": "1 km"
+            }
+        ]
+    },
+    {
+        "type": "GUN",
+        "id": "sw629",
+        "copy-from": "sw629",
+        "name": {
+            "str_sp": "S&W 629"
+        },
+        "pocket_data": [
+            {
+                "pocket_type": "MAGAZINE",
+                "holster": true,
+                "rigid": true,
+                "ammo_restriction": {
+                    "44": 6
+                },
+                "allowed_speedloaders": [
+                    "44_speedloader6"
+                ],
+                "max_contains_weight": "1000 kg",
+                "max_item_length": "1 km"
+            }
+        ]
+    }
+]

--- a/Kenan-Modpack/easy_containers/items/gun/44paper.json
+++ b/Kenan-Modpack/easy_containers/items/gun/44paper.json
@@ -1,0 +1,40 @@
+[
+    {
+        "type": "GUN",
+        "id": "colt_army",
+        "copy-from": "colt_army",
+        "name": {
+            "str_sp": "Colt M1860 Army"
+        },
+        "pocket_data": [
+            {
+                "pocket_type": "MAGAZINE",
+                "rigid": true,
+                "ammo_restriction": {
+                    "44paper": 6
+                },
+                "max_contains_weight": "1000 kg",
+                "max_item_length": "1 km"
+            }
+        ]
+    },
+    {
+        "type": "GUN",
+        "id": "lemat_revolver",
+        "copy-from": "lemat_revolver",
+        "name": {
+            "str": "LeMat revolver"
+        },
+        "pocket_data": [
+            {
+                "pocket_type": "MAGAZINE",
+                "rigid": true,
+                "ammo_restriction": {
+                    "44paper": 9
+                },
+                "max_contains_weight": "1000 kg",
+                "max_item_length": "1 km"
+            }
+        ]
+    }
+]

--- a/Kenan-Modpack/easy_containers/items/gun/45.json
+++ b/Kenan-Modpack/easy_containers/items/gun/45.json
@@ -1,0 +1,257 @@
+[
+    {
+        "type": "GUN",
+        "id": "TDI",
+        "copy-from": "TDI",
+        "name": {
+            "str": "Vector SMG .45"
+        },
+        "pocket_data": [
+            {
+                "pocket_type": "MAGAZINE_WELL",
+                "holster": true,
+                "max_contains_volume": "20 L",
+                "max_contains_weight": "1000 kg",
+                "item_restriction": [
+                    "tdi_mag",
+                    "glock_21mag",
+                    "glock_21mag26"
+                ],
+                "max_item_length": "1 km"
+            }
+        ]
+    },
+    {
+        "type": "GUN",
+        "id": "hk_ump45",
+        "copy-from": "hk_ump45",
+        "name": {
+            "str": "H&K UMP45"
+        },
+        "pocket_data": [
+            {
+                "pocket_type": "MAGAZINE_WELL",
+                "holster": true,
+                "max_contains_volume": "20 L",
+                "max_contains_weight": "1000 kg",
+                "item_restriction": [
+                    "ump45mag",
+                    "ump45_makeshiftmag"
+                ],
+                "max_item_length": "1 km"
+            }
+        ]
+    },
+    {
+        "type": "GUN",
+        "id": "m1911",
+        "copy-from": "m1911",
+        "name": {
+            "str": "M1911"
+        },
+        "pocket_data": [
+            {
+                "magazine_well": "250 ml",
+                "pocket_type": "MAGAZINE_WELL",
+                "holster": true,
+                "max_contains_volume": "20 L",
+                "max_contains_weight": "1000 kg",
+                "item_restriction": [
+                    "m1911mag",
+                    "m1911bigmag"
+                ],
+                "max_item_length": "1 km"
+            }
+        ]
+    },
+    {
+        "type": "GUN",
+        "id": "mac_10",
+        "copy-from": "mac_10",
+        "name": {
+            "str": "MAC-10"
+        },
+        "pocket_data": [
+            {
+                "pocket_type": "MAGAZINE_WELL",
+                "holster": true,
+                "max_contains_volume": "20 L",
+                "max_contains_weight": "1000 kg",
+                "item_restriction": [
+                    "mac10mag",
+                    "smg_45_mag"
+                ],
+                "max_item_length": "1 km"
+            }
+        ]
+    },
+    {
+        "type": "GUN",
+        "id": "rifle_45",
+        "copy-from": "rifle_45",
+        "name": {
+            "str": "pipe rifle: .45",
+            "str_pl": "pipe rifles: .45"
+        },
+        "pocket_data": [
+            {
+                "pocket_type": "MAGAZINE",
+                "rigid": true,
+                "ammo_restriction": {
+                    "45": 1
+                },
+                "max_contains_weight": "1000 kg",
+                "max_item_length": "1 km"
+            }
+        ]
+    },
+    {
+        "type": "GUN",
+        "id": "smg_45",
+        "copy-from": "smg_45",
+        "name": {
+            "str": "Luty SMG: .45",
+            "str_pl": "Luty SMGs: .45"
+        },
+        "pocket_data": [
+            {
+                "pocket_type": "MAGAZINE_WELL",
+                "holster": true,
+                "max_contains_volume": "20 L",
+                "max_contains_weight": "1000 kg",
+                "item_restriction": [
+                    "smg_45_mag",
+                    "mac10mag"
+                ],
+                "max_item_length": "1 km"
+            }
+        ]
+    },
+    {
+        "type": "GUN",
+        "id": "surv_hand_cannon",
+        "copy-from": "surv_hand_cannon",
+        "name": {
+            "str": "homemade hand cannon"
+        },
+        "pocket_data": [
+            {
+                "pocket_type": "MAGAZINE",
+                "rigid": true,
+                "ammo_restriction": {
+                    "45": 5
+                },
+                "max_contains_weight": "1000 kg",
+                "max_item_length": "1 km"
+            }
+        ]
+    },
+    {
+        "type": "GUN",
+        "id": "tommygun",
+        "copy-from": "tommygun",
+        "name": {
+            "str": "Thompson M1928A1"
+        },
+        "pocket_data": [
+            {
+                "pocket_type": "MAGAZINE_WELL",
+                "holster": true,
+                "max_contains_volume": "20 L",
+                "max_contains_weight": "1000 kg",
+                "item_restriction": [
+                    "thompson_mag",
+                    "thompson_bigmag",
+                    "thompson_drum",
+                    "thompson_makeshiftmag"
+                ],
+                "max_item_length": "1 km"
+            }
+        ]
+    },
+    {
+        "type": "GUN",
+        "id": "usp_45",
+        "copy-from": "usp_45",
+        "name": {
+            "str": "USP .45"
+        },
+        "pocket_data": [
+            {
+                "magazine_well": "250 ml",
+                "pocket_type": "MAGAZINE_WELL",
+                "holster": true,
+                "max_contains_volume": "20 L",
+                "max_contains_weight": "1000 kg",
+                "item_restriction": [
+                    "usp45mag"
+                ],
+                "max_item_length": "1 km"
+            }
+        ]
+    },
+    {
+        "type": "GUN",
+        "id": "walther_ppq_45",
+        "copy-from": "walther_ppq_45",
+        "name": {
+            "str": "Walther PPQ 45"
+        },
+        "pocket_data": [
+            {
+                "magazine_well": "240 ml",
+                "pocket_type": "MAGAZINE_WELL",
+                "holster": true,
+                "max_contains_volume": "20 L",
+                "max_contains_weight": "1000 kg",
+                "item_restriction": [
+                    "ppq45mag"
+                ],
+                "max_item_length": "1 km"
+            }
+        ]
+    },
+    {
+        "type": "GUN",
+        "id": "hptjhp",
+        "copy-from": "hptjhp",
+        "name": {
+            "str": "Hi-Point Model JHP"
+        },
+        "pocket_data": [
+            {
+                "magazine_well": "353 ml",
+                "pocket_type": "MAGAZINE_WELL",
+                "holster": true,
+                "max_contains_volume": "20 L",
+                "max_contains_weight": "1000 kg",
+                "item_restriction": [
+                    "hptjhpmag"
+                ],
+                "max_item_length": "1 km"
+            }
+        ]
+    },
+    {
+        "type": "GUN",
+        "id": "glock_21",
+        "copy-from": "glock_21",
+        "name": {
+            "str": "Glock 21"
+        },
+        "pocket_data": [
+            {
+                "magazine_well": "107 ml",
+                "pocket_type": "MAGAZINE_WELL",
+                "holster": true,
+                "max_contains_volume": "20 L",
+                "max_contains_weight": "1000 kg",
+                "item_restriction": [
+                    "glock_21mag",
+                    "glock_21mag26"
+                ],
+                "max_item_length": "1 km"
+            }
+        ]
+    }
+]

--- a/Kenan-Modpack/easy_containers/items/gun/454.json
+++ b/Kenan-Modpack/easy_containers/items/gun/454.json
@@ -1,0 +1,50 @@
+[
+    {
+        "type": "GUN",
+        "id": "raging_bull",
+        "copy-from": "raging_bull",
+        "name": {
+            "str_sp": "Taurus Raging Bull"
+        },
+        "pocket_data": [
+            {
+                "pocket_type": "MAGAZINE",
+                "holster": true,
+                "ammo_restriction": {
+                    "454": 5,
+                    "410shot": 5,
+                    "45colt": 5
+                },
+                "allowed_speedloaders": [
+                    "454_speedloader5"
+                ],
+                "max_contains_weight": "1000 kg",
+                "max_item_length": "1 km"
+            }
+        ]
+    },
+    {
+        "type": "GUN",
+        "id": "raging_judge",
+        "copy-from": "raging_judge",
+        "name": {
+            "str_sp": "Taurus Raging Judge Magnum"
+        },
+        "pocket_data": [
+            {
+                "pocket_type": "MAGAZINE",
+                "holster": true,
+                "ammo_restriction": {
+                    "454": 6,
+                    "410shot": 6,
+                    "45colt": 6
+                },
+                "allowed_speedloaders": [
+                    "454_speedloader6"
+                ],
+                "max_contains_weight": "1000 kg",
+                "max_item_length": "1 km"
+            }
+        ]
+    }
+]

--- a/Kenan-Modpack/easy_containers/items/gun/4570.json
+++ b/Kenan-Modpack/easy_containers/items/gun/4570.json
@@ -1,0 +1,59 @@
+[
+    {
+        "type": "GUN",
+        "id": "1895sbl",
+        "copy-from": "1895sbl",
+        "name": {
+            "str": "Marlin 1895 SBL"
+        },
+        "pocket_data": [
+            {
+                "pocket_type": "MAGAZINE",
+                "rigid": true,
+                "ammo_restriction": {
+                    "4570": 6
+                },
+                "max_contains_weight": "1000 kg",
+                "max_item_length": "1 km"
+            }
+        ]
+    },
+    {
+        "type": "GUN",
+        "id": "bfr",
+        "copy-from": "bfr",
+        "name": {
+            "str": "Magnum Research BFR"
+        },
+        "pocket_data": [
+            {
+                "pocket_type": "MAGAZINE",
+                "rigid": true,
+                "ammo_restriction": {
+                    "4570": 5
+                },
+                "max_contains_weight": "1000 kg",
+                "max_item_length": "1 km"
+            }
+        ]
+    },
+    {
+        "type": "GUN",
+        "id": "sharps",
+        "copy-from": "sharps",
+        "name": {
+            "str_sp": "1874 Sharps"
+        },
+        "pocket_data": [
+            {
+                "pocket_type": "MAGAZINE",
+                "rigid": true,
+                "ammo_restriction": {
+                    "4570": 1
+                },
+                "max_contains_weight": "1000 kg",
+                "max_item_length": "1 km"
+            }
+        ]
+    }
+]

--- a/Kenan-Modpack/easy_containers/items/gun/45colt.json
+++ b/Kenan-Modpack/easy_containers/items/gun/45colt.json
@@ -1,0 +1,60 @@
+[
+    {
+        "type": "GUN",
+        "id": "bond_410",
+        "copy-from": "bond_410",
+        "name": {
+            "str": "Bond Arms Derringer"
+        },
+        "pocket_data": [
+            {
+                "pocket_type": "MAGAZINE",
+                "rigid": true,
+                "ammo_restriction": {
+                    "45colt": 2,
+                    "410shot": 2
+                },
+                "max_contains_weight": "1000 kg",
+                "max_item_length": "1 km"
+            }
+        ]
+    },
+    {
+        "type": "GUN",
+        "id": "colt_lightning",
+        "copy-from": "colt_lightning",
+        "name": {
+            "str": "Colt Lightning .45 Carbine"
+        },
+        "pocket_data": [
+            {
+                "pocket_type": "MAGAZINE",
+                "rigid": true,
+                "ammo_restriction": {
+                    "45colt": 14
+                },
+                "max_contains_weight": "1000 kg",
+                "max_item_length": "1 km"
+            }
+        ]
+    },
+    {
+        "type": "GUN",
+        "id": "colt_saa",
+        "copy-from": "colt_saa",
+        "name": {
+            "str_sp": "Uberti Cattleman"
+        },
+        "pocket_data": [
+            {
+                "pocket_type": "MAGAZINE",
+                "rigid": true,
+                "ammo_restriction": {
+                    "45colt": 6
+                },
+                "max_contains_weight": "1000 kg",
+                "max_item_length": "1 km"
+            }
+        ]
+    }
+]

--- a/Kenan-Modpack/easy_containers/items/gun/46.json
+++ b/Kenan-Modpack/easy_containers/items/gun/46.json
@@ -1,0 +1,23 @@
+[
+    {
+        "type": "GUN",
+        "id": "hk_mp7",
+        "copy-from": "hk_mp7",
+        "name": {
+            "str": "H&K MP7A2"
+        },
+        "pocket_data": [
+            {
+                "pocket_type": "MAGAZINE_WELL",
+                "holster": true,
+                "max_contains_volume": "20 L",
+                "max_contains_weight": "1000 kg",
+                "item_restriction": [
+                    "hk46mag",
+                    "hk46bigmag"
+                ],
+                "max_item_length": "1 km"
+            }
+        ]
+    }
+]

--- a/Kenan-Modpack/easy_containers/items/gun/460.json
+++ b/Kenan-Modpack/easy_containers/items/gun/460.json
@@ -1,0 +1,26 @@
+[
+    {
+        "type": "GUN",
+        "id": "m1911-460",
+        "copy-from": "m1911-460",
+        "name": {
+            "str": "1911-460"
+        },
+        "pocket_data": [
+            {
+                "magazine_well": "250 ml",
+                "pocket_type": "MAGAZINE_WELL",
+                "holster": true,
+                "max_contains_volume": "20 L",
+                "max_contains_weight": "1000 kg",
+                "item_restriction": [
+                    "m1911mag",
+                    "m1911bigmag",
+                    "m1911mag",
+                    "m1911bigmag"
+                ],
+                "max_item_length": "1 km"
+            }
+        ]
+    }
+]

--- a/Kenan-Modpack/easy_containers/items/gun/50.json
+++ b/Kenan-Modpack/easy_containers/items/gun/50.json
@@ -1,0 +1,121 @@
+[
+    {
+        "type": "GUN",
+        "id": "m107a1",
+        "copy-from": "m107a1",
+        "name": {
+            "str_sp": "Barrett M107A1"
+        },
+        "pocket_data": [
+            {
+                "pocket_type": "MAGAZINE_WELL",
+                "holster": true,
+                "max_contains_volume": "20 L",
+                "max_contains_weight": "1000 kg",
+                "item_restriction": [
+                    "m107a1mag"
+                ],
+                "max_item_length": "1 km"
+            }
+        ]
+    },
+    {
+        "type": "GUN",
+        "id": "m2browning",
+        "copy-from": "m2browning",
+        "name": {
+            "str_sp": "M2HB Browning HMG"
+        },
+        "pocket_data": [
+            {
+                "pocket_type": "MAGAZINE_WELL",
+                "holster": true,
+                "max_contains_volume": "20 L",
+                "max_contains_weight": "1000 kg",
+                "item_restriction": [
+                    "belt50"
+                ],
+                "max_item_length": "1 km"
+            }
+        ]
+    },
+    {
+        "type": "GUN",
+        "id": "m2browning_sawn",
+        "copy-from": "m2browning_sawn",
+        "name": {
+            "str": ".50 caliber rifle"
+        },
+        "pocket_data": [
+            {
+                "pocket_type": "MAGAZINE",
+                "holster": true,
+                "rigid": true,
+                "ammo_restriction": {
+                    "50": 1
+                },
+                "max_contains_weight": "1000 kg",
+                "max_item_length": "1 km"
+            }
+        ]
+    },
+    {
+        "type": "GUN",
+        "id": "as50",
+        "copy-from": "as50",
+        "name": {
+            "str": "AI AS50"
+        },
+        "pocket_data": [
+            {
+                "pocket_type": "MAGAZINE_WELL",
+                "holster": true,
+                "max_contains_volume": "20 L",
+                "max_contains_weight": "1000 kg",
+                "item_restriction": [
+                    "as50mag"
+                ],
+                "max_item_length": "1 km"
+            }
+        ]
+    },
+    {
+        "type": "GUN",
+        "id": "tac50",
+        "copy-from": "tac50",
+        "name": {
+            "str": "McMillan TAC-50"
+        },
+        "pocket_data": [
+            {
+                "pocket_type": "MAGAZINE_WELL",
+                "holster": true,
+                "max_contains_volume": "20 L",
+                "max_contains_weight": "1000 kg",
+                "item_restriction": [
+                    "tac50mag"
+                ],
+                "max_item_length": "1 km"
+            }
+        ]
+    },
+    {
+        "type": "GUN",
+        "id": "bfg50",
+        "copy-from": "bfg50",
+        "name": {
+            "str": "Serbu BFG-50"
+        },
+        "pocket_data": [
+            {
+                "pocket_type": "MAGAZINE",
+                "rigid": true,
+                "ammo_restriction": {
+                    "50": 1
+                },
+                "max_contains_weight": "1000 kg",
+                "max_item_length": "1 km"
+            }
+        ]
+    }
+]

--- a/Kenan-Modpack/easy_containers/items/gun/500.json
+++ b/Kenan-Modpack/easy_containers/items/gun/500.json
@@ -1,0 +1,43 @@
+[
+    {
+        "type": "GUN",
+        "id": "bh_m89",
+        "copy-from": "bh_m89",
+        "name": {
+            "str_sp": "Big Horn Model 89"
+        },
+        "pocket_data": [
+            {
+                "pocket_type": "MAGAZINE",
+                "rigid": true,
+                "ammo_restriction": {
+                    "500": 7
+                },
+                "max_contains_weight": "1000 kg",
+                "max_item_length": "1 km"
+            }
+        ]
+    },
+    {
+        "type": "GUN",
+        "id": "sw_500",
+        "copy-from": "sw_500",
+        "name": {
+            "str_sp": "S&W 500"
+        },
+        "pocket_data": [
+            {
+                "pocket_type": "MAGAZINE",
+                "holster": true,
+                "ammo_restriction": {
+                    "500": 5
+                },
+                "allowed_speedloaders": [
+                    "500_speedloader5"
+                ],
+                "max_contains_weight": "1000 kg",
+                "max_item_length": "1 km"
+            }
+        ]
+    }
+]

--- a/Kenan-Modpack/easy_containers/items/gun/545x39.json
+++ b/Kenan-Modpack/easy_containers/items/gun/545x39.json
@@ -1,0 +1,23 @@
+[
+    {
+        "type": "GUN",
+        "id": "ak74",
+        "copy-from": "ak74",
+        "name": {
+            "str": "AK-74M"
+        },
+        "pocket_data": [
+            {
+                "pocket_type": "MAGAZINE_WELL",
+                "holster": true,
+                "max_contains_volume": "20 L",
+                "max_contains_weight": "1000 kg",
+                "item_restriction": [
+                    "ak74mag",
+                    "rpk74mag"
+                ],
+                "max_item_length": "1 km"
+            }
+        ]
+    }
+]

--- a/Kenan-Modpack/easy_containers/items/gun/57.json
+++ b/Kenan-Modpack/easy_containers/items/gun/57.json
@@ -1,0 +1,44 @@
+[
+    {
+        "type": "GUN",
+        "id": "fn57",
+        "copy-from": "fn57",
+        "name": {
+            "str": "FN Five-Seven"
+        },
+        "pocket_data": [
+            {
+                "magazine_well": "250 ml",
+                "pocket_type": "MAGAZINE_WELL",
+                "holster": true,
+                "max_contains_volume": "20 L",
+                "max_contains_weight": "1000 kg",
+                "item_restriction": [
+                    "fn57mag"
+                ],
+                "max_item_length": "1 km"
+            }
+        ]
+    },
+    {
+        "type": "GUN",
+        "id": "fn_p90",
+        "copy-from": "fn_p90",
+        "name": {
+            "str": "FN P90"
+        },
+        "pocket_data": [
+            {
+                "magazine_well": "500 ml",
+                "pocket_type": "MAGAZINE_WELL",
+                "holster": true,
+                "max_contains_volume": "20 L",
+                "max_contains_weight": "1000 kg",
+                "item_restriction": [
+                    "fnp90mag"
+                ],
+                "max_item_length": "1 km"
+            }
+        ]
+    }
+]

--- a/Kenan-Modpack/easy_containers/items/gun/5x50.json
+++ b/Kenan-Modpack/easy_containers/items/gun/5x50.json
@@ -1,0 +1,44 @@
+[
+    {
+        "type": "GUN",
+        "id": "needlegun",
+        "copy-from": "needlegun",
+        "name": {
+            "str": "RM216 SPIW"
+        },
+        "pocket_data": [
+            {
+                "pocket_type": "MAGAZINE_WELL",
+                "holster": true,
+                "max_contains_volume": "20 L",
+                "max_contains_weight": "1000 kg",
+                "item_restriction": [
+                    "5x50_100_mag",
+                    "5x50_50_mag"
+                ],
+                "max_item_length": "1 km"
+            }
+        ]
+    },
+    {
+        "type": "GUN",
+        "id": "needlepistol",
+        "copy-from": "needlepistol",
+        "name": {
+            "str": "RM232 IDW"
+        },
+        "pocket_data": [
+            {
+                "pocket_type": "MAGAZINE_WELL",
+                "holster": true,
+                "max_contains_volume": "20 L",
+                "max_contains_weight": "1000 kg",
+                "item_restriction": [
+                    "5x50_50_mag",
+                    "5x50_100_mag"
+                ],
+                "max_item_length": "1 km"
+            }
+        ]
+    }
+]

--- a/Kenan-Modpack/easy_containers/items/gun/66mm.json
+++ b/Kenan-Modpack/easy_containers/items/gun/66mm.json
@@ -1,0 +1,23 @@
+[
+    {
+        "type": "GUN",
+        "id": "m202_flash",
+        "copy-from": "m202_flash",
+        "name": {
+            "str_sp": "M202A1 FLASH"
+        },
+        "pocket_data": [
+            {
+                "magazine_well": "500 ml",
+                "pocket_type": "MAGAZINE_WELL",
+                "holster": true,
+                "max_contains_volume": "20 L",
+                "max_contains_weight": "1000 kg",
+                "item_restriction": [
+                    "m74_clip"
+                ],
+                "max_item_length": "1 km"
+            }
+        ]
+    }
+]

--- a/Kenan-Modpack/easy_containers/items/gun/700nx.json
+++ b/Kenan-Modpack/easy_containers/items/gun/700nx.json
@@ -1,0 +1,21 @@
+[
+    {
+        "type": "GUN",
+        "id": "trex_gun",
+        "copy-from": "trex_gun",
+        "name": {
+            "str": "Elephant gun"
+        },
+        "pocket_data": [
+            {
+                "pocket_type": "MAGAZINE",
+                "rigid": true,
+                "ammo_restriction": {
+                    "700nx": 1
+                },
+                "max_contains_weight": "1000 kg",
+                "max_item_length": "1 km"
+            }
+        ]
+    }
+]

--- a/Kenan-Modpack/easy_containers/items/gun/762.json
+++ b/Kenan-Modpack/easy_containers/items/gun/762.json
@@ -1,0 +1,118 @@
+[
+    {
+        "type": "GUN",
+        "id": "ak47",
+        "copy-from": "ak47",
+        "name": {
+            "str": "AKM"
+        },
+        "pocket_data": [
+            {
+                "pocket_type": "MAGAZINE_WELL",
+                "holster": true,
+                "max_contains_volume": "20 L",
+                "max_contains_weight": "1000 kg",
+                "item_restriction": [
+                    "akmag30",
+                    "akmag10",
+                    "akmag20",
+                    "akmag40",
+                    "akdrum75"
+                ],
+                "max_item_length": "1 km"
+            }
+        ]
+    },
+    {
+        "type": "GUN",
+        "id": "arx160",
+        "copy-from": "arx160",
+        "name": {
+            "str_sp": "Beretta ARX-160"
+        },
+        "pocket_data": [
+            {
+                "pocket_type": "MAGAZINE_WELL",
+                "holster": true,
+                "max_contains_volume": "20 L",
+                "max_contains_weight": "1000 kg",
+                "item_restriction": [
+                    "akmag30",
+                    "akmag10",
+                    "akmag20",
+                    "akmag40"
+                ],
+                "max_item_length": "1 km"
+            }
+        ]
+    },
+    {
+        "type": "GUN",
+        "id": "sks",
+        "copy-from": "sks",
+        "name": {
+            "str": "SKS"
+        },
+        "pocket_data": [
+            {
+                "pocket_type": "MAGAZINE",
+                "ammo_restriction": {
+                    "762": 10
+                },
+                "allowed_speedloaders": [
+                    "762x39_clip"
+                ],
+                "max_contains_weight": "1000 kg",
+                "max_item_length": "1 km"
+            }
+        ]
+    },
+    {
+        "type": "GUN",
+        "id": "aksemi",
+        "copy-from": "aksemi",
+        "name": {
+            "str": "AK-47"
+        },
+        "pocket_data": [
+            {
+                "pocket_type": "MAGAZINE_WELL",
+                "holster": true,
+                "max_contains_volume": "20 L",
+                "max_contains_weight": "1000 kg",
+                "item_restriction": [
+                    "akmag30",
+                    "akmag10",
+                    "akmag20",
+                    "akmag40",
+                    "akdrum75"
+                ],
+                "max_item_length": "1 km"
+            }
+        ]
+    },
+    {
+        "type": "GUN",
+        "id": "draco",
+        "copy-from": "draco",
+        "name": {
+            "str": "Mini Draco"
+        },
+        "pocket_data": [
+            {
+                "pocket_type": "MAGAZINE_WELL",
+                "holster": true,
+                "max_contains_volume": "20 L",
+                "max_contains_weight": "1000 kg",
+                "item_restriction": [
+                    "akmag30",
+                    "akmag10",
+                    "akmag20",
+                    "akmag40",
+                    "akdrum75"
+                ],
+                "max_item_length": "1 km"
+            }
+        ]
+    }
+]

--- a/Kenan-Modpack/easy_containers/items/gun/762R.json
+++ b/Kenan-Modpack/easy_containers/items/gun/762R.json
@@ -1,0 +1,23 @@
+[
+    {
+        "type": "GUN",
+        "id": "mosin91_30",
+        "copy-from": "mosin91_30",
+        "name": {
+            "str_sp": "Mosin-Nagant 1891/30"
+        },
+        "pocket_data": [
+            {
+                "pocket_type": "MAGAZINE",
+                "ammo_restriction": {
+                    "762R": 5
+                },
+                "allowed_speedloaders": [
+                    "762R_clip"
+                ],
+                "max_contains_weight": "1000 kg",
+                "max_item_length": "1 km"
+            }
+        ]
+    }
+]

--- a/Kenan-Modpack/easy_containers/items/gun/762x25.json
+++ b/Kenan-Modpack/easy_containers/items/gun/762x25.json
@@ -1,0 +1,44 @@
+[
+    {
+        "type": "GUN",
+        "id": "ppsh",
+        "copy-from": "ppsh",
+        "name": {
+            "str": "PPSh-41"
+        },
+        "pocket_data": [
+            {
+                "pocket_type": "MAGAZINE_WELL",
+                "holster": true,
+                "max_contains_volume": "20 L",
+                "max_contains_weight": "1000 kg",
+                "item_restriction": [
+                    "ppshmag",
+                    "ppshdrum"
+                ],
+                "max_item_length": "1 km"
+            }
+        ]
+    },
+    {
+        "type": "GUN",
+        "id": "tokarev",
+        "copy-from": "tokarev",
+        "name": {
+            "str_sp": "Tokarev TT-33"
+        },
+        "pocket_data": [
+            {
+                "magazine_well": "250 ml",
+                "pocket_type": "MAGAZINE_WELL",
+                "holster": true,
+                "max_contains_volume": "20 L",
+                "max_contains_weight": "1000 kg",
+                "item_restriction": [
+                    "tokarevmag"
+                ],
+                "max_item_length": "1 km"
+            }
+        ]
+    }
+]

--- a/Kenan-Modpack/easy_containers/items/gun/84x246mm.json
+++ b/Kenan-Modpack/easy_containers/items/gun/84x246mm.json
@@ -1,0 +1,21 @@
+[
+    {
+        "type": "GUN",
+        "id": "m3_carlgustav",
+        "copy-from": "m3_carlgustav",
+        "name": {
+            "str": "M3 recoilless rifle"
+        },
+        "pocket_data": [
+            {
+                "pocket_type": "MAGAZINE",
+                "rigid": true,
+                "ammo_restriction": {
+                    "84x246mm": 1
+                },
+                "max_contains_weight": "1000 kg",
+                "max_item_length": "1 km"
+            }
+        ]
+    }
+]

--- a/Kenan-Modpack/easy_containers/items/gun/8x40mm.json
+++ b/Kenan-Modpack/easy_containers/items/gun/8x40mm.json
@@ -1,0 +1,151 @@
+[
+    {
+        "type": "GUN",
+        "id": "rm103a_pistol",
+        "copy-from": "rm103a_pistol",
+        "name": {
+            "str": "RM103A automagnum"
+        },
+        "pocket_data": [
+            {
+                "pocket_type": "MAGAZINE_WELL",
+                "holster": true,
+                "magazine_well": "250 ml",
+                "max_contains_volume": "20 L",
+                "max_contains_weight": "1000 kg",
+                "item_restriction": [
+                    "8x40_10_mag",
+                    "8x40_25_mag"
+                ],
+                "max_item_length": "1 km"
+            }
+        ]
+    },
+    {
+        "type": "GUN",
+        "id": "rm11b_sniper_rifle",
+        "copy-from": "rm11b_sniper_rifle",
+        "name": {
+            "str": "RM11B scout rifle"
+        },
+        "pocket_data": [
+            {
+                "pocket_type": "MAGAZINE_WELL",
+                "holster": true,
+                "max_contains_volume": "20 L",
+                "max_contains_weight": "1000 kg",
+                "item_restriction": [
+                    "8x40_10_mag",
+                    "8x40_25_mag"
+                ],
+                "max_item_length": "1 km"
+            }
+        ]
+    },
+    {
+        "type": "GUN",
+        "id": "rm2000_smg",
+        "copy-from": "rm2000_smg",
+        "name": {
+            "str": "RM2000 submachine gun"
+        },
+        "pocket_data": [
+            {
+                "pocket_type": "MAGAZINE_WELL",
+                "holster": true,
+                "max_contains_volume": "20 L",
+                "max_contains_weight": "1000 kg",
+                "item_restriction": [
+                    "8x40_25_mag",
+                    "8x40_10_mag"
+                ],
+                "max_item_length": "1 km"
+            }
+        ]
+    },
+    {
+        "type": "GUN",
+        "id": "rm298",
+        "copy-from": "rm298",
+        "name": {
+            "str": "RM298 HMG"
+        },
+        "pocket_data": [
+            {
+                "pocket_type": "MAGAZINE_WELL",
+                "holster": true,
+                "max_contains_volume": "20 L",
+                "max_contains_weight": "1000 kg",
+                "item_restriction": [
+                    "8x40_500_mag",
+                    "8x40_250_mag"
+                ],
+                "max_item_length": "1 km"
+            }
+        ]
+    },
+    {
+        "type": "GUN",
+        "id": "rm51_assault_rifle",
+        "copy-from": "rm51_assault_rifle",
+        "name": {
+            "str": "RM51 assault rifle"
+        },
+        "pocket_data": [
+            {
+                "pocket_type": "MAGAZINE_WELL",
+                "holster": true,
+                "max_contains_volume": "20 L",
+                "max_contains_weight": "1000 kg",
+                "item_restriction": [
+                    "8x40_50_mag",
+                    "8x40_100_mag"
+                ],
+                "max_item_length": "1 km"
+            }
+        ]
+    },
+    {
+        "type": "GUN",
+        "id": "rm614_lmg",
+        "copy-from": "rm614_lmg",
+        "name": {
+            "str": "RM614 LMG"
+        },
+        "pocket_data": [
+            {
+                "pocket_type": "MAGAZINE_WELL",
+                "holster": true,
+                "max_contains_volume": "20 L",
+                "max_contains_weight": "1000 kg",
+                "item_restriction": [
+                    "8x40_250_mag",
+                    "8x40_500_mag"
+                ],
+                "max_item_length": "1 km"
+            }
+        ]
+    },
+    {
+        "type": "GUN",
+        "id": "rm88_battle_rifle",
+        "copy-from": "rm88_battle_rifle",
+        "name": {
+            "str": "RM88 battle rifle"
+        },
+        "pocket_data": [
+            {
+                "pocket_type": "MAGAZINE_WELL",
+                "holster": true,
+                "max_contains_volume": "20 L",
+                "max_contains_weight": "1000 kg",
+                "item_restriction": [
+                    "8x40_100_mag",
+                    "8x40_50_mag",
+                    "8x40_250_mag"
+                ],
+                "max_item_length": "1 km"
+            }
+        ]
+    }
+]

--- a/Kenan-Modpack/easy_containers/items/gun/9mm.json
+++ b/Kenan-Modpack/easy_containers/items/gun/9mm.json
@@ -1,0 +1,800 @@
+[
+    {
+        "type": "GUN",
+        "id": "90two",
+        "copy-from": "90two",
+        "name": {
+            "str": "Beretta 90-two"
+        },
+        "pocket_data": [
+            {
+                "magazine_well": "250 ml",
+                "pocket_type": "MAGAZINE_WELL",
+                "holster": true,
+                "max_contains_volume": "20 L",
+                "max_contains_weight": "1000 kg",
+                "item_restriction": [
+                    "m9mag",
+                    "m9mag_10rd",
+                    "m9mag_17rd",
+                    "m9mag_18rd",
+                    "m9mag_20rd",
+                    "m9bigmag",
+                    "m9mag_32rd",
+                    "m9mag_35rd"
+                ],
+                "max_item_length": "1 km"
+            }
+        ]
+    },
+    {
+        "type": "GUN",
+        "id": "calico",
+        "copy-from": "calico",
+        "name": {
+            "str_sp": "Calico M960"
+        },
+        "pocket_data": [
+            {
+                "pocket_type": "MAGAZINE_WELL",
+                "holster": true,
+                "max_contains_volume": "20 L",
+                "max_contains_weight": "1000 kg",
+                "item_restriction": [
+                    "calicomag",
+                    "calicomag_100rd"
+                ],
+                "max_item_length": "1 km"
+            }
+        ]
+    },
+    {
+        "type": "GUN",
+        "id": "cx4",
+        "copy-from": "cx4",
+        "name": {
+            "str": "Cx4 Storm"
+        },
+        "pocket_data": [
+            {
+                "pocket_type": "MAGAZINE_WELL",
+                "holster": true,
+                "max_contains_volume": "20 L",
+                "max_contains_weight": "1000 kg",
+                "item_restriction": [
+                    "m9bigmag",
+                    "m9mag_10rd",
+                    "m9mag",
+                    "m9mag_17rd",
+                    "m9mag_18rd",
+                    "m9mag_20rd",
+                    "m9mag_32rd",
+                    "m9mag_35rd"
+                ],
+                "max_item_length": "1 km"
+            }
+        ]
+    },
+    {
+        "type": "GUN",
+        "id": "glock_19",
+        "copy-from": "glock_19",
+        "name": {
+            "str": "Glock 19"
+        },
+        "pocket_data": [
+            {
+                "magazine_well": "250 ml",
+                "pocket_type": "MAGAZINE_WELL",
+                "holster": true,
+                "max_contains_volume": "20 L",
+                "max_contains_weight": "1000 kg",
+                "item_restriction": [
+                    "glockmag",
+                    "glockbigmag",
+                    "glock17_17",
+                    "glock17_22",
+                    "glock_drum_50rd",
+                    "glock_drum_100rd"
+                ],
+                "max_item_length": "1 km"
+            }
+        ]
+    },
+    {
+        "type": "GUN",
+        "id": "hk_mp5",
+        "copy-from": "hk_mp5",
+        "name": {
+            "str": "H&K MP5A2"
+        },
+        "pocket_data": [
+            {
+                "pocket_type": "MAGAZINE_WELL",
+                "holster": true,
+                "max_contains_volume": "20 L",
+                "max_contains_weight": "1000 kg",
+                "item_restriction": [
+                    "mp5mag",
+                    "mp5mag_10rd",
+                    "mp5mag_15rd",
+                    "mp5mag_20rd",
+                    "mp5mag_38rd",
+                    "mp5mag_40rd",
+                    "mp5bigmag",
+                    "mp5mag_100rd"
+                ],
+                "max_item_length": "1 km"
+            }
+        ]
+    },
+    {
+        "type": "GUN",
+        "id": "briefcase_smg",
+        "copy-from": "briefcase_smg",
+        "name": {
+            "str": "H&K operational briefcase"
+        },
+        "pocket_data": [
+            {
+                "pocket_type": "MAGAZINE_WELL",
+                "rigid": true,
+                "holster": true,
+                "max_contains_volume": "20 L",
+                "max_contains_weight": "1000 kg",
+                "item_restriction": [
+                    "mp5mag",
+                    "mp5mag_10rd",
+                    "mp5mag_15rd",
+                    "mp5mag_20rd"
+                ],
+                "max_item_length": "1 km"
+            }
+        ]
+    },
+    {
+        "type": "GUN",
+        "id": "p08",
+        "copy-from": "p08",
+        "name": {
+            "str": "Luger P08"
+        },
+        "pocket_data": [
+            {
+                "magazine_well": "55 ml",
+                "pocket_type": "MAGAZINE_WELL",
+                "holster": true,
+                "max_contains_volume": "20 L",
+                "max_contains_weight": "1000 kg",
+                "item_restriction": [
+                    "p08mag_8rd",
+                    "p08mag_32rd"
+                ],
+                "max_item_length": "1 km"
+            }
+        ]
+    },
+    {
+        "type": "GUN",
+        "id": "mp18",
+        "copy-from": "mp18",
+        "name": {
+            "str": "MP 18"
+        },
+        "pocket_data": [
+            {
+                "magazine_well": "30 ml",
+                "pocket_type": "MAGAZINE_WELL",
+                "holster": true,
+                "max_contains_volume": "20 L",
+                "max_contains_weight": "1000 kg",
+                "item_restriction": [
+                    "p08mag_32rd",
+                    "p08mag_8rd"
+                ],
+                "max_item_length": "1 km"
+            }
+        ]
+    },
+    {
+        "type": "GUN",
+        "id": "mauser_c96",
+        "copy-from": "mauser_c96",
+        "name": {
+            "str": "Broomhandle Mauser"
+        },
+        "pocket_data": [
+            {
+                "pocket_type": "MAGAZINE",
+                "ammo_restriction": {
+                    "9mm": 10
+                },
+                "allowed_speedloaders": [
+                    "clip9mm_10rd"
+                ],
+                "max_contains_weight": "1000 kg",
+                "max_item_length": "1 km"
+            }
+        ]
+    },
+    {
+        "type": "GUN",
+        "id": "mauser_m714",
+        "copy-from": "mauser_m714",
+        "name": {
+            "str": "detachable-magazine Mauser"
+        },
+        "pocket_data": [
+            {
+                "magazine_well": "60 ml",
+                "pocket_type": "MAGAZINE_WELL",
+                "holster": true,
+                "max_contains_volume": "20 L",
+                "max_contains_weight": "1000 kg",
+                "item_restriction": [
+                    "mausermag_20rd",
+                    "mausermag_10rd"
+                ],
+                "max_item_length": "1 km"
+            }
+        ]
+    },
+    {
+        "type": "GUN",
+        "id": "mp40",
+        "copy-from": "mp40",
+        "name": {
+            "str": "MP 40"
+        },
+        "pocket_data": [
+            {
+                "magazine_well": "40 ml",
+                "pocket_type": "MAGAZINE_WELL",
+                "holster": true,
+                "max_contains_volume": "20 L",
+                "max_contains_weight": "1000 kg",
+                "item_restriction": [
+                    "mp40mag_32rd"
+                ],
+                "max_item_length": "1 km"
+            }
+        ]
+    },
+    {
+        "type": "GUN",
+        "id": "ksub2000",
+        "copy-from": "ksub2000",
+        "name": {
+            "str_sp": "Kel-Tec SUB-2000"
+        },
+        "pocket_data": [
+            {
+                "magazine_well": "250 ml",
+                "pocket_type": "MAGAZINE_WELL",
+                "holster": true,
+                "max_contains_volume": "20 L",
+                "max_contains_weight": "1000 kg",
+                "item_restriction": [
+                    "glockmag",
+                    "glockbigmag",
+                    "glock17_17",
+                    "glock17_22",
+                    "glock_drum_50rd",
+                    "glock_drum_100rd"
+                ],
+                "max_item_length": "1 km"
+            }
+        ]
+    },
+    {
+        "type": "GUN",
+        "id": "m9",
+        "copy-from": "m9",
+        "name": {
+            "str_sp": "Beretta M9A1"
+        },
+        "pocket_data": [
+            {
+                "magazine_well": "250 ml",
+                "pocket_type": "MAGAZINE_WELL",
+                "holster": true,
+                "max_contains_volume": "20 L",
+                "max_contains_weight": "1000 kg",
+                "item_restriction": [
+                    "m9mag",
+                    "m9mag_10rd",
+                    "m9mag_17rd",
+                    "m9mag_18rd",
+                    "m9mag_20rd",
+                    "m9bigmag",
+                    "m9mag_32rd",
+                    "m9mag_35rd"
+                ],
+                "max_item_length": "1 km"
+            }
+        ]
+    },
+    {
+        "type": "GUN",
+        "id": "px4",
+        "copy-from": "px4",
+        "name": {
+            "str": "Beretta Px4 Storm"
+        },
+        "pocket_data": [
+            {
+                "magazine_well": "250 ml",
+                "pocket_type": "MAGAZINE_WELL",
+                "holster": true,
+                "max_contains_volume": "20 L",
+                "max_contains_weight": "1000 kg",
+                "item_restriction": [
+                    "px4mag",
+                    "px4mag_10rd",
+                    "px4mag_15rd",
+                    "px4mag_20rd"
+                ],
+                "max_item_length": "1 km"
+            }
+        ]
+    },
+    {
+        "type": "GUN",
+        "id": "rifle_9mm",
+        "copy-from": "rifle_9mm",
+        "name": {
+            "str": "pipe rifle: 9x19mm",
+            "str_pl": "pipe rifles: 9x19mm"
+        },
+        "pocket_data": [
+            {
+                "pocket_type": "MAGAZINE",
+                "rigid": true,
+                "ammo_restriction": {
+                    "9mm": 1
+                },
+                "max_contains_weight": "1000 kg",
+                "max_item_length": "1 km"
+            }
+        ]
+    },
+    {
+        "type": "GUN",
+        "id": "smg_9mm",
+        "copy-from": "smg_9mm",
+        "name": {
+            "str": "Luty SMG: 9x19mm",
+            "str_pl": "Luty SMGs: 9x19mm"
+        },
+        "pocket_data": [
+            {
+                "pocket_type": "MAGAZINE_WELL",
+                "holster": true,
+                "max_contains_volume": "20 L",
+                "max_contains_weight": "1000 kg",
+                "item_restriction": [
+                    "survivor9mm_mag",
+                    "stenmag"
+                ],
+                "max_item_length": "1 km"
+            }
+        ]
+    },
+    {
+        "type": "GUN",
+        "id": "sten",
+        "copy-from": "sten",
+        "name": {
+            "str": "STEN"
+        },
+        "pocket_data": [
+            {
+                "pocket_type": "MAGAZINE_WELL",
+                "holster": true,
+                "max_contains_volume": "20 L",
+                "max_contains_weight": "1000 kg",
+                "item_restriction": [
+                    "stenmag",
+                    "survivor9mm_mag"
+                ],
+                "max_item_length": "1 km"
+            }
+        ]
+    },
+    {
+        "type": "GUN",
+        "id": "tec9",
+        "copy-from": "tec9",
+        "name": {
+            "str_sp": "TEC-9"
+        },
+        "pocket_data": [
+            {
+                "pocket_type": "MAGAZINE_WELL",
+                "holster": true,
+                "max_contains_volume": "20 L",
+                "max_contains_weight": "1000 kg",
+                "item_restriction": [
+                    "tec9mag",
+                    "tec9mag_10rd",
+                    "tec9mag_20rd",
+                    "tec9mag_30rd",
+                    "tec9mag_36rd",
+                    "tec9mag_50rd",
+                    "tec9mag_72rd"
+                ],
+                "max_item_length": "1 km"
+            }
+        ]
+    },
+    {
+        "type": "GUN",
+        "id": "usp_9mm",
+        "copy-from": "usp_9mm",
+        "name": {
+            "str_sp": "USP 9x19mm"
+        },
+        "pocket_data": [
+            {
+                "magazine_well": "250 ml",
+                "pocket_type": "MAGAZINE_WELL",
+                "holster": true,
+                "max_contains_volume": "20 L",
+                "max_contains_weight": "1000 kg",
+                "item_restriction": [
+                    "usp9mag",
+                    "usp9mag_10rd",
+                    "usp9mag_18rd",
+                    "usp9mag_20rd",
+                    "usp9mag_32rd"
+                ],
+                "max_item_length": "1 km"
+            }
+        ]
+    },
+    {
+        "type": "GUN",
+        "id": "uzi",
+        "copy-from": "uzi",
+        "name": {
+            "str_sp": "Uzi 9x19mm"
+        },
+        "pocket_data": [
+            {
+                "pocket_type": "MAGAZINE_WELL",
+                "holster": true,
+                "max_contains_volume": "20 L",
+                "max_contains_weight": "1000 kg",
+                "item_restriction": [
+                    "uzimag",
+                    "uzimag_20rd",
+                    "uzimag_25rd",
+                    "uzimag_40rd",
+                    "uzimag_50rd",
+                    "uzimag_100rd"
+                ],
+                "max_item_length": "1 km"
+            }
+        ]
+    },
+    {
+        "type": "GUN",
+        "id": "glock_17",
+        "copy-from": "glock_17",
+        "name": {
+            "str": "Glock 17"
+        },
+        "pocket_data": [
+            {
+                "magazine_well": "250 ml",
+                "pocket_type": "MAGAZINE_WELL",
+                "holster": true,
+                "max_contains_volume": "20 L",
+                "max_contains_weight": "1000 kg",
+                "item_restriction": [
+                    "glock17_17",
+                    "glock17_22",
+                    "glock_drum_50rd",
+                    "glock_drum_100rd",
+                    "glockbigmag"
+                ],
+                "max_item_length": "1 km"
+            }
+        ]
+    },
+    {
+        "type": "GUN",
+        "id": "kpf9",
+        "copy-from": "kpf9",
+        "name": {
+            "str": "Kel-Tec PF-9"
+        },
+        "pocket_data": [
+            {
+                "magazine_well": "65 ml",
+                "pocket_type": "MAGAZINE_WELL",
+                "holster": true,
+                "max_contains_volume": "20 L",
+                "max_contains_weight": "1000 kg",
+                "item_restriction": [
+                    "kpf9mag",
+                    "kpf9mag_8rd"
+                ],
+                "max_item_length": "1 km"
+            }
+        ]
+    },
+    {
+        "type": "GUN",
+        "id": "m11",
+        "copy-from": "m11",
+        "name": {
+            "str": "M11"
+        },
+        "pocket_data": [
+            {
+                "magazine_well": "250 ml",
+                "pocket_type": "MAGAZINE_WELL",
+                "holster": true,
+                "max_contains_volume": "20 L",
+                "max_contains_weight": "1000 kg",
+                "item_restriction": [
+                    "p228mag_13rd_9x19mm"
+                ],
+                "max_item_length": "1 km"
+            }
+        ]
+    },
+    {
+        "type": "GUN",
+        "id": "m17",
+        "copy-from": "m17",
+        "name": {
+            "str": "M17"
+        },
+        "pocket_data": [
+            {
+                "magazine_well": "250 ml",
+                "pocket_type": "MAGAZINE_WELL",
+                "holster": true,
+                "max_contains_volume": "20 L",
+                "max_contains_weight": "1000 kg",
+                "item_restriction": [
+                    "p320mag_10rd_9x19mm",
+                    "p320mag_17rd_9x19mm",
+                    "p320mag_21rd_9x19mm"
+                ],
+                "max_item_length": "1 km"
+            }
+        ]
+    },
+    {
+        "type": "GUN",
+        "id": "p226_9mm",
+        "copy-from": "p226_9mm",
+        "name": {
+            "str": "SIG P226 MK25"
+        },
+        "pocket_data": [
+            {
+                "magazine_well": "250 ml",
+                "pocket_type": "MAGAZINE_WELL",
+                "holster": true,
+                "max_contains_volume": "20 L",
+                "max_contains_weight": "1000 kg",
+                "item_restriction": [
+                    "p226mag_10rd_9x19mm",
+                    "p226mag_15rd_9x19mm"
+                ],
+                "max_item_length": "1 km"
+            }
+        ]
+    },
+    {
+        "type": "GUN",
+        "id": "sp2022",
+        "copy-from": "sp2022",
+        "name": {
+            "str": "SIG Pro SP2022 9mm"
+        },
+        "pocket_data": [
+            {
+                "pocket_type": "MAGAZINE_WELL",
+                "holster": true,
+                "max_contains_volume": "20 L",
+                "magazine_well": "250 ml",
+                "max_contains_weight": "1000 kg",
+                "item_restriction": [
+                    "sp2022mag_10rd_9mm",
+                    "sp2022mag_12rd_9mm",
+                    "sp2022mag_15rd_9mm"
+                ],
+                "max_item_length": "1 km"
+            }
+        ]
+    },
+    {
+        "type": "GUN",
+        "id": "hi_power_9mm",
+        "copy-from": "hi_power_9mm",
+        "name": {
+            "str": "Browning Hi-Power 9x19mm"
+        },
+        "pocket_data": [
+            {
+                "magazine_well": "191 ml",
+                "pocket_type": "MAGAZINE_WELL",
+                "holster": true,
+                "max_contains_volume": "20 L",
+                "max_contains_weight": "1000 kg",
+                "item_restriction": [
+                    "bhp9mag_13rd",
+                    "bhp9mag_15rd"
+                ],
+                "max_item_length": "1 km"
+            }
+        ]
+    },
+    {
+        "type": "GUN",
+        "id": "walther_p38",
+        "copy-from": "walther_p38",
+        "name": {
+            "str": "Walther P38"
+        },
+        "pocket_data": [
+            {
+                "magazine_well": "228 ml",
+                "pocket_type": "MAGAZINE_WELL",
+                "holster": true,
+                "max_contains_volume": "20 L",
+                "max_contains_weight": "1000 kg",
+                "item_restriction": [
+                    "p38mag"
+                ],
+                "max_item_length": "1 km"
+            }
+        ]
+    },
+    {
+        "type": "GUN",
+        "id": "walther_ppq_9mm",
+        "copy-from": "walther_ppq_9mm",
+        "name": {
+            "str": "Walther PPQ 9mm"
+        },
+        "pocket_data": [
+            {
+                "magazine_well": "207 ml",
+                "pocket_type": "MAGAZINE_WELL",
+                "holster": true,
+                "max_contains_volume": "20 L",
+                "max_contains_weight": "1000 kg",
+                "item_restriction": [
+                    "ppq9mag_10rd",
+                    "ppq9mag_15rd",
+                    "ppq9mag_17rd"
+                ],
+                "max_item_length": "1 km"
+            }
+        ]
+    },
+    {
+        "type": "GUN",
+        "id": "hptc9",
+        "copy-from": "hptc9",
+        "name": {
+            "str": "Hi-Point C-9"
+        },
+        "pocket_data": [
+            {
+                "magazine_well": "284 ml",
+                "pocket_type": "MAGAZINE_WELL",
+                "holster": true,
+                "max_contains_volume": "20 L",
+                "max_contains_weight": "1000 kg",
+                "item_restriction": [
+                    "hptc9mag_8rd",
+                    "hptc9mag_10rd",
+                    "hptc9mag_15rd"
+                ],
+                "max_item_length": "1 km"
+            }
+        ]
+    },
+    {
+        "type": "GUN",
+        "id": "cz75",
+        "copy-from": "cz75",
+        "name": {
+            "str": "CZ 75 B"
+        },
+        "pocket_data": [
+            {
+                "magazine_well": "230 ml",
+                "pocket_type": "MAGAZINE_WELL",
+                "holster": true,
+                "max_contains_volume": "20 L",
+                "max_contains_weight": "1000 kg",
+                "item_restriction": [
+                    "cz75mag_12rd",
+                    "cz75mag_20rd",
+                    "cz75mag_26rd"
+                ],
+                "max_item_length": "1 km"
+            }
+        ]
+    },
+    {
+        "type": "GUN",
+        "id": "walther_ccp",
+        "copy-from": "walther_ccp",
+        "name": {
+            "str": "Walther CCP"
+        },
+        "pocket_data": [
+            {
+                "magazine_well": "176 ml",
+                "pocket_type": "MAGAZINE_WELL",
+                "holster": true,
+                "max_contains_volume": "20 L",
+                "max_contains_weight": "1000 kg",
+                "item_restriction": [
+                    "ccpmag",
+                    "ccpmag_9rd"
+                ],
+                "max_item_length": "1 km"
+            }
+        ]
+    },
+    {
+        "type": "GUN",
+        "id": "colt_ro635",
+        "copy-from": "colt_ro635",
+        "name": {
+            "str": "Colt Model 635"
+        },
+        "pocket_data": [
+            {
+                "pocket_type": "MAGAZINE_WELL",
+                "holster": true,
+                "max_contains_volume": "20 L",
+                "max_contains_weight": "1000 kg",
+                "item_restriction": [
+                    "uzimag",
+                    "uzimag_20rd",
+                    "uzimag_25rd",
+                    "uzimag_40rd",
+                    "uzimag_50rd",
+                    "uzimag_100rd"
+                ],
+                "max_item_length": "1 km"
+            }
+        ]
+    },
+    {
+        "type": "GUN",
+        "id": "bt_apc9k",
+        "copy-from": "bt_apc9k",
+        "name": {
+            "str": "B&T APC9 PRO K"
+        },
+        "pocket_data": [
+            {
+                "pocket_type": "MAGAZINE_WELL",
+                "holster": true,
+                "max_contains_volume": "20 L",
+                "max_contains_weight": "1000 kg",
+                "item_restriction": [
+                    "btmp9mag_9x19mm_15",
+                    "btmp9mag_9x19mm_10rd",
+                    "btmp9mag_9x19mm_20",
+                    "btmp9mag_9x19mm_25",
+                    "btmp9mag_9x19mm_30",
+                    "btmp9mag_9x19mm_50rd"
+                ],
+                "max_item_length": "1 km"
+            }
+        ]
+    }
+]

--- a/Kenan-Modpack/easy_containers/items/gun/9x18.json
+++ b/Kenan-Modpack/easy_containers/items/gun/9x18.json
@@ -1,0 +1,43 @@
+[
+    {
+        "type": "GUN",
+        "id": "makarov",
+        "copy-from": "makarov",
+        "name": {
+            "str": "Makarov PM"
+        },
+        "pocket_data": [
+            {
+                "magazine_well": "250 ml",
+                "pocket_type": "MAGAZINE_WELL",
+                "holster": true,
+                "max_contains_volume": "20 L",
+                "max_contains_weight": "1000 kg",
+                "item_restriction": [
+                    "makarovmag"
+                ],
+                "max_item_length": "1 km"
+            }
+        ]
+    },
+    {
+        "type": "GUN",
+        "id": "skorpion_82",
+        "copy-from": "skorpion_82",
+        "name": {
+            "str": "Skorpion Vz. 82"
+        },
+        "pocket_data": [
+            {
+                "pocket_type": "MAGAZINE_WELL",
+                "holster": true,
+                "max_contains_volume": "20 L",
+                "max_contains_weight": "1000 kg",
+                "item_restriction": [
+                    "skorpion82mag"
+                ],
+                "max_item_length": "1 km"
+            }
+        ]
+    }
+]

--- a/Kenan-Modpack/easy_containers/items/gun/atgm.json
+++ b/Kenan-Modpack/easy_containers/items/gun/atgm.json
@@ -1,0 +1,21 @@
+[
+    {
+        "type": "GUN",
+        "id": "atgm_launcher",
+        "copy-from": "atgm_launcher",
+        "name": {
+            "str_sp": "BGM-71F TOW"
+        },
+        "pocket_data": [
+            {
+                "pocket_type": "MAGAZINE",
+                "rigid": true,
+                "ammo_restriction": {
+                    "atgm": 1
+                },
+                "max_contains_weight": "1000 kg",
+                "max_item_length": "1 km"
+            }
+        ]
+    }
+]

--- a/Kenan-Modpack/easy_containers/items/gun/bio.json
+++ b/Kenan-Modpack/easy_containers/items/gun/bio.json
@@ -1,0 +1,21 @@
+[
+    {
+        "type": "GUN",
+        "id": "bio_shotgun_gun",
+        "copy-from": "bio_shotgun_gun",
+        "name": {
+            "str": "bionic shotgun"
+        },
+        "pocket_data": [
+            {
+                "pocket_type": "MAGAZINE",
+                "rigid": true,
+                "ammo_restriction": {
+                    "shot": 1
+                },
+                "max_contains_weight": "1000 kg",
+                "max_item_length": "1 km"
+            }
+        ]
+    }
+]

--- a/Kenan-Modpack/easy_containers/items/gun/blunderbuss.json
+++ b/Kenan-Modpack/easy_containers/items/gun/blunderbuss.json
@@ -1,0 +1,22 @@
+[
+    {
+        "type": "GUN",
+        "id": "blunderbuss",
+        "copy-from": "blunderbuss",
+        "name": {
+            "str": "blunderbuss",
+            "str_pl": "blunderbusses"
+        },
+        "pocket_data": [
+            {
+                "pocket_type": "MAGAZINE",
+                "rigid": true,
+                "ammo_restriction": {
+                    "blunderbuss": 1
+                },
+                "max_contains_weight": "1000 kg",
+                "max_item_length": "1 km"
+            }
+        ]
+    }
+]

--- a/Kenan-Modpack/easy_containers/items/gun/cannon.json
+++ b/Kenan-Modpack/easy_containers/items/gun/cannon.json
@@ -1,0 +1,21 @@
+[
+    {
+        "type": "GUN",
+        "id": "cannon_3in_ordnance",
+        "copy-from": "cannon_3in_ordnance",
+        "name": {
+            "str": "3-inch ordnance rifle"
+        },
+        "pocket_data": [
+            {
+                "pocket_type": "MAGAZINE",
+                "rigid": true,
+                "ammo_restriction": {
+                    "cannon": 1
+                },
+                "max_contains_weight": "1000 kg",
+                "max_item_length": "1 km"
+            }
+        ]
+    }
+]

--- a/Kenan-Modpack/easy_containers/items/gun/chemical_spray.json
+++ b/Kenan-Modpack/easy_containers/items/gun/chemical_spray.json
@@ -1,0 +1,23 @@
+[
+    {
+        "type": "GUN",
+        "id": "chemical_thrower",
+        "copy-from": "chemical_thrower",
+        "name": {
+            "str": "makeshift chemical thrower"
+        },
+        "pocket_data": [
+            {
+                "magazine_well": "2 L",
+                "pocket_type": "MAGAZINE_WELL",
+                "holster": true,
+                "max_contains_volume": "20 L",
+                "max_contains_weight": "1000 kg",
+                "item_restriction": [
+                    "pressurized_tank_chem"
+                ],
+                "max_item_length": "1 km"
+            }
+        ]
+    }
+]

--- a/Kenan-Modpack/easy_containers/items/gun/combination.json
+++ b/Kenan-Modpack/easy_containers/items/gun/combination.json
@@ -1,0 +1,21 @@
+[
+    {
+        "type": "GUN",
+        "id": "combination_gun",
+        "copy-from": "combination_gun",
+        "name": {
+            "str": "combination gun"
+        },
+        "pocket_data": [
+            {
+                "pocket_type": "MAGAZINE",
+                "rigid": true,
+                "ammo_restriction": {
+                    "3006": 1
+                },
+                "max_contains_weight": "1000 kg",
+                "max_item_length": "1 km"
+            }
+        ]
+    }
+]

--- a/Kenan-Modpack/easy_containers/items/gun/exodii.json
+++ b/Kenan-Modpack/easy_containers/items/gun/exodii.json
@@ -1,0 +1,42 @@
+[
+    {
+        "type": "GUN",
+        "id": "pamd68",
+        "copy-from": "pamd68",
+        "name": {
+            "str": "PA md. 68 Battle Rifle"
+        },
+        "pocket_data": [
+            {
+                "pocket_type": "MAGAZINE_WELL",
+                "holster": true,
+                "max_contains_volume": "20 L",
+                "max_contains_weight": "1000 kg",
+                "item_restriction": [
+                    "exodiiBRmag"
+                ],
+                "max_item_length": "1 km"
+            }
+        ]
+    },
+    {
+        "type": "GUN",
+        "id": "pamd71z",
+        "copy-from": "pamd71z",
+        "name": {
+            "str": "PA md. 71 zombie hunting rifle"
+        },
+        "pocket_data": [
+            {
+                "pocket_type": "MAGAZINE_WELL",
+                "holster": true,
+                "max_contains_volume": "20 L",
+                "max_contains_weight": "1000 kg",
+                "item_restriction": [
+                    "exodiiminimag"
+                ],
+                "max_item_length": "1 km"
+            }
+        ]
+    }
+]

--- a/Kenan-Modpack/easy_containers/items/gun/flammable.json
+++ b/Kenan-Modpack/easy_containers/items/gun/flammable.json
@@ -1,0 +1,43 @@
+[
+    {
+        "type": "GUN",
+        "id": "flamethrower",
+        "copy-from": "flamethrower",
+        "name": {
+            "str": "flamethrower"
+        },
+        "pocket_data": [
+            {
+                "pocket_type": "MAGAZINE_WELL",
+                "holster": true,
+                "max_contains_volume": "20 L",
+                "max_contains_weight": "1000 kg",
+                "item_restriction": [
+                    "pressurized_tank"
+                ],
+                "max_item_length": "1 km"
+            }
+        ]
+    },
+    {
+        "type": "GUN",
+        "id": "rm451_flamethrower",
+        "copy-from": "rm451_flamethrower",
+        "name": {
+            "str": "RM451 flamethrower"
+        },
+        "pocket_data": [
+            {
+                "pocket_type": "MAGAZINE_WELL",
+                "holster": true,
+                "max_contains_volume": "20 L",
+                "max_contains_weight": "1000 kg",
+                "item_restriction": [
+                    "rm4502",
+                    "rm4504"
+                ],
+                "max_item_length": "1 km"
+            }
+        ]
+    }
+]

--- a/Kenan-Modpack/easy_containers/items/gun/flintlock.json
+++ b/Kenan-Modpack/easy_containers/items/gun/flintlock.json
@@ -1,0 +1,78 @@
+[
+    {
+        "type": "GUN",
+        "id": "carbine_flintlock",
+        "copy-from": "carbine_flintlock",
+        "name": {
+            "str": "flintlock carbine"
+        },
+        "pocket_data": [
+            {
+                "pocket_type": "MAGAZINE",
+                "rigid": true,
+                "ammo_restriction": {
+                    "flintlock": 1
+                },
+                "max_contains_weight": "1000 kg",
+                "max_item_length": "1 km"
+            }
+        ]
+    },
+    {
+        "type": "GUN",
+        "id": "carbine_flintlock_double",
+        "copy-from": "carbine_flintlock_double",
+        "name": {
+            "str": "handmade double-barrel flintlock"
+        },
+        "pocket_data": [
+            {
+                "pocket_type": "MAGAZINE",
+                "rigid": true,
+                "ammo_restriction": {
+                    "flintlock": 2
+                },
+                "max_contains_weight": "1000 kg",
+                "max_item_length": "1 km"
+            }
+        ]
+    },
+    {
+        "type": "GUN",
+        "id": "pistol_flintlock",
+        "copy-from": "pistol_flintlock",
+        "name": {
+            "str": "flintlock pistol"
+        },
+        "pocket_data": [
+            {
+                "pocket_type": "MAGAZINE",
+                "rigid": true,
+                "ammo_restriction": {
+                    "flintlock": 1
+                },
+                "max_contains_weight": "1000 kg",
+                "max_item_length": "1 km"
+            }
+        ]
+    },
+    {
+        "type": "GUN",
+        "id": "rifle_flintlock",
+        "copy-from": "rifle_flintlock",
+        "name": {
+            "str": "flintlock musket"
+        },
+        "pocket_data": [
+            {
+                "pocket_type": "MAGAZINE",
+                "rigid": true,
+                "ammo_restriction": {
+                    "flintlock": 1
+                },
+                "max_contains_weight": "1000 kg",
+                "max_item_length": "1 km"
+            }
+        ]
+    }
+]

--- a/Kenan-Modpack/easy_containers/items/gun/monster_gun.json
+++ b/Kenan-Modpack/easy_containers/items/gun/monster_gun.json
@@ -1,0 +1,21 @@
+[
+    {
+        "type": "GUN",
+        "id": "barb_launcher",
+        "copy-from": "barb_launcher",
+        "name": {
+            "str": "barb launching organ"
+        },
+        "pocket_data": [
+            {
+                "pocket_type": "MAGAZINE",
+                "rigid": true,
+                "ammo_restriction": {
+                    "barb": 1
+                },
+                "max_contains_weight": "1000 kg",
+                "max_item_length": "1 km"
+            }
+        ]
+    }
+]

--- a/Kenan-Modpack/easy_containers/items/gun/nail.json
+++ b/Kenan-Modpack/easy_containers/items/gun/nail.json
@@ -1,0 +1,41 @@
+[
+    {
+        "type": "GUN",
+        "id": "nailgun",
+        "copy-from": "nailgun",
+        "name": {
+            "str": "nail gun"
+        },
+        "pocket_data": [
+            {
+                "pocket_type": "MAGAZINE",
+                "rigid": true,
+                "ammo_restriction": {
+                    "nail": 20
+                },
+                "max_contains_weight": "1000 kg",
+                "max_item_length": "1 km"
+            }
+        ]
+    },
+    {
+        "type": "GUN",
+        "id": "coilgun",
+        "copy-from": "coilgun",
+        "name": {
+            "str": "coilgun"
+        },
+        "pocket_data": [
+            {
+                "pocket_type": "MAGAZINE_WELL",
+                "holster": true,
+                "max_contains_volume": "20 L",
+                "max_contains_weight": "1000 kg",
+                "item_restriction": [
+                    "nailmag"
+                ],
+                "max_item_length": "1 km"
+            }
+        ]
+    }
+]

--- a/Kenan-Modpack/easy_containers/items/gun/paintball.json
+++ b/Kenan-Modpack/easy_containers/items/gun/paintball.json
@@ -1,0 +1,21 @@
+[
+    {
+        "type": "GUN",
+        "id": "paintballgun",
+        "copy-from": "paintballgun",
+        "name": {
+            "str": "Paintball gun"
+        },
+        "pocket_data": [
+            {
+                "pocket_type": "MAGAZINE",
+                "rigid": true,
+                "ammo_restriction": {
+                    "paintball": 50
+                },
+                "max_contains_weight": "1000 kg",
+                "max_item_length": "1 km"
+            }
+        ]
+    }
+]

--- a/Kenan-Modpack/easy_containers/items/gun/shot.json
+++ b/Kenan-Modpack/easy_containers/items/gun/shot.json
@@ -1,0 +1,519 @@
+[
+    {
+        "type": "GUN",
+        "id": "ashot",
+        "copy-from": "ashot",
+        "name": {
+            "str": "12 gauge pistol"
+        },
+        "pocket_data": [
+            {
+                "pocket_type": "MAGAZINE",
+                "rigid": true,
+                "ammo_restriction": {
+                    "shot": 1
+                },
+                "max_contains_weight": "1000 kg",
+                "max_item_length": "1 km"
+            }
+        ]
+    },
+    {
+        "type": "GUN",
+        "id": "bigun",
+        "copy-from": "bigun",
+        "name": {
+            "str": "12-gauge gatling gun"
+        },
+        "pocket_data": [
+            {
+                "pocket_type": "MAGAZINE_WELL",
+                "holster": true,
+                "max_contains_volume": "20 L",
+                "max_contains_weight": "1000 kg",
+                "item_restriction": [
+                    "shotbelt_20"
+                ],
+                "max_item_length": "1 km"
+            }
+        ]
+    },
+    {
+        "type": "GUN",
+        "id": "lever_shotgun",
+        "copy-from": "lever_shotgun",
+        "name": {
+            "str": "handmade lever shotgun"
+        },
+        "pocket_data": [
+            {
+                "pocket_type": "MAGAZINE",
+                "rigid": true,
+                "ammo_restriction": {
+                    "shot": 6
+                },
+                "max_contains_weight": "1000 kg",
+                "max_item_length": "1 km"
+            }
+        ]
+    },
+    {
+        "type": "GUN",
+        "id": "browning_a5",
+        "copy-from": "browning_a5",
+        "name": {
+            "str": "Browning Auto 5"
+        },
+        "pocket_data": [
+            {
+                "pocket_type": "MAGAZINE",
+                "rigid": true,
+                "ammo_restriction": {
+                    "shot": 5
+                },
+                "max_contains_weight": "1000 kg",
+                "max_item_length": "1 km"
+            }
+        ]
+    },
+    {
+        "type": "GUN",
+        "id": "ksg",
+        "copy-from": "ksg",
+        "name": {
+            "str_sp": "Kel-Tec KSG"
+        },
+        "pocket_data": [
+            {
+                "pocket_type": "MAGAZINE",
+                "rigid": true,
+                "ammo_restriction": {
+                    "shot": 7
+                },
+                "max_contains_weight": "1000 kg",
+                "max_item_length": "1 km"
+            }
+        ]
+    },
+    {
+        "type": "GUN",
+        "id": "ksg-25",
+        "copy-from": "ksg-25",
+        "name": {
+            "str_sp": "Kel-Tec KSG-25"
+        },
+        "pocket_data": [
+            {
+                "pocket_type": "MAGAZINE",
+                "rigid": true,
+                "ammo_restriction": {
+                    "shot": 12
+                },
+                "max_contains_weight": "1000 kg",
+                "max_item_length": "1 km"
+            }
+        ]
+    },
+    {
+        "type": "GUN",
+        "id": "m1014",
+        "copy-from": "m1014",
+        "name": {
+            "str": "M1014 shotgun"
+        },
+        "pocket_data": [
+            {
+                "pocket_type": "MAGAZINE",
+                "rigid": true,
+                "ammo_restriction": {
+                    "shot": 8
+                },
+                "max_contains_weight": "1000 kg",
+                "max_item_length": "1 km"
+            }
+        ]
+    },
+    {
+        "type": "GUN",
+        "id": "mossberg_500",
+        "copy-from": "mossberg_500",
+        "name": {
+            "str_sp": "Mossberg 500 Field"
+        },
+        "pocket_data": [
+            {
+                "pocket_type": "MAGAZINE",
+                "rigid": true,
+                "ammo_restriction": {
+                    "shot": 6
+                },
+                "max_contains_weight": "1000 kg",
+                "max_item_length": "1 km"
+            }
+        ]
+    },
+    {
+        "type": "GUN",
+        "id": "mossberg_590",
+        "copy-from": "mossberg_590",
+        "name": {
+            "str_sp": "Mossberg 590A1"
+        },
+        "pocket_data": [
+            {
+                "pocket_type": "MAGAZINE",
+                "rigid": true,
+                "ammo_restriction": {
+                    "shot": 9
+                },
+                "max_contains_weight": "1000 kg",
+                "max_item_length": "1 km"
+            }
+        ]
+    },
+    {
+        "type": "GUN",
+        "id": "mossberg_930",
+        "copy-from": "mossberg_930",
+        "name": {
+            "str": "Mossberg 930 SPX"
+        },
+        "pocket_data": [
+            {
+                "pocket_type": "MAGAZINE",
+                "rigid": true,
+                "ammo_restriction": {
+                    "shot": 8
+                },
+                "max_contains_weight": "1000 kg",
+                "max_item_length": "1 km"
+            }
+        ]
+    },
+    {
+        "type": "GUN",
+        "id": "pipe_double_shotgun",
+        "copy-from": "pipe_double_shotgun",
+        "name": {
+            "str": "double-barrel pipe shotgun"
+        },
+        "pocket_data": [
+            {
+                "pocket_type": "MAGAZINE",
+                "rigid": true,
+                "ammo_restriction": {
+                    "shot": 2
+                },
+                "max_contains_weight": "1000 kg",
+                "max_item_length": "1 km"
+            }
+        ]
+    },
+    {
+        "type": "GUN",
+        "id": "pipe_shotgun",
+        "copy-from": "pipe_shotgun",
+        "name": {
+            "str": "pipe shotgun"
+        },
+        "pocket_data": [
+            {
+                "pocket_type": "MAGAZINE",
+                "rigid": true,
+                "ammo_restriction": {
+                    "shot": 1
+                },
+                "max_contains_weight": "1000 kg",
+                "max_item_length": "1 km"
+            }
+        ]
+    },
+    {
+        "type": "GUN",
+        "id": "remington_870",
+        "copy-from": "remington_870",
+        "name": {
+            "str_sp": "Remington 870 Wingmaster"
+        },
+        "pocket_data": [
+            {
+                "pocket_type": "MAGAZINE",
+                "rigid": true,
+                "ammo_restriction": {
+                    "shot": 5
+                },
+                "max_contains_weight": "1000 kg",
+                "max_item_length": "1 km"
+            }
+        ]
+    },
+    {
+        "type": "GUN",
+        "id": "remington_870_breacher",
+        "copy-from": "remington_870_breacher",
+        "name": {
+            "str": "Remington 870 MCS"
+        },
+        "pocket_data": [
+            {
+                "pocket_type": "MAGAZINE",
+                "rigid": true,
+                "ammo_restriction": {
+                    "shot": 4
+                },
+                "max_contains_weight": "1000 kg",
+                "max_item_length": "1 km"
+            }
+        ]
+    },
+    {
+        "type": "GUN",
+        "id": "remington_870_express",
+        "copy-from": "remington_870_express",
+        "name": {
+            "str": "Remington 870 express",
+            "str_pl": "Remington 870 expresses"
+        },
+        "pocket_data": [
+            {
+                "pocket_type": "MAGAZINE",
+                "rigid": true,
+                "ammo_restriction": {
+                    "shot": 7
+                },
+                "max_contains_weight": "1000 kg",
+                "max_item_length": "1 km"
+            }
+        ]
+    },
+    {
+        "type": "GUN",
+        "id": "remington_1100",
+        "copy-from": "remington_1100",
+        "name": {
+            "str": "Remington 1100 competition"
+        },
+        "pocket_data": [
+            {
+                "pocket_type": "MAGAZINE",
+                "rigid": true,
+                "ammo_restriction": {
+                    "shot": 5
+                },
+                "max_contains_weight": "1000 kg",
+                "max_item_length": "1 km"
+            }
+        ]
+    },
+    {
+        "type": "GUN",
+        "id": "revolver_shotgun",
+        "copy-from": "revolver_shotgun",
+        "name": {
+            "str": "shotgun revolver"
+        },
+        "pocket_data": [
+            {
+                "pocket_type": "MAGAZINE",
+                "rigid": true,
+                "ammo_restriction": {
+                    "shot": 6
+                },
+                "max_contains_weight": "1000 kg",
+                "max_item_length": "1 km"
+            }
+        ]
+    },
+    {
+        "type": "GUN",
+        "id": "saiga_12",
+        "copy-from": "saiga_12",
+        "name": {
+            "str": "Saiga-12"
+        },
+        "pocket_data": [
+            {
+                "pocket_type": "MAGAZINE_WELL",
+                "holster": true,
+                "max_contains_volume": "20 L",
+                "max_contains_weight": "1000 kg",
+                "item_restriction": [
+                    "saiga10mag",
+                    "saiga30mag"
+                ],
+                "max_item_length": "1 km"
+            }
+        ]
+    },
+    {
+        "type": "GUN",
+        "id": "shotgun_d",
+        "copy-from": "shotgun_d",
+        "name": {
+            "str": "double barrel shotgun"
+        },
+        "pocket_data": [
+            {
+                "pocket_type": "MAGAZINE",
+                "rigid": true,
+                "ammo_restriction": {
+                    "shot": 2
+                },
+                "max_contains_weight": "1000 kg",
+                "max_item_length": "1 km"
+            }
+        ]
+    },
+    {
+        "type": "GUN",
+        "id": "shotgun_s",
+        "copy-from": "shotgun_s",
+        "name": {
+            "str": "single barrel shotgun"
+        },
+        "pocket_data": [
+            {
+                "pocket_type": "MAGAZINE",
+                "rigid": true,
+                "ammo_restriction": {
+                    "shot": 1
+                },
+                "max_contains_weight": "1000 kg",
+                "max_item_length": "1 km"
+            }
+        ]
+    },
+    {
+        "type": "GUN",
+        "id": "streetsweeper",
+        "copy-from": "streetsweeper",
+        "name": {
+            "str": "Cobray Streetsweeper"
+        },
+        "pocket_data": [
+            {
+                "pocket_type": "MAGAZINE",
+                "rigid": true,
+                "ammo_restriction": {
+                    "shot": 12
+                },
+                "max_contains_weight": "1000 kg",
+                "max_item_length": "1 km"
+            }
+        ]
+    },
+    {
+        "type": "GUN",
+        "id": "SPAS_12",
+        "copy-from": "SPAS_12",
+        "name": {
+            "str": "Franchi SPAS-12"
+        },
+        "pocket_data": [
+            {
+                "pocket_type": "MAGAZINE",
+                "rigid": true,
+                "ammo_restriction": {
+                    "shot": 9
+                },
+                "max_contains_weight": "1000 kg",
+                "max_item_length": "1 km"
+            }
+        ]
+    },
+    {
+        "type": "GUN",
+        "id": "tavor_12",
+        "copy-from": "tavor_12",
+        "name": {
+            "str": "Tavor TS12"
+        },
+        "pocket_data": [
+            {
+                "pocket_type": "MAGAZINE",
+                "rigid": true,
+                "ammo_restriction": {
+                    "shot": 5
+                },
+                "max_contains_weight": "1000 kg",
+                "max_item_length": "1 km"
+            }
+        ]
+    },
+    {
+        "type": "GUN",
+        "id": "winchester_1887",
+        "copy-from": "winchester_1887",
+        "name": {
+            "str": "1887 bootleg shotgun"
+        },
+        "pocket_data": [
+            {
+                "pocket_type": "MAGAZINE",
+                "rigid": true,
+                "ammo_restriction": {
+                    "shot": 6
+                },
+                "max_contains_weight": "1000 kg",
+                "max_item_length": "1 km"
+            }
+        ]
+    },
+    {
+        "type": "GUN",
+        "id": "winchester_1897",
+        "copy-from": "winchester_1897",
+        "name": {
+            "str": "M1897 Trench Gun"
+        },
+        "pocket_data": [
+            {
+                "pocket_type": "MAGAZINE",
+                "rigid": true,
+                "ammo_restriction": {
+                    "shot": 6
+                },
+                "max_contains_weight": "1000 kg",
+                "max_item_length": "1 km"
+            }
+        ]
+    },
+    {
+        "type": "GUN",
+        "id": "slamfire_shotgun",
+        "copy-from": "slamfire_shotgun",
+        "name": {
+            "str": "slam-fire pipe shotgun"
+        },
+        "pocket_data": [
+            {
+                "pocket_type": "MAGAZINE",
+                "rigid": true,
+                "ammo_restriction": {
+                    "shot": 1
+                },
+                "max_contains_weight": "1000 kg",
+                "max_item_length": "1 km"
+            }
+        ]
+    },
+    {
+        "type": "GUN",
+        "id": "slamfire_shotgun_d",
+        "copy-from": "slamfire_shotgun_d",
+        "name": {
+            "str": "double slam-fire pipe shotgun"
+        },
+        "pocket_data": [
+            {
+                "pocket_type": "MAGAZINE",
+                "rigid": true,
+                "ammo_restriction": {
+                    "shot": 2
+                },
+                "max_contains_weight": "1000 kg",
+                "max_item_length": "1 km"
+            }
+        ]
+    }
+]

--- a/Kenan-Modpack/easy_containers/items/gun/signal_flare.json
+++ b/Kenan-Modpack/easy_containers/items/gun/signal_flare.json
@@ -1,0 +1,21 @@
+[
+    {
+        "type": "GUN",
+        "id": "flaregun",
+        "copy-from": "flaregun",
+        "name": {
+            "str": "flaregun"
+        },
+        "pocket_data": [
+            {
+                "pocket_type": "MAGAZINE",
+                "rigid": true,
+                "ammo_restriction": {
+                    "signal_flare": 1
+                },
+                "max_contains_weight": "1000 kg",
+                "max_item_length": "1 km"
+            }
+        ]
+    }
+]

--- a/Kenan-Modpack/easy_containers/items/gunmod/brass_catcher.json
+++ b/Kenan-Modpack/easy_containers/items/gunmod/brass_catcher.json
@@ -1,0 +1,17 @@
+[
+    {
+        "type": "GUNMOD",
+        "id": "brass_catcher",
+        "copy-from": "brass_catcher",
+        "name": {
+            "str": "brass catcher"
+        },
+        "pocket_data": [
+            {
+                "max_contains_volume": "249 ml",
+                "max_contains_weight": "1000 kg",
+                "max_item_length": "1 km"
+            }
+        ]
+    }
+]

--- a/Kenan-Modpack/easy_containers/items/gunmod/rail.json
+++ b/Kenan-Modpack/easy_containers/items/gunmod/rail.json
@@ -1,0 +1,20 @@
+[
+    {
+        "type": "GUNMOD",
+        "id": "gun_crossbow",
+        "copy-from": "gun_crossbow",
+        "name": {
+            "str": "rail-mounted crossbow"
+        },
+        "pocket_data": [
+            {
+                "pocket_type": "MAGAZINE",
+                "ammo_restriction": {
+                    "bolt": 1
+                },
+                "max_contains_weight": "1000 kg",
+                "max_item_length": "1 km"
+            }
+        ]
+    }
+]

--- a/Kenan-Modpack/easy_containers/items/gunmod/underbarrel.json
+++ b/Kenan-Modpack/easy_containers/items/gunmod/underbarrel.json
@@ -1,0 +1,238 @@
+[
+    {
+        "type": "GUNMOD",
+        "id": "combination_gun_shotgun",
+        "copy-from": "combination_gun_shotgun",
+        "name": {
+            "str": "combination gun shotgun"
+        },
+        "pocket_data": [
+            {
+                "pocket_type": "MAGAZINE",
+                "ammo_restriction": {
+                    "shot": 2
+                },
+                "max_contains_weight": "1000 kg",
+                "max_item_length": "1 km"
+            }
+        ]
+    },
+    {
+        "type": "GUNMOD",
+        "id": "ksg_aux_shotgun",
+        "copy-from": "ksg_aux_shotgun",
+        "name": {
+            "str": "KSG second magazine"
+        },
+        "pocket_data": [
+            {
+                "pocket_type": "MAGAZINE",
+                "ammo_restriction": {
+                    "shot": 7
+                },
+                "max_contains_weight": "1000 kg",
+                "max_item_length": "1 km"
+            }
+        ]
+    },
+    {
+        "type": "GUNMOD",
+        "id": "ksg25_aux_shotgun",
+        "copy-from": "ksg25_aux_shotgun",
+        "name": {
+            "str": "KSG-25 second magazine"
+        },
+        "pocket_data": [
+            {
+                "pocket_type": "MAGAZINE",
+                "ammo_restriction": {
+                    "shot": 12
+                },
+                "max_contains_weight": "1000 kg",
+                "max_item_length": "1 km"
+            }
+        ]
+    },
+    {
+        "type": "GUNMOD",
+        "id": "ts12_aux_shotgun",
+        "copy-from": "ts12_aux_shotgun",
+        "name": {
+            "str": "TS12 second magazine"
+        },
+        "pocket_data": [
+            {
+                "pocket_type": "MAGAZINE",
+                "ammo_restriction": {
+                    "shot": 5
+                },
+                "max_contains_weight": "1000 kg",
+                "max_item_length": "1 km"
+            }
+        ]
+    },
+    {
+        "type": "GUNMOD",
+        "id": "ts12_aux_shotgun2",
+        "copy-from": "ts12_aux_shotgun2",
+        "name": {
+            "str": "TS12 third magazine"
+        },
+        "pocket_data": [
+            {
+                "pocket_type": "MAGAZINE",
+                "ammo_restriction": {
+                    "shot": 5
+                },
+                "max_contains_weight": "1000 kg",
+                "max_item_length": "1 km"
+            }
+        ]
+    },
+    {
+        "type": "GUNMOD",
+        "id": "lemat_revolver_shotgun",
+        "copy-from": "lemat_revolver_shotgun",
+        "name": {
+            "str": "LeMat revolver shotgun"
+        },
+        "pocket_data": [
+            {
+                "pocket_type": "MAGAZINE",
+                "ammo_restriction": {
+                    "shotpaper": 1
+                },
+                "max_contains_weight": "1000 kg",
+                "max_item_length": "1 km"
+            }
+        ]
+    },
+    {
+        "type": "GUNMOD",
+        "id": "m203",
+        "copy-from": "m203",
+        "name": {
+            "str_sp": "M203"
+        },
+        "pocket_data": [
+            {
+                "pocket_type": "MAGAZINE",
+                "ammo_restriction": {
+                    "40x46mm": 1
+                },
+                "max_contains_weight": "1000 kg",
+                "max_item_length": "1 km"
+            }
+        ]
+    },
+    {
+        "type": "GUNMOD",
+        "id": "m320_mod",
+        "copy-from": "m320_mod",
+        "name": {
+            "str_sp": "M320 GLM"
+        },
+        "pocket_data": [
+            {
+                "pocket_type": "MAGAZINE",
+                "ammo_restriction": {
+                    "40x46mm": 1
+                },
+                "max_contains_weight": "1000 kg",
+                "max_item_length": "1 km"
+            }
+        ]
+    },
+    {
+        "type": "GUNMOD",
+        "id": "M6_shotgun",
+        "copy-from": "M6_shotgun",
+        "name": {
+            "str": "M6 Survival Gun shotgun"
+        },
+        "pocket_data": [
+            {
+                "pocket_type": "MAGAZINE",
+                "ammo_restriction": {
+                    "shot": 1
+                },
+                "max_contains_weight": "1000 kg",
+                "max_item_length": "1 km"
+            }
+        ]
+    },
+    {
+        "type": "GUNMOD",
+        "id": "masterkey",
+        "copy-from": "masterkey",
+        "name": {
+            "str": "masterkey shotgun"
+        },
+        "pocket_data": [
+            {
+                "pocket_type": "MAGAZINE",
+                "ammo_restriction": {
+                    "shot": 4
+                },
+                "max_contains_weight": "1000 kg",
+                "max_item_length": "1 km"
+            }
+        ]
+    },
+    {
+        "type": "GUNMOD",
+        "id": "pipe_launcher40mm",
+        "copy-from": "pipe_launcher40mm",
+        "name": {
+            "str": "40mm pipe launcher"
+        },
+        "pocket_data": [
+            {
+                "pocket_type": "MAGAZINE",
+                "ammo_restriction": {
+                    "40x46mm": 1
+                },
+                "max_contains_weight": "1000 kg",
+                "max_item_length": "1 km"
+            }
+        ]
+    },
+    {
+        "type": "GUNMOD",
+        "id": "rm121aux",
+        "copy-from": "rm121aux",
+        "name": {
+            "str": "RM121 aux shotgun"
+        },
+        "pocket_data": [
+            {
+                "pocket_type": "MAGAZINE_WELL",
+                "holster": true,
+                "max_contains_volume": "20 L",
+                "max_contains_weight": "1000 kg",
+                "item_restriction": [
+                    "20x66_10_mag"
+                ],
+                "max_item_length": "1 km"
+            }
+        ]
+    },
+    {
+        "type": "GUNMOD",
+        "id": "u_shotgun",
+        "copy-from": "u_shotgun",
+        "name": {
+            "str": "underslung shotgun"
+        },
+        "pocket_data": [
+            {
+                "pocket_type": "MAGAZINE",
+                "ammo_restriction": {
+                    "shot": 2
+                },
+                "max_contains_weight": "1000 kg",
+                "max_item_length": "1 km"
+            }
+        ]
+    }
+]

--- a/Kenan-Modpack/easy_containers/items/items_holiday.json
+++ b/Kenan-Modpack/easy_containers/items/items_holiday.json
@@ -1,0 +1,21 @@
+[
+    {
+        "type": "TOOL",
+        "id": "jackolantern",
+        "copy-from": "jackolantern",
+        "name": {
+            "str": "jack o' lantern"
+        },
+        "pocket_data": [
+            {
+                "pocket_type": "MAGAZINE",
+                "ammo_restriction": {
+                    "candle_wax": 100
+                },
+                "rigid": true,
+                "max_contains_weight": "1000 kg",
+                "max_item_length": "1 km"
+            }
+        ]
+    }
+]

--- a/Kenan-Modpack/easy_containers/items/magazine/10mm.json
+++ b/Kenan-Modpack/easy_containers/items/magazine/10mm.json
@@ -1,0 +1,173 @@
+[
+    {
+        "type": "MAGAZINE",
+        "id": "40_speedloader6",
+        "copy-from": "40_speedloader6",
+        "name": {
+            "str": "10mm 6-round speedloader"
+        },
+        "pocket_data": [
+            {
+                "pocket_type": "MAGAZINE",
+                "ammo_restriction": {
+                    "40": 6,
+                    "10mm": 6
+                },
+                "max_contains_weight": "1000 kg",
+                "max_item_length": "1 km"
+            }
+        ]
+    },
+    {
+        "type": "MAGAZINE",
+        "id": "glock_20mag",
+        "copy-from": "glock_20mag",
+        "name": {
+            "str": "Glock 10mm 15-round magazine"
+        },
+        "pocket_data": [
+            {
+                "pocket_type": "MAGAZINE",
+                "rigid": true,
+                "ammo_restriction": {
+                    "10mm": 15
+                },
+                "max_contains_weight": "1000 kg",
+                "max_item_length": "1 km"
+            }
+        ]
+    },
+    {
+        "type": "MAGAZINE",
+        "id": "glock_29mag",
+        "copy-from": "glock_29mag",
+        "name": {
+            "str": "Glock 10mm 10-round magazine"
+        },
+        "pocket_data": [
+            {
+                "pocket_type": "MAGAZINE",
+                "rigid": true,
+                "ammo_restriction": {
+                    "10mm": 10
+                },
+                "max_contains_weight": "1000 kg",
+                "max_item_length": "1 km"
+            }
+        ]
+    },
+    {
+        "type": "MAGAZINE",
+        "id": "m1911_10mag",
+        "copy-from": "m1911_10mag",
+        "name": {
+            "str": "Colt Delta Elite 8-round magazine"
+        },
+        "pocket_data": [
+            {
+                "pocket_type": "MAGAZINE",
+                "rigid": true,
+                "ammo_restriction": {
+                    "10mm": 8
+                },
+                "max_contains_weight": "1000 kg",
+                "max_item_length": "1 km"
+            }
+        ]
+    },
+    {
+        "type": "MAGAZINE",
+        "id": "mp5_10_mag",
+        "copy-from": "mp5_10_mag",
+        "name": {
+            "str": "MP5/10 30-round magazine"
+        },
+        "pocket_data": [
+            {
+                "pocket_type": "MAGAZINE",
+                "rigid": true,
+                "ammo_restriction": {
+                    "10mm": 30
+                },
+                "max_contains_weight": "1000 kg",
+                "max_item_length": "1 km"
+            }
+        ]
+    },
+    {
+        "type": "MAGAZINE",
+        "id": "p220_10_mag",
+        "copy-from": "p220_10_mag",
+        "name": {
+            "str": "P220 8-round magazine"
+        },
+        "pocket_data": [
+            {
+                "pocket_type": "MAGAZINE",
+                "rigid": true,
+                "ammo_restriction": {
+                    "10mm": 8
+                },
+                "max_contains_weight": "1000 kg",
+                "max_item_length": "1 km"
+            }
+        ]
+    },
+    {
+        "type": "MAGAZINE",
+        "id": "tdi_10mm_mag",
+        "copy-from": "tdi_10mm_mag",
+        "name": {
+            "str": "Glock 10mm 30-round magazine"
+        },
+        "pocket_data": [
+            {
+                "pocket_type": "MAGAZINE",
+                "rigid": true,
+                "ammo_restriction": {
+                    "10mm": 30
+                },
+                "max_contains_weight": "1000 kg",
+                "max_item_length": "1 km"
+            }
+        ]
+    },
+    {
+        "type": "MAGAZINE",
+        "id": "witness_mag_10",
+        "copy-from": "witness_mag_10",
+        "name": {
+            "str": "EAA Witness 15-round magazine"
+        },
+        "pocket_data": [
+            {
+                "pocket_type": "MAGAZINE",
+                "rigid": true,
+                "ammo_restriction": {
+                    "10mm": 15
+                },
+                "max_contains_weight": "1000 kg",
+                "max_item_length": "1 km"
+            }
+        ]
+    },
+    {
+        "type": "MAGAZINE",
+        "id": "xd_10_mag",
+        "copy-from": "xd_10_mag",
+        "name": {
+            "str": "XD(M) 15-round magazine"
+        },
+        "pocket_data": [
+            {
+                "pocket_type": "MAGAZINE",
+                "rigid": true,
+                "ammo_restriction": {
+                    "10mm": 15
+                },
+                "max_contains_weight": "1000 kg",
+                "max_item_length": "1 km"
+            }
+        ]
+    }
+]

--- a/Kenan-Modpack/easy_containers/items/magazine/12mm.json
+++ b/Kenan-Modpack/easy_containers/items/magazine/12mm.json
@@ -1,0 +1,21 @@
+[
+    {
+        "type": "MAGAZINE",
+        "id": "hk_g80mag",
+        "copy-from": "hk_g80mag",
+        "name": {
+            "str": "H&K G80 20-round magazine"
+        },
+        "pocket_data": [
+            {
+                "pocket_type": "MAGAZINE",
+                "rigid": true,
+                "ammo_restriction": {
+                    "12mm": 20
+                },
+                "max_contains_weight": "1000 kg",
+                "max_item_length": "1 km"
+            }
+        ]
+    }
+]

--- a/Kenan-Modpack/easy_containers/items/magazine/20x60mm.json
+++ b/Kenan-Modpack/easy_containers/items/magazine/20x60mm.json
@@ -1,0 +1,59 @@
+[
+    {
+        "type": "MAGAZINE",
+        "id": "20x66_10_mag",
+        "copy-from": "20x66_10_mag",
+        "name": {
+            "str": "20x66mm 10-round magazine"
+        },
+        "pocket_data": [
+            {
+                "pocket_type": "MAGAZINE",
+                "rigid": true,
+                "ammo_restriction": {
+                    "20x66mm": 10
+                },
+                "max_contains_weight": "1000 kg",
+                "max_item_length": "1 km"
+            }
+        ]
+    },
+    {
+        "type": "MAGAZINE",
+        "id": "20x66_20_mag",
+        "copy-from": "20x66_20_mag",
+        "name": {
+            "str": "RM20 20-round magazine"
+        },
+        "pocket_data": [
+            {
+                "pocket_type": "MAGAZINE",
+                "rigid": true,
+                "ammo_restriction": {
+                    "20x66mm": 20
+                },
+                "max_contains_weight": "1000 kg",
+                "max_item_length": "1 km"
+            }
+        ]
+    },
+    {
+        "type": "MAGAZINE",
+        "id": "20x66_40_mag",
+        "copy-from": "20x66_40_mag",
+        "name": {
+            "str": "RM20 40-round magazine"
+        },
+        "pocket_data": [
+            {
+                "pocket_type": "MAGAZINE",
+                "rigid": true,
+                "ammo_restriction": {
+                    "20x66mm": 40
+                },
+                "max_contains_weight": "1000 kg",
+                "max_item_length": "1 km"
+            }
+        ]
+    }
+]

--- a/Kenan-Modpack/easy_containers/items/magazine/22.json
+++ b/Kenan-Modpack/easy_containers/items/magazine/22.json
@@ -1,0 +1,249 @@
+[
+    {
+        "type": "MAGAZINE",
+        "id": "22_speedloader8",
+        "copy-from": "22_speedloader8",
+        "name": {
+            "str": ".22 8-round speedloader"
+        },
+        "pocket_data": [
+            {
+                "pocket_type": "MAGAZINE",
+                "rigid": true,
+                "ammo_restriction": {
+                    "22": 8
+                },
+                "max_contains_weight": "1000 kg",
+                "max_item_length": "1 km"
+            }
+        ]
+    },
+    {
+        "type": "MAGAZINE",
+        "id": "a180mag",
+        "copy-from": "a180mag",
+        "name": {
+            "str": "American-180 165-round magazine"
+        },
+        "pocket_data": [
+            {
+                "pocket_type": "MAGAZINE",
+                "rigid": true,
+                "ammo_restriction": {
+                    "22": 165
+                },
+                "max_contains_weight": "1000 kg",
+                "max_item_length": "1 km"
+            }
+        ]
+    },
+    {
+        "type": "MAGAZINE",
+        "id": "a180mag1",
+        "copy-from": "a180mag1",
+        "name": {
+            "str": "American-180 Polymer 165-round magazine"
+        },
+        "pocket_data": [
+            {
+                "pocket_type": "MAGAZINE",
+                "rigid": true,
+                "ammo_restriction": {
+                    "22": 165
+                },
+                "max_contains_weight": "1000 kg",
+                "max_item_length": "1 km"
+            }
+        ]
+    },
+    {
+        "type": "MAGAZINE",
+        "id": "a180mag2",
+        "copy-from": "a180mag2",
+        "name": {
+            "str": "American-180 177-round magazine"
+        },
+        "pocket_data": [
+            {
+                "pocket_type": "MAGAZINE",
+                "rigid": true,
+                "ammo_restriction": {
+                    "22": 177
+                },
+                "max_contains_weight": "1000 kg",
+                "max_item_length": "1 km"
+            }
+        ]
+    },
+    {
+        "type": "MAGAZINE",
+        "id": "a180mag3",
+        "copy-from": "a180mag3",
+        "name": {
+            "str": "American-180 Polymer 220-round magazine"
+        },
+        "pocket_data": [
+            {
+                "pocket_type": "MAGAZINE",
+                "rigid": true,
+                "ammo_restriction": {
+                    "22": 220
+                },
+                "max_contains_weight": "1000 kg",
+                "max_item_length": "1 km"
+            }
+        ]
+    },
+    {
+        "type": "MAGAZINE",
+        "id": "a180mag4",
+        "copy-from": "a180mag4",
+        "name": {
+            "str": "American-180 Polymer 275-round magazine"
+        },
+        "pocket_data": [
+            {
+                "pocket_type": "MAGAZINE",
+                "rigid": true,
+                "ammo_restriction": {
+                    "22": 275
+                },
+                "max_contains_weight": "1000 kg",
+                "max_item_length": "1 km"
+            }
+        ]
+    },
+    {
+        "type": "MAGAZINE",
+        "id": "marlin_tubeloader",
+        "copy-from": "marlin_tubeloader",
+        "name": {
+            "str": ".22 19-round tube loader"
+        },
+        "pocket_data": [
+            {
+                "pocket_type": "MAGAZINE",
+                "rigid": true,
+                "ammo_restriction": {
+                    "22": 19
+                },
+                "max_contains_weight": "1000 kg",
+                "max_item_length": "1 km"
+            }
+        ]
+    },
+    {
+        "type": "MAGAZINE",
+        "id": "mosquitomag",
+        "copy-from": "mosquitomag",
+        "name": {
+            "str": "SIG Mosquito 10-round magazine"
+        },
+        "pocket_data": [
+            {
+                "pocket_type": "MAGAZINE",
+                "rigid": true,
+                "ammo_restriction": {
+                    "22": 10
+                },
+                "max_contains_weight": "1000 kg",
+                "max_item_length": "1 km"
+            }
+        ]
+    },
+    {
+        "type": "MAGAZINE",
+        "id": "ruger1022bigmag",
+        "copy-from": "ruger1022bigmag",
+        "name": {
+            "str": "Ruger 10/22 25-round magazine"
+        },
+        "pocket_data": [
+            {
+                "pocket_type": "MAGAZINE",
+                "rigid": true,
+                "ammo_restriction": {
+                    "22": 25
+                },
+                "max_contains_weight": "1000 kg",
+                "max_item_length": "1 km"
+            }
+        ]
+    },
+    {
+        "type": "MAGAZINE",
+        "id": "ruger1022mag",
+        "copy-from": "ruger1022mag",
+        "name": {
+            "str": "Ruger 10/22 10-round rotary magazine"
+        },
+        "pocket_data": [
+            {
+                "pocket_type": "MAGAZINE",
+                "rigid": true,
+                "ammo_restriction": {
+                    "22": 10
+                },
+                "max_contains_weight": "1000 kg",
+                "max_item_length": "1 km"
+            }
+        ]
+    },
+    {
+        "type": "MAGAZINE",
+        "id": "sw22mag",
+        "copy-from": "sw22mag",
+        "name": {
+            "str": "22A 10-round magazine"
+        },
+        "pocket_data": [
+            {
+                "pocket_type": "MAGAZINE",
+                "rigid": true,
+                "ammo_restriction": {
+                    "22": 10
+                },
+                "max_contains_weight": "1000 kg",
+                "max_item_length": "1 km"
+            }
+        ]
+    },
+    {
+        "type": "MAGAZINE",
+        "id": "j22mag",
+        "copy-from": "j22mag",
+        "name": {
+            "str": "J-22 6-round magazine"
+        },
+        "pocket_data": [
+            {
+                "pocket_type": "MAGAZINE",
+                "rigid": true,
+                "ammo_restriction": {
+                    "22": 6
+                },
+                "max_contains_weight": "1000 kg",
+                "max_item_length": "1 km"
+            }
+        ]
+    },
+    {
+        "type": "MAGAZINE",
+        "id": "wp22mag",
+        "copy-from": "wp22mag",
+        "name": {
+            "str": "P22 10-round magazine"
+        },
+        "pocket_data": [
+            {
+                "pocket_type": "MAGAZINE",
+                "rigid": true,
+                "ammo_restriction": {
+                    "22": 10
+                },
+                "max_contains_weight": "1000 kg",
+                "max_item_length": "1 km"
+            }
+        ]
+    }
+]

--- a/Kenan-Modpack/easy_containers/items/magazine/223.json
+++ b/Kenan-Modpack/easy_containers/items/magazine/223.json
@@ -1,0 +1,547 @@
+[
+    {
+        "type": "MAGAZINE",
+        "id": "belt223",
+        "copy-from": "belt223",
+        "name": {
+            "str": "5.56x45mm ammo belt"
+        },
+        "pocket_data": [
+            {
+                "pocket_type": "MAGAZINE",
+                "rigid": true,
+                "ammo_restriction": {
+                    "223": 500
+                },
+                "max_contains_weight": "1000 kg",
+                "max_item_length": "1 km"
+            }
+        ]
+    },
+    {
+        "type": "MAGAZINE",
+        "id": "famasmag",
+        "copy-from": "famasmag",
+        "name": {
+            "str": "MAS 25-round magazine"
+        },
+        "pocket_data": [
+            {
+                "pocket_type": "MAGAZINE",
+                "rigid": true,
+                "ammo_restriction": {
+                    "223": 25
+                },
+                "max_contains_weight": "1000 kg",
+                "max_item_length": "1 km"
+            }
+        ]
+    },
+    {
+        "type": "MAGAZINE",
+        "id": "ruger5",
+        "copy-from": "ruger5",
+        "name": {
+            "str": "Mini-14 5-round magazine"
+        },
+        "pocket_data": [
+            {
+                "pocket_type": "MAGAZINE",
+                "rigid": true,
+                "ammo_restriction": {
+                    "223": 5
+                },
+                "max_contains_weight": "1000 kg",
+                "max_item_length": "1 km"
+            }
+        ]
+    },
+    {
+        "type": "MAGAZINE",
+        "id": "stanag10",
+        "copy-from": "stanag10",
+        "name": {
+            "str": "STANAG 10-round magazine"
+        },
+        "pocket_data": [
+            {
+                "pocket_type": "MAGAZINE",
+                "rigid": true,
+                "ammo_restriction": {
+                    "223": 10,
+                    "300blk": 10
+                },
+                "max_contains_weight": "1000 kg",
+                "max_item_length": "1 km"
+            }
+        ]
+    },
+    {
+        "type": "MAGAZINE",
+        "id": "ruger10",
+        "copy-from": "ruger10",
+        "name": {
+            "str": "Mini-14 10-round magazine"
+        },
+        "pocket_data": [
+            {
+                "pocket_type": "MAGAZINE",
+                "rigid": true,
+                "ammo_restriction": {
+                    "223": 10
+                },
+                "max_contains_weight": "1000 kg",
+                "max_item_length": "1 km"
+            }
+        ]
+    },
+    {
+        "type": "MAGAZINE",
+        "id": "ruger20",
+        "copy-from": "ruger20",
+        "name": {
+            "str": "Mini-14 20-round magazine"
+        },
+        "pocket_data": [
+            {
+                "pocket_type": "MAGAZINE",
+                "rigid": true,
+                "ammo_restriction": {
+                    "223": 20
+                },
+                "max_contains_weight": "1000 kg",
+                "max_item_length": "1 km"
+            }
+        ]
+    },
+    {
+        "type": "MAGAZINE",
+        "id": "ruger30",
+        "copy-from": "ruger30",
+        "name": {
+            "str": "Mini-14 30-round magazine"
+        },
+        "pocket_data": [
+            {
+                "pocket_type": "MAGAZINE",
+                "rigid": true,
+                "ammo_restriction": {
+                    "223": 30
+                },
+                "max_contains_weight": "1000 kg",
+                "max_item_length": "1 km"
+            }
+        ]
+    },
+    {
+        "type": "MAGAZINE",
+        "id": "ruger90",
+        "copy-from": "ruger90",
+        "name": {
+            "str": "Mini-14 90-round snail drum magazine"
+        },
+        "pocket_data": [
+            {
+                "pocket_type": "MAGAZINE",
+                "rigid": true,
+                "ammo_restriction": {
+                    "223": 90
+                },
+                "max_contains_weight": "1000 kg",
+                "max_item_length": "1 km"
+            }
+        ]
+    },
+    {
+        "type": "MAGAZINE",
+        "id": "ruger100",
+        "copy-from": "ruger100",
+        "name": {
+            "str": "Mini-14 100-round double drum magazine"
+        },
+        "pocket_data": [
+            {
+                "pocket_type": "MAGAZINE",
+                "rigid": true,
+                "ammo_restriction": {
+                    "223": 100
+                },
+                "max_contains_weight": "1000 kg",
+                "max_item_length": "1 km"
+            }
+        ]
+    },
+    {
+        "type": "MAGAZINE",
+        "id": "stanag5",
+        "copy-from": "stanag5",
+        "name": {
+            "str": "STANAG 5-round magazine"
+        },
+        "pocket_data": [
+            {
+                "pocket_type": "MAGAZINE",
+                "rigid": true,
+                "ammo_restriction": {
+                    "223": 5,
+                    "300blk": 5
+                },
+                "max_contains_weight": "1000 kg",
+                "max_item_length": "1 km"
+            }
+        ]
+    },
+    {
+        "type": "MAGAZINE",
+        "id": "stanag20",
+        "copy-from": "stanag20",
+        "name": {
+            "str": "STANAG 20-round magazine"
+        },
+        "pocket_data": [
+            {
+                "pocket_type": "MAGAZINE",
+                "rigid": true,
+                "ammo_restriction": {
+                    "223": 20,
+                    "300blk": 20
+                },
+                "max_contains_weight": "1000 kg",
+                "max_item_length": "1 km"
+            }
+        ]
+    },
+    {
+        "type": "MAGAZINE",
+        "id": "stanag30",
+        "copy-from": "stanag30",
+        "name": {
+            "str": "STANAG 30-round magazine"
+        },
+        "pocket_data": [
+            {
+                "pocket_type": "MAGAZINE",
+                "rigid": true,
+                "ammo_restriction": {
+                    "223": 30,
+                    "300blk": 30
+                },
+                "max_contains_weight": "1000 kg",
+                "max_item_length": "1 km"
+            }
+        ]
+    },
+    {
+        "type": "MAGAZINE",
+        "id": "stanag40",
+        "copy-from": "stanag40",
+        "name": {
+            "str": "STANAG 40-round magazine"
+        },
+        "pocket_data": [
+            {
+                "pocket_type": "MAGAZINE",
+                "rigid": true,
+                "ammo_restriction": {
+                    "223": 40,
+                    "300blk": 40
+                },
+                "max_contains_weight": "1000 kg",
+                "max_item_length": "1 km"
+            }
+        ]
+    },
+    {
+        "type": "MAGAZINE",
+        "id": "stanag50",
+        "copy-from": "stanag50",
+        "name": {
+            "str": "STANAG 50-round drum magazine"
+        },
+        "pocket_data": [
+            {
+                "pocket_type": "MAGAZINE",
+                "rigid": true,
+                "ammo_restriction": {
+                    "223": 50,
+                    "300blk": 50
+                },
+                "max_contains_weight": "1000 kg",
+                "max_item_length": "1 km"
+            }
+        ]
+    },
+    {
+        "type": "MAGAZINE",
+        "id": "stanag60",
+        "copy-from": "stanag60",
+        "name": {
+            "str": "STANAG 60-round magazine"
+        },
+        "pocket_data": [
+            {
+                "pocket_type": "MAGAZINE",
+                "rigid": true,
+                "ammo_restriction": {
+                    "223": 60,
+                    "300blk": 60
+                },
+                "max_contains_weight": "1000 kg",
+                "max_item_length": "1 km"
+            }
+        ]
+    },
+    {
+        "type": "MAGAZINE",
+        "id": "stanag60drum",
+        "copy-from": "stanag60drum",
+        "name": {
+            "str": "STANAG 60-round drum magazine"
+        },
+        "pocket_data": [
+            {
+                "pocket_type": "MAGAZINE",
+                "rigid": true,
+                "ammo_restriction": {
+                    "223": 60,
+                    "300blk": 60
+                },
+                "max_contains_weight": "1000 kg",
+                "max_item_length": "1 km"
+            }
+        ]
+    },
+    {
+        "type": "MAGAZINE",
+        "id": "stanag90",
+        "copy-from": "stanag90",
+        "name": {
+            "str": "STANAG 90-round snail drum magazine"
+        },
+        "pocket_data": [
+            {
+                "pocket_type": "MAGAZINE",
+                "rigid": true,
+                "ammo_restriction": {
+                    "223": 90,
+                    "300blk": 90
+                },
+                "max_contains_weight": "1000 kg",
+                "max_item_length": "1 km"
+            }
+        ]
+    },
+    {
+        "type": "MAGAZINE",
+        "id": "stanag100",
+        "copy-from": "stanag100",
+        "name": {
+            "str": "STANAG 100-round magazine"
+        },
+        "pocket_data": [
+            {
+                "pocket_type": "MAGAZINE",
+                "rigid": true,
+                "ammo_restriction": {
+                    "223": 100,
+                    "300blk": 100
+                },
+                "max_contains_weight": "1000 kg",
+                "max_item_length": "1 km"
+            }
+        ]
+    },
+    {
+        "type": "MAGAZINE",
+        "id": "stanag100drum",
+        "copy-from": "stanag100drum",
+        "name": {
+            "str": "STANAG 100-round double drum magazine"
+        },
+        "pocket_data": [
+            {
+                "pocket_type": "MAGAZINE",
+                "rigid": true,
+                "ammo_restriction": {
+                    "223": 100,
+                    "300blk": 100
+                },
+                "max_contains_weight": "1000 kg",
+                "max_item_length": "1 km"
+            }
+        ]
+    },
+    {
+        "type": "MAGAZINE",
+        "id": "stanag150",
+        "copy-from": "stanag150",
+        "name": {
+            "str": "STANAG 150-round double drum magazine"
+        },
+        "pocket_data": [
+            {
+                "pocket_type": "MAGAZINE",
+                "rigid": true,
+                "ammo_restriction": {
+                    "223": 150,
+                    "300blk": 150
+                },
+                "max_contains_weight": "1000 kg",
+                "max_item_length": "1 km"
+            }
+        ]
+    },
+    {
+        "type": "MAGAZINE",
+        "id": "g36mag_30rd",
+        "copy-from": "g36mag_30rd",
+        "name": {
+            "str": "G36 30-round magazine"
+        },
+        "pocket_data": [
+            {
+                "pocket_type": "MAGAZINE",
+                "rigid": true,
+                "ammo_restriction": {
+                    "223": 30
+                },
+                "max_contains_weight": "1000 kg",
+                "max_item_length": "1 km"
+            }
+        ]
+    },
+    {
+        "type": "MAGAZINE",
+        "id": "g36mag_100rd",
+        "copy-from": "g36mag_100rd",
+        "name": {
+            "str": "G36 100-round double drum magazine"
+        },
+        "pocket_data": [
+            {
+                "pocket_type": "MAGAZINE",
+                "rigid": true,
+                "ammo_restriction": {
+                    "223": 100
+                },
+                "max_contains_weight": "1000 kg",
+                "max_item_length": "1 km"
+            }
+        ]
+    },
+    {
+        "type": "MAGAZINE",
+        "id": "augmag_10rd",
+        "copy-from": "augmag_10rd",
+        "name": {
+            "str": "AUG 10-round magazine"
+        },
+        "pocket_data": [
+            {
+                "pocket_type": "MAGAZINE",
+                "rigid": true,
+                "ammo_restriction": {
+                    "223": 10
+                },
+                "max_contains_weight": "1000 kg",
+                "max_item_length": "1 km"
+            }
+        ]
+    },
+    {
+        "type": "MAGAZINE",
+        "id": "augmag_30rd",
+        "copy-from": "augmag_30rd",
+        "name": {
+            "str": "AUG 30-round magazine"
+        },
+        "pocket_data": [
+            {
+                "pocket_type": "MAGAZINE",
+                "rigid": true,
+                "ammo_restriction": {
+                    "223": 30
+                },
+                "max_contains_weight": "1000 kg",
+                "max_item_length": "1 km"
+            }
+        ]
+    },
+    {
+        "type": "MAGAZINE",
+        "id": "augmag_42rd",
+        "copy-from": "augmag_42rd",
+        "name": {
+            "str": "AUG 42-round magazine"
+        },
+        "pocket_data": [
+            {
+                "pocket_type": "MAGAZINE",
+                "rigid": true,
+                "ammo_restriction": {
+                    "223": 42
+                },
+                "max_contains_weight": "1000 kg",
+                "max_item_length": "1 km"
+            }
+        ]
+    },
+    {
+        "type": "MAGAZINE",
+        "id": "augmag_100rd",
+        "copy-from": "augmag_100rd",
+        "name": {
+            "str": "AUG 100-round double drum magazine"
+        },
+        "pocket_data": [
+            {
+                "pocket_type": "MAGAZINE",
+                "rigid": true,
+                "ammo_restriction": {
+                    "223": 100
+                },
+                "max_contains_weight": "1000 kg",
+                "max_item_length": "1 km"
+            }
+        ]
+    },
+    {
+        "type": "MAGAZINE",
+        "id": "survivor223mag",
+        "copy-from": "survivor223mag",
+        "name": {
+            "str": "STANAG 5-round makeshift magazine"
+        },
+        "pocket_data": [
+            {
+                "pocket_type": "MAGAZINE",
+                "rigid": true,
+                "ammo_restriction": {
+                    "223": 5,
+                    "300blk": 5
+                },
+                "max_contains_weight": "1000 kg",
+                "max_item_length": "1 km"
+            }
+        ]
+    },
+    {
+        "type": "MAGAZINE",
+        "id": "ruger_makeshiftmag",
+        "copy-from": "ruger_makeshiftmag",
+        "name": {
+            "str": "Mini-14 5-round makeshift magazine"
+        },
+        "pocket_data": [
+            {
+                "pocket_type": "MAGAZINE",
+                "rigid": true,
+                "ammo_restriction": {
+                    "223": 5
+                },
+                "max_contains_weight": "1000 kg",
+                "max_item_length": "1 km"
+            }
+        ]
+    }
+]

--- a/Kenan-Modpack/easy_containers/items/magazine/300.json
+++ b/Kenan-Modpack/easy_containers/items/magazine/300.json
@@ -1,0 +1,21 @@
+[
+    {
+        "type": "MAGAZINE",
+        "id": "m2010mag",
+        "copy-from": "m2010mag",
+        "name": {
+            "str": "M2010 5-round magazine"
+        },
+        "pocket_data": [
+            {
+                "pocket_type": "MAGAZINE",
+                "rigid": true,
+                "ammo_restriction": {
+                    "300": 5
+                },
+                "max_contains_weight": "1000 kg",
+                "max_item_length": "1 km"
+            }
+        ]
+    }
+]

--- a/Kenan-Modpack/easy_containers/items/magazine/3006.json
+++ b/Kenan-Modpack/easy_containers/items/magazine/3006.json
@@ -1,0 +1,97 @@
+[
+    {
+        "type": "MAGAZINE",
+        "id": "3006_clip",
+        "copy-from": "3006_clip",
+        "name": {
+            "str": ".30-06 5-round clip"
+        },
+        "pocket_data": [
+            {
+                "pocket_type": "MAGAZINE",
+                "rigid": true,
+                "ammo_restriction": {
+                    "3006": 5
+                },
+                "max_contains_weight": "1000 kg",
+                "max_item_length": "1 km"
+            }
+        ]
+    },
+    {
+        "type": "MAGAZINE",
+        "id": "blrmag",
+        "copy-from": "blrmag",
+        "name": {
+            "str": "Browning BLR 4-round magazine"
+        },
+        "pocket_data": [
+            {
+                "pocket_type": "MAGAZINE",
+                "rigid": true,
+                "ammo_restriction": {
+                    "3006": 4
+                },
+                "max_contains_weight": "1000 kg",
+                "max_item_length": "1 km"
+            }
+        ]
+    },
+    {
+        "type": "MAGAZINE",
+        "id": "garandclip",
+        "copy-from": "garandclip",
+        "name": {
+            "str": "M1 Garand 8-round clip"
+        },
+        "pocket_data": [
+            {
+                "pocket_type": "MAGAZINE",
+                "rigid": true,
+                "ammo_restriction": {
+                    "3006": 8
+                },
+                "max_contains_weight": "1000 kg",
+                "max_item_length": "1 km"
+            }
+        ]
+    },
+    {
+        "type": "MAGAZINE",
+        "id": "m1918bigmag",
+        "copy-from": "m1918bigmag",
+        "name": {
+            "str": "BAR 30-round magazine"
+        },
+        "pocket_data": [
+            {
+                "pocket_type": "MAGAZINE",
+                "rigid": true,
+                "ammo_restriction": {
+                    "3006": 30
+                },
+                "max_contains_weight": "1000 kg",
+                "max_item_length": "1 km"
+            }
+        ]
+    },
+    {
+        "type": "MAGAZINE",
+        "id": "m1918mag",
+        "copy-from": "m1918mag",
+        "name": {
+            "str": "BAR 20-round magazine"
+        },
+        "pocket_data": [
+            {
+                "pocket_type": "MAGAZINE",
+                "rigid": true,
+                "ammo_restriction": {
+                    "3006": 20
+                },
+                "max_contains_weight": "1000 kg",
+                "max_item_length": "1 km"
+            }
+        ]
+    }
+]

--- a/Kenan-Modpack/easy_containers/items/magazine/308.json
+++ b/Kenan-Modpack/easy_containers/items/magazine/308.json
@@ -1,0 +1,249 @@
+[
+    {
+        "type": "MAGAZINE",
+        "id": "belt308",
+        "copy-from": "belt308",
+        "name": {
+            "str": "7.62x51mm ammo belt"
+        },
+        "pocket_data": [
+            {
+                "pocket_type": "MAGAZINE",
+                "rigid": true,
+                "ammo_restriction": {
+                    "308": 500
+                },
+                "max_contains_weight": "1000 kg",
+                "max_item_length": "1 km"
+            }
+        ]
+    },
+    {
+        "type": "MAGAZINE",
+        "id": "falbigmag",
+        "copy-from": "falbigmag",
+        "name": {
+            "str": "FAL 30-round magazine"
+        },
+        "pocket_data": [
+            {
+                "pocket_type": "MAGAZINE",
+                "rigid": true,
+                "ammo_restriction": {
+                    "308": 30
+                },
+                "max_contains_weight": "1000 kg",
+                "max_item_length": "1 km"
+            }
+        ]
+    },
+    {
+        "type": "MAGAZINE",
+        "id": "falmag",
+        "copy-from": "falmag",
+        "name": {
+            "str": "FAL 20-round magazine"
+        },
+        "pocket_data": [
+            {
+                "pocket_type": "MAGAZINE",
+                "rigid": true,
+                "ammo_restriction": {
+                    "308": 20
+                },
+                "max_contains_weight": "1000 kg",
+                "max_item_length": "1 km"
+            }
+        ]
+    },
+    {
+        "type": "MAGAZINE",
+        "id": "fal_makeshiftmag",
+        "copy-from": "fal_makeshiftmag",
+        "name": {
+            "str": "FAL 5-round makeshift magazine"
+        },
+        "pocket_data": [
+            {
+                "pocket_type": "MAGAZINE",
+                "rigid": true,
+                "ammo_restriction": {
+                    "308": 5
+                },
+                "max_contains_weight": "1000 kg",
+                "max_item_length": "1 km"
+            }
+        ]
+    },
+    {
+        "type": "MAGAZINE",
+        "id": "g3bigmag",
+        "copy-from": "g3bigmag",
+        "name": {
+            "str": "G3 50-round drum magazine"
+        },
+        "pocket_data": [
+            {
+                "pocket_type": "MAGAZINE",
+                "rigid": true,
+                "ammo_restriction": {
+                    "308": 50
+                },
+                "max_contains_weight": "1000 kg",
+                "max_item_length": "1 km"
+            }
+        ]
+    },
+    {
+        "type": "MAGAZINE",
+        "id": "g3mag",
+        "copy-from": "g3mag",
+        "name": {
+            "str": "G3 20-round magazine"
+        },
+        "pocket_data": [
+            {
+                "pocket_type": "MAGAZINE",
+                "rigid": true,
+                "ammo_restriction": {
+                    "308": 20
+                },
+                "max_contains_weight": "1000 kg",
+                "max_item_length": "1 km"
+            }
+        ]
+    },
+    {
+        "type": "MAGAZINE",
+        "id": "m14mag",
+        "copy-from": "m14mag",
+        "name": {
+            "str": "M14 20-round magazine"
+        },
+        "pocket_data": [
+            {
+                "pocket_type": "MAGAZINE",
+                "rigid": true,
+                "ammo_restriction": {
+                    "308": 20
+                },
+                "max_contains_weight": "1000 kg",
+                "max_item_length": "1 km"
+            }
+        ]
+    },
+    {
+        "type": "MAGAZINE",
+        "id": "m14smallmag",
+        "copy-from": "m14smallmag",
+        "name": {
+            "str": "M14 5-round magazine"
+        },
+        "pocket_data": [
+            {
+                "pocket_type": "MAGAZINE",
+                "rigid": true,
+                "ammo_restriction": {
+                    "308": 5
+                },
+                "max_contains_weight": "1000 kg",
+                "max_item_length": "1 km"
+            }
+        ]
+    },
+    {
+        "type": "MAGAZINE",
+        "id": "scarhbigmag",
+        "copy-from": "scarhbigmag",
+        "name": {
+            "str": "SCAR-H 50-round drum magazine"
+        },
+        "pocket_data": [
+            {
+                "pocket_type": "MAGAZINE",
+                "rigid": true,
+                "ammo_restriction": {
+                    "308": 50
+                },
+                "max_contains_weight": "1000 kg",
+                "max_item_length": "1 km"
+            }
+        ]
+    },
+    {
+        "type": "MAGAZINE",
+        "id": "scarhmag",
+        "copy-from": "scarhmag",
+        "name": {
+            "str": "SCAR-H 20-round magazine"
+        },
+        "pocket_data": [
+            {
+                "pocket_type": "MAGAZINE",
+                "rigid": true,
+                "ammo_restriction": {
+                    "308": 20
+                },
+                "max_contains_weight": "1000 kg",
+                "max_item_length": "1 km"
+            }
+        ]
+    },
+    {
+        "type": "MAGAZINE",
+        "id": "hk417mag_20rd",
+        "copy-from": "hk417mag_20rd",
+        "name": {
+            "str": "HK417 20-round magazine"
+        },
+        "pocket_data": [
+            {
+                "pocket_type": "MAGAZINE",
+                "rigid": true,
+                "ammo_restriction": {
+                    "308": 20
+                },
+                "max_contains_weight": "1000 kg",
+                "max_item_length": "1 km"
+            }
+        ]
+    },
+    {
+        "type": "MAGAZINE",
+        "id": "hk417mag_10rd",
+        "copy-from": "hk417mag_10rd",
+        "name": {
+            "str": "HK417 10-round magazine"
+        },
+        "pocket_data": [
+            {
+                "pocket_type": "MAGAZINE",
+                "rigid": true,
+                "ammo_restriction": {
+                    "308": 10
+                },
+                "max_contains_weight": "1000 kg",
+                "max_item_length": "1 km"
+            }
+        ]
+    },
+    {
+        "type": "MAGAZINE",
+        "id": "ar10mag_20rd",
+        "copy-from": "ar10mag_20rd",
+        "name": {
+            "str": "AR-10 20-round magazine"
+        },
+        "pocket_data": [
+            {
+                "pocket_type": "MAGAZINE",
+                "rigid": true,
+                "ammo_restriction": {
+                    "308": 20
+                },
+                "max_contains_weight": "1000 kg",
+                "max_item_length": "1 km"
+            }
+        ]
+    }
+]

--- a/Kenan-Modpack/easy_containers/items/magazine/32.json
+++ b/Kenan-Modpack/easy_containers/items/magazine/32.json
@@ -1,0 +1,78 @@
+[
+    {
+        "type": "MAGAZINE",
+        "id": "ppkmag",
+        "copy-from": "ppkmag",
+        "name": {
+            "str": "PPK 8-round magazine"
+        },
+        "pocket_data": [
+            {
+                "pocket_type": "MAGAZINE",
+                "rigid": true,
+                "ammo_restriction": {
+                    "32": 8
+                },
+                "max_contains_weight": "1000 kg",
+                "max_item_length": "1 km"
+            }
+        ]
+    },
+    {
+        "type": "MAGAZINE",
+        "id": "sigp230mag",
+        "copy-from": "sigp230mag",
+        "name": {
+            "str": "P230 8-round magazine"
+        },
+        "pocket_data": [
+            {
+                "pocket_type": "MAGAZINE",
+                "rigid": true,
+                "ammo_restriction": {
+                    "32": 8
+                },
+                "max_contains_weight": "1000 kg",
+                "max_item_length": "1 km"
+            }
+        ]
+    },
+    {
+        "type": "MAGAZINE",
+        "id": "skorpion61mag",
+        "copy-from": "skorpion61mag",
+        "name": {
+            "str": "Skorpion Vz. 61 20-round magazine"
+        },
+        "pocket_data": [
+            {
+                "pocket_type": "MAGAZINE",
+                "rigid": true,
+                "ammo_restriction": {
+                    "32": 20
+                },
+                "max_contains_weight": "1000 kg",
+                "max_item_length": "1 km"
+            }
+        ]
+    },
+    {
+        "type": "MAGAZINE",
+        "id": "kp32mag",
+        "copy-from": "kp32mag",
+        "name": {
+            "str": "P32 7-round magazine"
+        },
+        "pocket_data": [
+            {
+                "pocket_type": "MAGAZINE",
+                "rigid": true,
+                "ammo_restriction": {
+                    "32": 7
+                },
+                "max_contains_weight": "1000 kg",
+                "max_item_length": "1 km"
+            }
+        ]
+    }
+]

--- a/Kenan-Modpack/easy_containers/items/magazine/357sig.json
+++ b/Kenan-Modpack/easy_containers/items/magazine/357sig.json
@@ -1,0 +1,40 @@
+[
+    {
+        "type": "MAGAZINE",
+        "id": "p226mag_12rd_357sig",
+        "copy-from": "p226mag_12rd_357sig",
+        "name": {
+            "str": "P226 .357 SIG 12-round magazine"
+        },
+        "pocket_data": [
+            {
+                "pocket_type": "MAGAZINE",
+                "rigid": true,
+                "ammo_restriction": {
+                    "357sig": 12
+                },
+                "max_contains_weight": "1000 kg",
+                "max_item_length": "1 km"
+            }
+        ]
+    },
+    {
+        "type": "MAGAZINE",
+        "id": "p320mag_13rd_357sig",
+        "copy-from": "p320mag_13rd_357sig",
+        "name": {
+            "str": "P320 .357 SIG 13-round magazine"
+        },
+        "pocket_data": [
+            {
+                "pocket_type": "MAGAZINE",
+                "rigid": true,
+                "ammo_restriction": {
+                    "357sig": 13
+                },
+                "max_contains_weight": "1000 kg",
+                "max_item_length": "1 km"
+            }
+        ]
+    }
+]

--- a/Kenan-Modpack/easy_containers/items/magazine/38.json
+++ b/Kenan-Modpack/easy_containers/items/magazine/38.json
@@ -1,0 +1,62 @@
+[
+    {
+        "type": "MAGAZINE",
+        "id": "38_speedloader",
+        "copy-from": "38_speedloader",
+        "name": {
+            "str": ".38/.357 7-round speedloader"
+        },
+        "pocket_data": [
+            {
+                "pocket_type": "MAGAZINE",
+                "rigid": true,
+                "ammo_restriction": {
+                    "357mag": 7,
+                    "38": 7
+                },
+                "max_contains_weight": "1000 kg",
+                "max_item_length": "1 km"
+            }
+        ]
+    },
+    {
+        "type": "MAGAZINE",
+        "id": "38_speedloader5",
+        "copy-from": "38_speedloader5",
+        "name": {
+            "str": ".38/.357 5-round speedloader"
+        },
+        "pocket_data": [
+            {
+                "pocket_type": "MAGAZINE",
+                "rigid": true,
+                "ammo_restriction": {
+                    "357mag": 5,
+                    "38": 5
+                },
+                "max_contains_weight": "1000 kg",
+                "max_item_length": "1 km"
+            }
+        ]
+    },
+    {
+        "type": "MAGAZINE",
+        "id": "38_speedloader6",
+        "copy-from": "38_speedloader6",
+        "name": {
+            "str": ".38/.357 6-round speedloader"
+        },
+        "pocket_data": [
+            {
+                "pocket_type": "MAGAZINE",
+                "rigid": true,
+                "ammo_restriction": {
+                    "357mag": 6,
+                    "38": 6
+                },
+                "max_contains_weight": "1000 kg",
+                "max_item_length": "1 km"
+            }
+        ]
+    }
+]

--- a/Kenan-Modpack/easy_containers/items/magazine/380.json
+++ b/Kenan-Modpack/easy_containers/items/magazine/380.json
@@ -1,0 +1,135 @@
+[
+    {
+        "type": "MAGAZINE",
+        "id": "kp3atmag",
+        "copy-from": "kp3atmag",
+        "name": {
+            "str": "P3AT 6-round magazine"
+        },
+        "pocket_data": [
+            {
+                "pocket_type": "MAGAZINE",
+                "rigid": true,
+                "ammo_restriction": {
+                    "380": 6
+                },
+                "max_contains_weight": "1000 kg",
+                "max_item_length": "1 km"
+            }
+        ]
+    },
+    {
+        "type": "MAGAZINE",
+        "id": "fn1910mag",
+        "copy-from": "fn1910mag",
+        "name": {
+            "str": "FN 1910 6-round magazine"
+        },
+        "pocket_data": [
+            {
+                "pocket_type": "MAGAZINE",
+                "rigid": true,
+                "ammo_restriction": {
+                    "380": 6
+                },
+                "max_contains_weight": "1000 kg",
+                "max_item_length": "1 km"
+            }
+        ]
+    },
+    {
+        "type": "MAGAZINE",
+        "id": "rugerlcpmag",
+        "copy-from": "rugerlcpmag",
+        "name": {
+            "str": "LCP 6-round magazine"
+        },
+        "pocket_data": [
+            {
+                "pocket_type": "MAGAZINE",
+                "rigid": true,
+                "ammo_restriction": {
+                    "380": 6
+                },
+                "max_contains_weight": "1000 kg",
+                "max_item_length": "1 km"
+            }
+        ]
+    },
+    {
+        "type": "MAGAZINE",
+        "id": "mac11mag",
+        "copy-from": "mac11mag",
+        "name": {
+            "str": "MAC-11 32-round magazine"
+        },
+        "pocket_data": [
+            {
+                "pocket_type": "MAGAZINE",
+                "rigid": true,
+                "ammo_restriction": {
+                    "380": 32
+                },
+                "max_contains_weight": "1000 kg",
+                "max_item_length": "1 km"
+            }
+        ]
+    },
+    {
+        "type": "MAGAZINE",
+        "id": "hptcf380mag_8rd",
+        "copy-from": "hptcf380mag_8rd",
+        "name": {
+            "str": "CF-380 8-round magazine"
+        },
+        "pocket_data": [
+            {
+                "pocket_type": "MAGAZINE",
+                "rigid": true,
+                "ammo_restriction": {
+                    "380": 8
+                },
+                "max_contains_weight": "1000 kg",
+                "max_item_length": "1 km"
+            }
+        ]
+    },
+    {
+        "type": "MAGAZINE",
+        "id": "hptcf380mag_10rd",
+        "copy-from": "hptcf380mag_10rd",
+        "name": {
+            "str": "CF-380 10-round magazine"
+        },
+        "pocket_data": [
+            {
+                "pocket_type": "MAGAZINE",
+                "rigid": true,
+                "ammo_restriction": {
+                    "380": 10
+                },
+                "max_contains_weight": "1000 kg",
+                "max_item_length": "1 km"
+            }
+        ]
+    },
+    {
+        "type": "MAGAZINE",
+        "id": "taurus_spectrum_mag",
+        "copy-from": "taurus_spectrum_mag",
+        "name": {
+            "str": "Taurus Spectrum 6-round magazine"
+        },
+        "pocket_data": [
+            {
+                "pocket_type": "MAGAZINE",
+                "rigid": true,
+                "ammo_restriction": {
+                    "380": 6
+                },
+                "max_contains_weight": "1000 kg",
+                "max_item_length": "1 km"
+            }
+        ]
+    }
+]

--- a/Kenan-Modpack/easy_containers/items/magazine/38super.json
+++ b/Kenan-Modpack/easy_containers/items/magazine/38super.json
@@ -1,0 +1,40 @@
+[
+    {
+        "type": "MAGAZINE",
+        "id": "af2011a1mag",
+        "copy-from": "af2011a1mag",
+        "name": {
+            "str": "AF2011A1 16-round double magazine"
+        },
+        "pocket_data": [
+            {
+                "pocket_type": "MAGAZINE",
+                "rigid": true,
+                "ammo_restriction": {
+                    "38super": 16
+                },
+                "max_contains_weight": "1000 kg",
+                "max_item_length": "1 km"
+            }
+        ]
+    },
+    {
+        "type": "MAGAZINE",
+        "id": "m1911mag_10rd_38super",
+        "copy-from": "m1911mag_10rd_38super",
+        "name": {
+            "str": "M1911 .38 Super 9-round magazine"
+        },
+        "pocket_data": [
+            {
+                "pocket_type": "MAGAZINE",
+                "rigid": true,
+                "ammo_restriction": {
+                    "38super": 9
+                },
+                "max_contains_weight": "1000 kg",
+                "max_item_length": "1 km"
+            }
+        ]
+    }
+]

--- a/Kenan-Modpack/easy_containers/items/magazine/40.json
+++ b/Kenan-Modpack/easy_containers/items/magazine/40.json
@@ -1,0 +1,213 @@
+[
+    {
+        "type": "MAGAZINE",
+        "id": "90two40mag",
+        "copy-from": "90two40mag",
+        "name": {
+            "str": "90-two .40 S&W 12-round magazine"
+        },
+        "pocket_data": [
+            {
+                "pocket_type": "MAGAZINE",
+                "rigid": true,
+                "ammo_restriction": {
+                    "40": 12
+                },
+                "max_contains_weight": "1000 kg",
+                "max_item_length": "1 km"
+            }
+        ]
+    },
+    {
+        "type": "MAGAZINE",
+        "id": "glock40bigmag",
+        "copy-from": "glock40bigmag",
+        "name": {
+            "str": "Glock .40 S&W/.357 SIG 22-round magazine"
+        },
+        "pocket_data": [
+            {
+                "pocket_type": "MAGAZINE",
+                "rigid": true,
+                "ammo_restriction": {
+                    "40": 22,
+                    "357sig": 22
+                },
+                "max_contains_weight": "1000 kg",
+                "max_item_length": "1 km"
+            }
+        ]
+    },
+    {
+        "type": "MAGAZINE",
+        "id": "glock40mag",
+        "copy-from": "glock40mag",
+        "name": {
+            "str": "Glock .40 S&W/.357 SIG 15-round magazine"
+        },
+        "pocket_data": [
+            {
+                "pocket_type": "MAGAZINE",
+                "rigid": true,
+                "ammo_restriction": {
+                    "40": 15,
+                    "357sig": 15
+                },
+                "max_contains_weight": "1000 kg",
+                "max_item_length": "1 km"
+            }
+        ]
+    },
+    {
+        "type": "MAGAZINE",
+        "id": "px4_40mag",
+        "copy-from": "px4_40mag",
+        "name": {
+            "str": "Px4 .40 S&W 14-round magazine"
+        },
+        "pocket_data": [
+            {
+                "pocket_type": "MAGAZINE",
+                "rigid": true,
+                "ammo_restriction": {
+                    "40": 14
+                },
+                "max_contains_weight": "1000 kg",
+                "max_item_length": "1 km"
+            }
+        ]
+    },
+    {
+        "type": "MAGAZINE",
+        "id": "sig40mag",
+        "copy-from": "sig40mag",
+        "name": {
+            "str": "SIG Pro .40 12-round magazine"
+        },
+        "pocket_data": [
+            {
+                "pocket_type": "MAGAZINE",
+                "rigid": true,
+                "ammo_restriction": {
+                    "40": 12
+                },
+                "max_contains_weight": "1000 kg",
+                "max_item_length": "1 km"
+            }
+        ]
+    },
+    {
+        "type": "MAGAZINE",
+        "id": "smg_40_mag",
+        "copy-from": "smg_40_mag",
+        "name": {
+            "str": "makeshift .40 20-round magazine"
+        },
+        "pocket_data": [
+            {
+                "pocket_type": "MAGAZINE",
+                "rigid": true,
+                "ammo_restriction": {
+                    "40": 20
+                },
+                "max_contains_weight": "1000 kg",
+                "max_item_length": "1 km"
+            }
+        ]
+    },
+    {
+        "type": "MAGAZINE",
+        "id": "bhp40mag",
+        "copy-from": "bhp40mag",
+        "name": {
+            "str": "Hi-Power .40 S&W 10-round magazine"
+        },
+        "pocket_data": [
+            {
+                "pocket_type": "MAGAZINE",
+                "rigid": true,
+                "ammo_restriction": {
+                    "40": 10
+                },
+                "max_contains_weight": "1000 kg",
+                "max_item_length": "1 km"
+            }
+        ]
+    },
+    {
+        "type": "MAGAZINE",
+        "id": "ppq40mag_10rd",
+        "copy-from": "ppq40mag_10rd",
+        "name": {
+            "str": "PPQ .40 S&W 10-round magazine"
+        },
+        "pocket_data": [
+            {
+                "pocket_type": "MAGAZINE",
+                "rigid": true,
+                "ammo_restriction": {
+                    "40": 10
+                },
+                "max_contains_weight": "1000 kg",
+                "max_item_length": "1 km"
+            }
+        ]
+    },
+    {
+        "type": "MAGAZINE",
+        "id": "ppq40mag_12rd",
+        "copy-from": "ppq40mag_12rd",
+        "name": {
+            "str": "PPQ .40 S&W 12-round magazine"
+        },
+        "pocket_data": [
+            {
+                "pocket_type": "MAGAZINE",
+                "rigid": true,
+                "ammo_restriction": {
+                    "40": 12
+                },
+                "max_contains_weight": "1000 kg",
+                "max_item_length": "1 km"
+            }
+        ]
+    },
+    {
+        "type": "MAGAZINE",
+        "id": "ppq40mag_14rd",
+        "copy-from": "ppq40mag_14rd",
+        "name": {
+            "str": "PPQ .40 S&W 14-round magazine"
+        },
+        "pocket_data": [
+            {
+                "pocket_type": "MAGAZINE",
+                "rigid": true,
+                "ammo_restriction": {
+                    "40": 14
+                },
+                "max_contains_weight": "1000 kg",
+                "max_item_length": "1 km"
+            }
+        ]
+    },
+    {
+        "type": "MAGAZINE",
+        "id": "hptjcpmag",
+        "copy-from": "hptjcpmag",
+        "name": {
+            "str": "Model JCP 10-round magazine"
+        },
+        "pocket_data": [
+            {
+                "pocket_type": "MAGAZINE",
+                "rigid": true,
+                "ammo_restriction": {
+                    "40": 10
+                },
+                "max_contains_weight": "1000 kg",
+                "max_item_length": "1 km"
+            }
+        ]
+    }
+]

--- a/Kenan-Modpack/easy_containers/items/magazine/40mm.json
+++ b/Kenan-Modpack/easy_containers/items/magazine/40mm.json
@@ -1,0 +1,21 @@
+[
+    {
+        "type": "MAGAZINE",
+        "id": "belt40mm",
+        "copy-from": "belt40mm",
+        "name": {
+            "str": "40x53mm grenade belt"
+        },
+        "pocket_data": [
+            {
+                "pocket_type": "MAGAZINE",
+                "rigid": true,
+                "ammo_restriction": {
+                    "40x53mm": 50
+                },
+                "max_contains_weight": "1000 kg",
+                "max_item_length": "1 km"
+            }
+        ]
+    }
+]

--- a/Kenan-Modpack/easy_containers/items/magazine/410shot.json
+++ b/Kenan-Modpack/easy_containers/items/magazine/410shot.json
@@ -1,0 +1,40 @@
+[
+    {
+        "type": "MAGAZINE",
+        "id": "saiga410mag_10rd",
+        "copy-from": "saiga410mag_10rd",
+        "name": {
+            "str": "Saiga-410 10-round magazine"
+        },
+        "pocket_data": [
+            {
+                "pocket_type": "MAGAZINE",
+                "rigid": true,
+                "ammo_restriction": {
+                    "410shot": 10
+                },
+                "max_contains_weight": "1000 kg",
+                "max_item_length": "1 km"
+            }
+        ]
+    },
+    {
+        "type": "MAGAZINE",
+        "id": "saiga410mag_30rd",
+        "copy-from": "saiga410mag_30rd",
+        "name": {
+            "str": "Saiga-410 30-round drum magazine"
+        },
+        "pocket_data": [
+            {
+                "pocket_type": "MAGAZINE",
+                "rigid": true,
+                "ammo_restriction": {
+                    "410shot": 30
+                },
+                "max_contains_weight": "1000 kg",
+                "max_item_length": "1 km"
+            }
+        ]
+    }
+]

--- a/Kenan-Modpack/easy_containers/items/magazine/44.json
+++ b/Kenan-Modpack/easy_containers/items/magazine/44.json
@@ -1,0 +1,40 @@
+[
+    {
+        "type": "MAGAZINE",
+        "id": "44_speedloader6",
+        "copy-from": "44_speedloader6",
+        "name": {
+            "str": ".44 6-round speedloader"
+        },
+        "pocket_data": [
+            {
+                "pocket_type": "MAGAZINE",
+                "rigid": true,
+                "ammo_restriction": {
+                    "44": 6
+                },
+                "max_contains_weight": "1000 kg",
+                "max_item_length": "1 km"
+            }
+        ]
+    },
+    {
+        "type": "MAGAZINE",
+        "id": "deaglemag",
+        "copy-from": "deaglemag",
+        "name": {
+            "str": "Desert Eagle 8-round magazine"
+        },
+        "pocket_data": [
+            {
+                "pocket_type": "MAGAZINE",
+                "rigid": true,
+                "ammo_restriction": {
+                    "44": 8
+                },
+                "max_contains_weight": "1000 kg",
+                "max_item_length": "1 km"
+            }
+        ]
+    }
+]

--- a/Kenan-Modpack/easy_containers/items/magazine/45.json
+++ b/Kenan-Modpack/easy_containers/items/magazine/45.json
@@ -1,0 +1,230 @@
+[
+    {
+        "type": "MAGAZINE",
+        "id": "mac10mag",
+        "copy-from": "mac10mag",
+        "name": {
+            "str": "MAC-10 30-round magazine"
+        },
+        "pocket_data": [
+            {
+                "pocket_type": "MAGAZINE",
+                "rigid": true,
+                "ammo_restriction": {
+                    "45": 30
+                },
+                "max_contains_weight": "1000 kg",
+                "max_item_length": "1 km"
+            }
+        ]
+    },
+    {
+        "type": "MAGAZINE",
+        "id": "smg_45_mag",
+        "copy-from": "smg_45_mag",
+        "name": {
+            "str": "MAC-10 20-round makeshift magazine"
+        },
+        "pocket_data": [
+            {
+                "pocket_type": "MAGAZINE",
+                "rigid": true,
+                "ammo_restriction": {
+                    "45": 20
+                },
+                "max_contains_weight": "1000 kg",
+                "max_item_length": "1 km"
+            }
+        ]
+    },
+    {
+        "type": "MAGAZINE",
+        "id": "tdi_mag",
+        "copy-from": "tdi_mag",
+        "name": {
+            "str": "Vector SMG 30-round magazine"
+        },
+        "pocket_data": [
+            {
+                "pocket_type": "MAGAZINE",
+                "rigid": true,
+                "ammo_restriction": {
+                    "45": 30
+                },
+                "max_contains_weight": "1000 kg",
+                "max_item_length": "1 km"
+            }
+        ]
+    },
+    {
+        "type": "MAGAZINE",
+        "id": "thompson_bigmag",
+        "copy-from": "thompson_bigmag",
+        "name": {
+            "str": "Thompson 30-round magazine"
+        },
+        "pocket_data": [
+            {
+                "pocket_type": "MAGAZINE",
+                "rigid": true,
+                "ammo_restriction": {
+                    "45": 30
+                },
+                "max_contains_weight": "1000 kg",
+                "max_item_length": "1 km"
+            }
+        ]
+    },
+    {
+        "type": "MAGAZINE",
+        "id": "thompson_drum",
+        "copy-from": "thompson_drum",
+        "name": {
+            "str": "Thompson 50-round drum magazine"
+        },
+        "pocket_data": [
+            {
+                "pocket_type": "MAGAZINE",
+                "rigid": true,
+                "ammo_restriction": {
+                    "45": 50
+                },
+                "max_contains_weight": "1000 kg",
+                "max_item_length": "1 km"
+            }
+        ]
+    },
+    {
+        "type": "MAGAZINE",
+        "id": "thompson_mag",
+        "copy-from": "thompson_mag",
+        "name": {
+            "str": "Thompson 20-round magazine"
+        },
+        "pocket_data": [
+            {
+                "pocket_type": "MAGAZINE",
+                "rigid": true,
+                "ammo_restriction": {
+                    "45": 20
+                },
+                "max_contains_weight": "1000 kg",
+                "max_item_length": "1 km"
+            }
+        ]
+    },
+    {
+        "type": "MAGAZINE",
+        "id": "ump45mag",
+        "copy-from": "ump45mag",
+        "name": {
+            "str": "UMP45 25-round magazine"
+        },
+        "pocket_data": [
+            {
+                "pocket_type": "MAGAZINE",
+                "rigid": true,
+                "ammo_restriction": {
+                    "45": 25
+                },
+                "max_contains_weight": "1000 kg",
+                "max_item_length": "1 km"
+            }
+        ]
+    },
+    {
+        "type": "MAGAZINE",
+        "id": "usp45mag",
+        "copy-from": "usp45mag",
+        "name": {
+            "str": "USP .45 12-round magazine"
+        },
+        "pocket_data": [
+            {
+                "pocket_type": "MAGAZINE",
+                "rigid": true,
+                "ammo_restriction": {
+                    "45": 12
+                },
+                "max_contains_weight": "1000 kg",
+                "max_item_length": "1 km"
+            }
+        ]
+    },
+    {
+        "type": "MAGAZINE",
+        "id": "ppq45mag",
+        "copy-from": "ppq45mag",
+        "name": {
+            "str": "PPQ .45 ACP 12-round magazine"
+        },
+        "pocket_data": [
+            {
+                "pocket_type": "MAGAZINE",
+                "rigid": true,
+                "ammo_restriction": {
+                    "45": 12
+                },
+                "max_contains_weight": "1000 kg",
+                "max_item_length": "1 km"
+            }
+        ]
+    },
+    {
+        "type": "MAGAZINE",
+        "id": "hptjhpmag",
+        "copy-from": "hptjhpmag",
+        "name": {
+            "str": "Model JHP 9-round magazine"
+        },
+        "pocket_data": [
+            {
+                "pocket_type": "MAGAZINE",
+                "rigid": true,
+                "ammo_restriction": {
+                    "45": 9
+                },
+                "max_contains_weight": "1000 kg",
+                "max_item_length": "1 km"
+            }
+        ]
+    },
+    {
+        "type": "MAGAZINE",
+        "id": "glock_21mag",
+        "copy-from": "glock_21mag",
+        "name": {
+            "str": "Glock 21 13-round magazine"
+        },
+        "pocket_data": [
+            {
+                "pocket_type": "MAGAZINE",
+                "rigid": true,
+                "ammo_restriction": {
+                    "45": 13
+                },
+                "max_contains_weight": "1000 kg",
+                "max_item_length": "1 km"
+            }
+        ]
+    },
+    {
+        "type": "MAGAZINE",
+        "id": "glock_21mag26",
+        "copy-from": "glock_21mag26",
+        "name": {
+            "str": "Glock 21 26-round magazine"
+        },
+        "pocket_data": [
+            {
+                "pocket_type": "MAGAZINE",
+                "rigid": true,
+                "ammo_restriction": {
+                    "45": 26
+                },
+                "max_contains_weight": "1000 kg",
+                "max_item_length": "1 km"
+            }
+        ]
+    }
+]

--- a/Kenan-Modpack/easy_containers/items/magazine/454.json
+++ b/Kenan-Modpack/easy_containers/items/magazine/454.json
@@ -1,0 +1,44 @@
+[
+    {
+        "type": "MAGAZINE",
+        "id": "454_speedloader5",
+        "copy-from": "454_speedloader5",
+        "name": {
+            "str": ".454 5-round speedloader"
+        },
+        "pocket_data": [
+            {
+                "pocket_type": "MAGAZINE",
+                "rigid": true,
+                "ammo_restriction": {
+                    "454": 5,
+                    "45colt": 5,
+                    "410shot": 5
+                },
+                "max_contains_weight": "1000 kg",
+                "max_item_length": "1 km"
+            }
+        ]
+    },
+    {
+        "type": "MAGAZINE",
+        "id": "454_speedloader6",
+        "copy-from": "454_speedloader6",
+        "name": {
+            "str": ".454 6-round speedloader"
+        },
+        "pocket_data": [
+            {
+                "pocket_type": "MAGAZINE",
+                "rigid": true,
+                "ammo_restriction": {
+                    "454": 6,
+                    "45colt": 6,
+                    "410shot": 6
+                },
+                "max_contains_weight": "1000 kg",
+                "max_item_length": "1 km"
+            }
+        ]
+    }
+]

--- a/Kenan-Modpack/easy_containers/items/magazine/46.json
+++ b/Kenan-Modpack/easy_containers/items/magazine/46.json
@@ -1,0 +1,40 @@
+[
+    {
+        "type": "MAGAZINE",
+        "id": "hk46bigmag",
+        "copy-from": "hk46bigmag",
+        "name": {
+            "str": "MP7 40-round magazine"
+        },
+        "pocket_data": [
+            {
+                "pocket_type": "MAGAZINE",
+                "rigid": true,
+                "ammo_restriction": {
+                    "46": 40
+                },
+                "max_contains_weight": "1000 kg",
+                "max_item_length": "1 km"
+            }
+        ]
+    },
+    {
+        "type": "MAGAZINE",
+        "id": "hk46mag",
+        "copy-from": "hk46mag",
+        "name": {
+            "str": "MP7 20-round magazine"
+        },
+        "pocket_data": [
+            {
+                "pocket_type": "MAGAZINE",
+                "rigid": true,
+                "ammo_restriction": {
+                    "46": 20
+                },
+                "max_contains_weight": "1000 kg",
+                "max_item_length": "1 km"
+            }
+        ]
+    }
+]

--- a/Kenan-Modpack/easy_containers/items/magazine/460.json
+++ b/Kenan-Modpack/easy_containers/items/magazine/460.json
@@ -1,0 +1,42 @@
+[
+    {
+        "type": "MAGAZINE",
+        "id": "m1911bigmag",
+        "copy-from": "m1911bigmag",
+        "name": {
+            "str": "M1911 10-round magazine"
+        },
+        "pocket_data": [
+            {
+                "pocket_type": "MAGAZINE",
+                "rigid": true,
+                "ammo_restriction": {
+                    "45": 10,
+                    "460": 10
+                },
+                "max_contains_weight": "1000 kg",
+                "max_item_length": "1 km"
+            }
+        ]
+    },
+    {
+        "type": "MAGAZINE",
+        "id": "m1911mag",
+        "copy-from": "m1911mag",
+        "name": {
+            "str": "M1911 7-round magazine"
+        },
+        "pocket_data": [
+            {
+                "pocket_type": "MAGAZINE",
+                "rigid": true,
+                "ammo_restriction": {
+                    "45": 7,
+                    "460": 7
+                },
+                "max_contains_weight": "1000 kg",
+                "max_item_length": "1 km"
+            }
+        ]
+    }
+]

--- a/Kenan-Modpack/easy_containers/items/magazine/50.json
+++ b/Kenan-Modpack/easy_containers/items/magazine/50.json
@@ -1,0 +1,78 @@
+[
+    {
+        "type": "MAGAZINE",
+        "id": "belt50",
+        "copy-from": "belt50",
+        "name": {
+            "str": ".50 BMG ammo belt"
+        },
+        "pocket_data": [
+            {
+                "pocket_type": "MAGAZINE",
+                "rigid": true,
+                "ammo_restriction": {
+                    "50": 100
+                },
+                "max_contains_weight": "1000 kg",
+                "max_item_length": "1 km"
+            }
+        ]
+    },
+    {
+        "type": "MAGAZINE",
+        "id": "m107a1mag",
+        "copy-from": "m107a1mag",
+        "name": {
+            "str": "Barrett 10-round magazine"
+        },
+        "pocket_data": [
+            {
+                "pocket_type": "MAGAZINE",
+                "rigid": true,
+                "ammo_restriction": {
+                    "50": 10
+                },
+                "max_contains_weight": "1000 kg",
+                "max_item_length": "1 km"
+            }
+        ]
+    },
+    {
+        "type": "MAGAZINE",
+        "id": "as50mag",
+        "copy-from": "as50mag",
+        "name": {
+            "str": "AS50 10-round magazine"
+        },
+        "pocket_data": [
+            {
+                "pocket_type": "MAGAZINE",
+                "rigid": true,
+                "ammo_restriction": {
+                    "50": 10
+                },
+                "max_contains_weight": "1000 kg",
+                "max_item_length": "1 km"
+            }
+        ]
+    },
+    {
+        "type": "MAGAZINE",
+        "id": "tac50mag",
+        "copy-from": "tac50mag",
+        "name": {
+            "str": "TAC-50 5-round magazine"
+        },
+        "pocket_data": [
+            {
+                "pocket_type": "MAGAZINE",
+                "rigid": true,
+                "ammo_restriction": {
+                    "50": 5
+                },
+                "max_contains_weight": "1000 kg",
+                "max_item_length": "1 km"
+            }
+        ]
+    }
+]

--- a/Kenan-Modpack/easy_containers/items/magazine/500.json
+++ b/Kenan-Modpack/easy_containers/items/magazine/500.json
@@ -1,0 +1,21 @@
+[
+    {
+        "type": "MAGAZINE",
+        "id": "500_speedloader5",
+        "copy-from": "500_speedloader5",
+        "name": {
+            "str": ".500 5-round speedloader"
+        },
+        "pocket_data": [
+            {
+                "pocket_type": "MAGAZINE",
+                "rigid": true,
+                "ammo_restriction": {
+                    "500": 5
+                },
+                "max_contains_weight": "1000 kg",
+                "max_item_length": "1 km"
+            }
+        ]
+    }
+]

--- a/Kenan-Modpack/easy_containers/items/magazine/545x39.json
+++ b/Kenan-Modpack/easy_containers/items/magazine/545x39.json
@@ -1,0 +1,40 @@
+[
+    {
+        "type": "MAGAZINE",
+        "id": "ak74mag",
+        "copy-from": "ak74mag",
+        "name": {
+            "str": "AK-74M 30-round magazine"
+        },
+        "pocket_data": [
+            {
+                "pocket_type": "MAGAZINE",
+                "rigid": true,
+                "ammo_restriction": {
+                    "545x39": 30
+                },
+                "max_contains_weight": "1000 kg",
+                "max_item_length": "1 km"
+            }
+        ]
+    },
+    {
+        "type": "MAGAZINE",
+        "id": "rpk74mag",
+        "copy-from": "rpk74mag",
+        "name": {
+            "str": "AK-74M 45-round magazine"
+        },
+        "pocket_data": [
+            {
+                "pocket_type": "MAGAZINE",
+                "rigid": true,
+                "ammo_restriction": {
+                    "545x39": 45
+                },
+                "max_contains_weight": "1000 kg",
+                "max_item_length": "1 km"
+            }
+        ]
+    }
+]

--- a/Kenan-Modpack/easy_containers/items/magazine/57.json
+++ b/Kenan-Modpack/easy_containers/items/magazine/57.json
@@ -1,0 +1,40 @@
+[
+    {
+        "type": "MAGAZINE",
+        "id": "fn57mag",
+        "copy-from": "fn57mag",
+        "name": {
+            "str": "Five-Seven 20-round magazine"
+        },
+        "pocket_data": [
+            {
+                "pocket_type": "MAGAZINE",
+                "rigid": true,
+                "ammo_restriction": {
+                    "57": 20
+                },
+                "max_contains_weight": "1000 kg",
+                "max_item_length": "1 km"
+            }
+        ]
+    },
+    {
+        "type": "MAGAZINE",
+        "id": "fnp90mag",
+        "copy-from": "fnp90mag",
+        "name": {
+            "str": "P90 50-round magazine"
+        },
+        "pocket_data": [
+            {
+                "pocket_type": "MAGAZINE",
+                "rigid": true,
+                "ammo_restriction": {
+                    "57": 50
+                },
+                "max_contains_weight": "1000 kg",
+                "max_item_length": "1 km"
+            }
+        ]
+    }
+]

--- a/Kenan-Modpack/easy_containers/items/magazine/5x50.json
+++ b/Kenan-Modpack/easy_containers/items/magazine/5x50.json
@@ -1,0 +1,40 @@
+[
+    {
+        "type": "MAGAZINE",
+        "id": "5x50_100_mag",
+        "copy-from": "5x50_100_mag",
+        "name": {
+            "str": "5x50mm 100-round magazine"
+        },
+        "pocket_data": [
+            {
+                "pocket_type": "MAGAZINE",
+                "rigid": true,
+                "ammo_restriction": {
+                    "5x50": 100
+                },
+                "max_contains_weight": "1000 kg",
+                "max_item_length": "1 km"
+            }
+        ]
+    },
+    {
+        "type": "MAGAZINE",
+        "id": "5x50_50_mag",
+        "copy-from": "5x50_50_mag",
+        "name": {
+            "str": "5x50mm 50-round magazine"
+        },
+        "pocket_data": [
+            {
+                "pocket_type": "MAGAZINE",
+                "rigid": true,
+                "ammo_restriction": {
+                    "5x50": 50
+                },
+                "max_contains_weight": "1000 kg",
+                "max_item_length": "1 km"
+            }
+        ]
+    }
+]

--- a/Kenan-Modpack/easy_containers/items/magazine/66mm.json
+++ b/Kenan-Modpack/easy_containers/items/magazine/66mm.json
@@ -1,0 +1,21 @@
+[
+    {
+        "type": "MAGAZINE",
+        "id": "m74_clip",
+        "copy-from": "m74_clip",
+        "name": {
+            "str": "M74 4-rocket clip"
+        },
+        "pocket_data": [
+            {
+                "pocket_type": "MAGAZINE",
+                "rigid": true,
+                "ammo_restriction": {
+                    "m235": 4
+                },
+                "max_contains_weight": "1000 kg",
+                "max_item_length": "1 km"
+            }
+        ]
+    }
+]

--- a/Kenan-Modpack/easy_containers/items/magazine/762.json
+++ b/Kenan-Modpack/easy_containers/items/magazine/762.json
@@ -1,0 +1,116 @@
+[
+    {
+        "type": "MAGAZINE",
+        "id": "762x39_clip",
+        "copy-from": "762x39_clip",
+        "name": {
+            "str": "7.62x39mm 10-round clip"
+        },
+        "pocket_data": [
+            {
+                "pocket_type": "MAGAZINE",
+                "rigid": true,
+                "ammo_restriction": {
+                    "762": 10
+                },
+                "max_contains_weight": "1000 kg",
+                "max_item_length": "1 km"
+            }
+        ]
+    },
+    {
+        "type": "MAGAZINE",
+        "id": "akmag10",
+        "copy-from": "akmag10",
+        "name": {
+            "str": "AK 10-round magazine"
+        },
+        "pocket_data": [
+            {
+                "pocket_type": "MAGAZINE",
+                "rigid": true,
+                "ammo_restriction": {
+                    "762": 10
+                },
+                "max_contains_weight": "1000 kg",
+                "max_item_length": "1 km"
+            }
+        ]
+    },
+    {
+        "type": "MAGAZINE",
+        "id": "akmag20",
+        "copy-from": "akmag20",
+        "name": {
+            "str": "AK 20-round magazine"
+        },
+        "pocket_data": [
+            {
+                "pocket_type": "MAGAZINE",
+                "rigid": true,
+                "ammo_restriction": {
+                    "762": 20
+                },
+                "max_contains_weight": "1000 kg",
+                "max_item_length": "1 km"
+            }
+        ]
+    },
+    {
+        "type": "MAGAZINE",
+        "id": "akmag30",
+        "copy-from": "akmag30",
+        "name": {
+            "str": "AK 30-round magazine"
+        },
+        "pocket_data": [
+            {
+                "pocket_type": "MAGAZINE",
+                "rigid": true,
+                "ammo_restriction": {
+                    "762": 30
+                },
+                "max_contains_weight": "1000 kg",
+                "max_item_length": "1 km"
+            }
+        ]
+    },
+    {
+        "type": "MAGAZINE",
+        "id": "akmag40",
+        "copy-from": "akmag40",
+        "name": {
+            "str": "AK 40-round magazine"
+        },
+        "pocket_data": [
+            {
+                "pocket_type": "MAGAZINE",
+                "rigid": true,
+                "ammo_restriction": {
+                    "762": 40
+                },
+                "max_contains_weight": "1000 kg",
+                "max_item_length": "1 km"
+            }
+        ]
+    },
+    {
+        "type": "MAGAZINE",
+        "id": "akdrum75",
+        "copy-from": "akdrum75",
+        "name": {
+            "str": "AK 75-round drum magazine"
+        },
+        "pocket_data": [
+            {
+                "pocket_type": "MAGAZINE",
+                "rigid": true,
+                "ammo_restriction": {
+                    "762": 75
+                },
+                "max_contains_weight": "1000 kg",
+                "max_item_length": "1 km"
+            }
+        ]
+    }
+]

--- a/Kenan-Modpack/easy_containers/items/magazine/762R.json
+++ b/Kenan-Modpack/easy_containers/items/magazine/762R.json
@@ -1,0 +1,21 @@
+[
+    {
+        "type": "MAGAZINE",
+        "id": "762R_clip",
+        "copy-from": "762R_clip",
+        "name": {
+            "str": "7.62x54mmR 5-round clip"
+        },
+        "pocket_data": [
+            {
+                "pocket_type": "MAGAZINE",
+                "rigid": true,
+                "ammo_restriction": {
+                    "762R": 5
+                },
+                "max_contains_weight": "1000 kg",
+                "max_item_length": "1 km"
+            }
+        ]
+    }
+]

--- a/Kenan-Modpack/easy_containers/items/magazine/762x25.json
+++ b/Kenan-Modpack/easy_containers/items/magazine/762x25.json
@@ -1,0 +1,59 @@
+[
+    {
+        "type": "MAGAZINE",
+        "id": "ppshdrum",
+        "copy-from": "ppshdrum",
+        "name": {
+            "str": "PPSh 71-round drum magazine"
+        },
+        "pocket_data": [
+            {
+                "pocket_type": "MAGAZINE",
+                "rigid": true,
+                "ammo_restriction": {
+                    "762x25": 71
+                },
+                "max_contains_weight": "1000 kg",
+                "max_item_length": "1 km"
+            }
+        ]
+    },
+    {
+        "type": "MAGAZINE",
+        "id": "ppshmag",
+        "copy-from": "ppshmag",
+        "name": {
+            "str": "PPSh 35-round magazine"
+        },
+        "pocket_data": [
+            {
+                "pocket_type": "MAGAZINE",
+                "rigid": true,
+                "ammo_restriction": {
+                    "762x25": 35
+                },
+                "max_contains_weight": "1000 kg",
+                "max_item_length": "1 km"
+            }
+        ]
+    },
+    {
+        "type": "MAGAZINE",
+        "id": "tokarevmag",
+        "copy-from": "tokarevmag",
+        "name": {
+            "str": "TT-33 8-round magazine"
+        },
+        "pocket_data": [
+            {
+                "pocket_type": "MAGAZINE",
+                "rigid": true,
+                "ammo_restriction": {
+                    "762x25": 8
+                },
+                "max_contains_weight": "1000 kg",
+                "max_item_length": "1 km"
+            }
+        ]
+    }
+]

--- a/Kenan-Modpack/easy_containers/items/magazine/8x40mm.json
+++ b/Kenan-Modpack/easy_containers/items/magazine/8x40mm.json
@@ -1,0 +1,115 @@
+[
+    {
+        "type": "MAGAZINE",
+        "id": "8x40_100_mag",
+        "copy-from": "8x40_100_mag",
+        "name": {
+            "str": "8x40mm 100-round magazine"
+        },
+        "pocket_data": [
+            {
+                "pocket_type": "MAGAZINE",
+                "rigid": true,
+                "ammo_restriction": {
+                    "8x40mm": 100
+                },
+                "max_contains_weight": "1000 kg",
+                "max_item_length": "1 km"
+            }
+        ]
+    },
+    {
+        "type": "MAGAZINE",
+        "id": "8x40_10_mag",
+        "copy-from": "8x40_10_mag",
+        "name": {
+            "str": "8x40mm 10-round magazine"
+        },
+        "pocket_data": [
+            {
+                "pocket_type": "MAGAZINE",
+                "rigid": true,
+                "ammo_restriction": {
+                    "8x40mm": 10
+                },
+                "max_contains_weight": "1000 kg",
+                "max_item_length": "1 km"
+            }
+        ]
+    },
+    {
+        "type": "MAGAZINE",
+        "id": "8x40_250_mag",
+        "copy-from": "8x40_250_mag",
+        "name": {
+            "str": "8x40mm 250-round drum magazine"
+        },
+        "pocket_data": [
+            {
+                "pocket_type": "MAGAZINE",
+                "rigid": true,
+                "ammo_restriction": {
+                    "8x40mm": 250
+                },
+                "max_contains_weight": "1000 kg",
+                "max_item_length": "1 km"
+            }
+        ]
+    },
+    {
+        "type": "MAGAZINE",
+        "id": "8x40_25_mag",
+        "copy-from": "8x40_25_mag",
+        "name": {
+            "str": "8x40mm 25-round magazine"
+        },
+        "pocket_data": [
+            {
+                "pocket_type": "MAGAZINE",
+                "rigid": true,
+                "ammo_restriction": {
+                    "8x40mm": 25
+                },
+                "max_contains_weight": "1000 kg",
+                "max_item_length": "1 km"
+            }
+        ]
+    },
+    {
+        "type": "MAGAZINE",
+        "id": "8x40_500_mag",
+        "copy-from": "8x40_500_mag",
+        "name": {
+            "str": "8x40mm 500-round drum magazine"
+        },
+        "pocket_data": [
+            {
+                "pocket_type": "MAGAZINE",
+                "rigid": true,
+                "ammo_restriction": {
+                    "8x40mm": 500
+                },
+                "max_contains_weight": "1000 kg",
+                "max_item_length": "1 km"
+            }
+        ]
+    },
+    {
+        "type": "MAGAZINE",
+        "id": "8x40_50_mag",
+        "copy-from": "8x40_50_mag",
+        "name": {
+            "str": "8x40mm 50-round magazine"
+        },
+        "pocket_data": [
+            {
+                "pocket_type": "MAGAZINE",
+                "ammo_restriction": {
+                    "8x40mm": 50
+                },
+                "max_contains_weight": "1000 kg",
+                "max_item_length": "1 km"
+            }
+        ]
+    }
+]

--- a/Kenan-Modpack/easy_containers/items/magazine/9mm.json
+++ b/Kenan-Modpack/easy_containers/items/magazine/9mm.json
@@ -1,0 +1,1616 @@
+[
+    {
+        "type": "MAGAZINE",
+        "id": "calicomag",
+        "copy-from": "calicomag",
+        "name": {
+            "str": "Calico 50-round helical magazine"
+        },
+        "pocket_data": [
+            {
+                "pocket_type": "MAGAZINE",
+                "rigid": true,
+                "ammo_restriction": {
+                    "9mm": 50
+                },
+                "max_contains_weight": "1000 kg",
+                "max_item_length": "1 km"
+            }
+        ]
+    },
+    {
+        "type": "MAGAZINE",
+        "id": "calicomag_100rd",
+        "copy-from": "calicomag_100rd",
+        "name": {
+            "str": "Calico 100-round helical magazine"
+        },
+        "pocket_data": [
+            {
+                "pocket_type": "MAGAZINE",
+                "rigid": true,
+                "ammo_restriction": {
+                    "9mm": 100
+                },
+                "max_contains_weight": "1000 kg",
+                "max_item_length": "1 km"
+            }
+        ]
+    },
+    {
+        "type": "MAGAZINE",
+        "id": "glockbigmag",
+        "copy-from": "glockbigmag",
+        "name": {
+            "str": "Glock 9x19mm 30-round magazine"
+        },
+        "pocket_data": [
+            {
+                "pocket_type": "MAGAZINE",
+                "rigid": true,
+                "ammo_restriction": {
+                    "9mm": 30
+                },
+                "max_contains_weight": "1000 kg",
+                "max_item_length": "1 km"
+            }
+        ]
+    },
+    {
+        "type": "MAGAZINE",
+        "id": "glockmag",
+        "copy-from": "glockmag",
+        "name": {
+            "str": "Glock 9x19mm 15-round magazine"
+        },
+        "pocket_data": [
+            {
+                "pocket_type": "MAGAZINE",
+                "rigid": true,
+                "ammo_restriction": {
+                    "9mm": 15
+                },
+                "max_contains_weight": "1000 kg",
+                "max_item_length": "1 km"
+            }
+        ]
+    },
+    {
+        "type": "MAGAZINE",
+        "id": "glock17_17",
+        "copy-from": "glock17_17",
+        "name": {
+            "str": "Glock 9x19mm 17-round magazine"
+        },
+        "pocket_data": [
+            {
+                "pocket_type": "MAGAZINE",
+                "rigid": true,
+                "ammo_restriction": {
+                    "9mm": 17
+                },
+                "max_contains_weight": "1000 kg",
+                "max_item_length": "1 km"
+            }
+        ]
+    },
+    {
+        "type": "MAGAZINE",
+        "id": "glock17_22",
+        "copy-from": "glock17_22",
+        "name": {
+            "str": "Glock 9x19mm 22-round magazine"
+        },
+        "pocket_data": [
+            {
+                "pocket_type": "MAGAZINE",
+                "rigid": true,
+                "ammo_restriction": {
+                    "9mm": 22
+                },
+                "max_contains_weight": "1000 kg",
+                "max_item_length": "1 km"
+            }
+        ]
+    },
+    {
+        "type": "MAGAZINE",
+        "id": "glock_drum_50rd",
+        "copy-from": "glock_drum_50rd",
+        "name": {
+            "str": "Glock 9x19mm 50-round drum magazine"
+        },
+        "pocket_data": [
+            {
+                "pocket_type": "MAGAZINE",
+                "rigid": true,
+                "ammo_restriction": {
+                    "9mm": 50
+                },
+                "max_contains_weight": "1000 kg",
+                "max_item_length": "1 km"
+            }
+        ]
+    },
+    {
+        "type": "MAGAZINE",
+        "id": "glock_drum_100rd",
+        "copy-from": "glock_drum_100rd",
+        "name": {
+            "str": "Glock 9x19mm 100-round double drum magazine"
+        },
+        "pocket_data": [
+            {
+                "pocket_type": "MAGAZINE",
+                "rigid": true,
+                "ammo_restriction": {
+                    "9mm": 100
+                },
+                "max_contains_weight": "1000 kg",
+                "max_item_length": "1 km"
+            }
+        ]
+    },
+    {
+        "type": "MAGAZINE",
+        "id": "m9mag_35rd",
+        "copy-from": "m9mag_35rd",
+        "name": {
+            "str": "M9 35-round magazine"
+        },
+        "pocket_data": [
+            {
+                "pocket_type": "MAGAZINE",
+                "rigid": true,
+                "ammo_restriction": {
+                    "9mm": 35
+                },
+                "max_contains_weight": "1000 kg",
+                "max_item_length": "1 km"
+            }
+        ]
+    },
+    {
+        "type": "MAGAZINE",
+        "id": "m9mag_32rd",
+        "copy-from": "m9mag_32rd",
+        "name": {
+            "str": "M9 32-round magazine"
+        },
+        "pocket_data": [
+            {
+                "pocket_type": "MAGAZINE",
+                "rigid": true,
+                "ammo_restriction": {
+                    "9mm": 32
+                },
+                "max_contains_weight": "1000 kg",
+                "max_item_length": "1 km"
+            }
+        ]
+    },
+    {
+        "type": "MAGAZINE",
+        "id": "m9bigmag",
+        "copy-from": "m9bigmag",
+        "name": {
+            "str": "M9 30-round magazine"
+        },
+        "pocket_data": [
+            {
+                "pocket_type": "MAGAZINE",
+                "rigid": true,
+                "ammo_restriction": {
+                    "9mm": 30
+                },
+                "max_contains_weight": "1000 kg",
+                "max_item_length": "1 km"
+            }
+        ]
+    },
+    {
+        "type": "MAGAZINE",
+        "id": "m9mag_20rd",
+        "copy-from": "m9mag_20rd",
+        "name": {
+            "str": "M9 20-round magazine"
+        },
+        "pocket_data": [
+            {
+                "pocket_type": "MAGAZINE",
+                "rigid": true,
+                "ammo_restriction": {
+                    "9mm": 20
+                },
+                "max_contains_weight": "1000 kg",
+                "max_item_length": "1 km"
+            }
+        ]
+    },
+    {
+        "type": "MAGAZINE",
+        "id": "m9mag_18rd",
+        "copy-from": "m9mag_18rd",
+        "name": {
+            "str": "M9 18-round magazine"
+        },
+        "pocket_data": [
+            {
+                "pocket_type": "MAGAZINE",
+                "rigid": true,
+                "ammo_restriction": {
+                    "9mm": 18
+                },
+                "max_contains_weight": "1000 kg",
+                "max_item_length": "1 km"
+            }
+        ]
+    },
+    {
+        "type": "MAGAZINE",
+        "id": "m9mag_17rd",
+        "copy-from": "m9mag_17rd",
+        "name": {
+            "str": "M9 17-round magazine"
+        },
+        "pocket_data": [
+            {
+                "pocket_type": "MAGAZINE",
+                "rigid": true,
+                "ammo_restriction": {
+                    "9mm": 17
+                },
+                "max_contains_weight": "1000 kg",
+                "max_item_length": "1 km"
+            }
+        ]
+    },
+    {
+        "type": "MAGAZINE",
+        "id": "m9mag",
+        "copy-from": "m9mag",
+        "name": {
+            "str": "M9 15-round magazine"
+        },
+        "pocket_data": [
+            {
+                "pocket_type": "MAGAZINE",
+                "rigid": true,
+                "ammo_restriction": {
+                    "9mm": 15
+                },
+                "max_contains_weight": "1000 kg",
+                "max_item_length": "1 km"
+            }
+        ]
+    },
+    {
+        "type": "MAGAZINE",
+        "id": "m9mag_10rd",
+        "copy-from": "m9mag_10rd",
+        "name": {
+            "str": "M9 10-round magazine"
+        },
+        "pocket_data": [
+            {
+                "pocket_type": "MAGAZINE",
+                "rigid": true,
+                "ammo_restriction": {
+                    "9mm": 10
+                },
+                "max_contains_weight": "1000 kg",
+                "max_item_length": "1 km"
+            }
+        ]
+    },
+    {
+        "type": "MAGAZINE",
+        "id": "mp5mag_100rd",
+        "copy-from": "mp5mag_100rd",
+        "name": {
+            "str": "MP5 100-round double drum magazine"
+        },
+        "pocket_data": [
+            {
+                "pocket_type": "MAGAZINE",
+                "rigid": true,
+                "ammo_restriction": {
+                    "9mm": 100
+                },
+                "max_contains_weight": "1000 kg",
+                "max_item_length": "1 km"
+            }
+        ]
+    },
+    {
+        "type": "MAGAZINE",
+        "id": "mp5bigmag",
+        "copy-from": "mp5bigmag",
+        "name": {
+            "str": "MP5 50-round drum magazine"
+        },
+        "pocket_data": [
+            {
+                "pocket_type": "MAGAZINE",
+                "rigid": true,
+                "ammo_restriction": {
+                    "9mm": 50
+                },
+                "max_contains_weight": "1000 kg",
+                "max_item_length": "1 km"
+            }
+        ]
+    },
+    {
+        "type": "MAGAZINE",
+        "id": "mp5mag_40rd",
+        "copy-from": "mp5mag_40rd",
+        "name": {
+            "str": "MP5 40-round magazine"
+        },
+        "pocket_data": [
+            {
+                "pocket_type": "MAGAZINE",
+                "rigid": true,
+                "ammo_restriction": {
+                    "9mm": 40
+                },
+                "max_contains_weight": "1000 kg",
+                "max_item_length": "1 km"
+            }
+        ]
+    },
+    {
+        "type": "MAGAZINE",
+        "id": "mp5mag_38rd",
+        "copy-from": "mp5mag_38rd",
+        "name": {
+            "str": "MP5 38-round magazine"
+        },
+        "pocket_data": [
+            {
+                "pocket_type": "MAGAZINE",
+                "rigid": true,
+                "ammo_restriction": {
+                    "9mm": 38
+                },
+                "max_contains_weight": "1000 kg",
+                "max_item_length": "1 km"
+            }
+        ]
+    },
+    {
+        "type": "MAGAZINE",
+        "id": "mp5mag",
+        "copy-from": "mp5mag",
+        "name": {
+            "str": "MP5 30-round magazine"
+        },
+        "pocket_data": [
+            {
+                "pocket_type": "MAGAZINE",
+                "rigid": true,
+                "ammo_restriction": {
+                    "9mm": 30
+                },
+                "max_contains_weight": "1000 kg",
+                "max_item_length": "1 km"
+            }
+        ]
+    },
+    {
+        "type": "MAGAZINE",
+        "id": "mp5mag_20rd",
+        "copy-from": "mp5mag_20rd",
+        "name": {
+            "str": "MP5 20-round magazine"
+        },
+        "pocket_data": [
+            {
+                "pocket_type": "MAGAZINE",
+                "rigid": true,
+                "ammo_restriction": {
+                    "9mm": 20
+                },
+                "max_contains_weight": "1000 kg",
+                "max_item_length": "1 km"
+            }
+        ]
+    },
+    {
+        "type": "MAGAZINE",
+        "id": "mp5mag_15rd",
+        "copy-from": "mp5mag_15rd",
+        "name": {
+            "str": "MP5 15-round magazine"
+        },
+        "pocket_data": [
+            {
+                "pocket_type": "MAGAZINE",
+                "rigid": true,
+                "ammo_restriction": {
+                    "9mm": 15
+                },
+                "max_contains_weight": "1000 kg",
+                "max_item_length": "1 km"
+            }
+        ]
+    },
+    {
+        "type": "MAGAZINE",
+        "id": "mp5mag_10rd",
+        "copy-from": "mp5mag_10rd",
+        "name": {
+            "str": "MP5 10-round magazine"
+        },
+        "pocket_data": [
+            {
+                "pocket_type": "MAGAZINE",
+                "rigid": true,
+                "ammo_restriction": {
+                    "9mm": 10
+                },
+                "max_contains_weight": "1000 kg",
+                "max_item_length": "1 km"
+            }
+        ]
+    },
+    {
+        "type": "MAGAZINE",
+        "id": "p08mag_8rd",
+        "copy-from": "p08mag_8rd",
+        "name": {
+            "str": "Luger 8-round magazine"
+        },
+        "pocket_data": [
+            {
+                "pocket_type": "MAGAZINE",
+                "rigid": true,
+                "ammo_restriction": {
+                    "9mm": 8
+                },
+                "max_contains_weight": "1000 kg",
+                "max_item_length": "1 km"
+            }
+        ]
+    },
+    {
+        "type": "MAGAZINE",
+        "id": "p08mag_32rd",
+        "copy-from": "p08mag_32rd",
+        "name": {
+            "str": "Luger 32-round snail-drum magazine"
+        },
+        "pocket_data": [
+            {
+                "pocket_type": "MAGAZINE",
+                "rigid": true,
+                "ammo_restriction": {
+                    "9mm": 32
+                },
+                "max_contains_weight": "1000 kg",
+                "max_item_length": "1 km"
+            }
+        ]
+    },
+    {
+        "type": "MAGAZINE",
+        "id": "clip9mm_10rd",
+        "copy-from": "clip9mm_10rd",
+        "name": {
+            "str": "9x19mm 10-round clip"
+        },
+        "pocket_data": [
+            {
+                "pocket_type": "MAGAZINE",
+                "ammo_restriction": {
+                    "9mm": 10
+                },
+                "max_contains_weight": "1000 kg",
+                "max_item_length": "1 km"
+            }
+        ]
+    },
+    {
+        "type": "MAGAZINE",
+        "id": "mausermag_10rd",
+        "copy-from": "mausermag_10rd",
+        "name": {
+            "str": "Mauser 10-round magazine"
+        },
+        "pocket_data": [
+            {
+                "pocket_type": "MAGAZINE",
+                "rigid": true,
+                "ammo_restriction": {
+                    "9mm": 10
+                },
+                "max_contains_weight": "1000 kg",
+                "max_item_length": "1 km"
+            }
+        ]
+    },
+    {
+        "type": "MAGAZINE",
+        "id": "mausermag_20rd",
+        "copy-from": "mausermag_20rd",
+        "name": {
+            "str": "Mauser 20-round magazine"
+        },
+        "pocket_data": [
+            {
+                "pocket_type": "MAGAZINE",
+                "rigid": true,
+                "ammo_restriction": {
+                    "9mm": 20
+                },
+                "max_contains_weight": "1000 kg",
+                "max_item_length": "1 km"
+            }
+        ]
+    },
+    {
+        "type": "MAGAZINE",
+        "id": "mp40mag_32rd",
+        "copy-from": "mp40mag_32rd",
+        "name": {
+            "str": "MP 40 32-round magazine"
+        },
+        "pocket_data": [
+            {
+                "pocket_type": "MAGAZINE",
+                "rigid": true,
+                "ammo_restriction": {
+                    "9mm": 32
+                },
+                "max_contains_weight": "1000 kg",
+                "max_item_length": "1 km"
+            }
+        ]
+    },
+    {
+        "type": "MAGAZINE",
+        "id": "px4mag_10rd",
+        "copy-from": "px4mag_10rd",
+        "name": {
+            "str": "Px4 9x19mm 10-round magazine"
+        },
+        "pocket_data": [
+            {
+                "pocket_type": "MAGAZINE",
+                "rigid": true,
+                "ammo_restriction": {
+                    "9mm": 10
+                },
+                "max_contains_weight": "1000 kg",
+                "max_item_length": "1 km"
+            }
+        ]
+    },
+    {
+        "type": "MAGAZINE",
+        "id": "px4mag_15rd",
+        "copy-from": "px4mag_15rd",
+        "name": {
+            "str": "Px4 9x19mm 15-round magazine"
+        },
+        "pocket_data": [
+            {
+                "pocket_type": "MAGAZINE",
+                "rigid": true,
+                "ammo_restriction": {
+                    "9mm": 15
+                },
+                "max_contains_weight": "1000 kg",
+                "max_item_length": "1 km"
+            }
+        ]
+    },
+    {
+        "type": "MAGAZINE",
+        "id": "px4mag",
+        "copy-from": "px4mag",
+        "name": {
+            "str": "Px4 9x19mm 17-round magazine"
+        },
+        "pocket_data": [
+            {
+                "pocket_type": "MAGAZINE",
+                "rigid": true,
+                "ammo_restriction": {
+                    "9mm": 17
+                },
+                "max_contains_weight": "1000 kg",
+                "max_item_length": "1 km"
+            }
+        ]
+    },
+    {
+        "type": "MAGAZINE",
+        "id": "px4mag_20rd",
+        "copy-from": "px4mag_20rd",
+        "name": {
+            "str": "Px4 9x19mm 20-round magazine"
+        },
+        "pocket_data": [
+            {
+                "pocket_type": "MAGAZINE",
+                "rigid": true,
+                "ammo_restriction": {
+                    "9mm": 20
+                },
+                "max_contains_weight": "1000 kg",
+                "max_item_length": "1 km"
+            }
+        ]
+    },
+    {
+        "type": "MAGAZINE",
+        "id": "stenmag",
+        "copy-from": "stenmag",
+        "name": {
+            "str": "STEN 32-round magazine"
+        },
+        "pocket_data": [
+            {
+                "pocket_type": "MAGAZINE",
+                "rigid": true,
+                "ammo_restriction": {
+                    "9mm": 32
+                },
+                "max_contains_weight": "1000 kg",
+                "max_item_length": "1 km"
+            }
+        ]
+    },
+    {
+        "type": "MAGAZINE",
+        "id": "survivor9mm_mag",
+        "copy-from": "survivor9mm_mag",
+        "name": {
+            "str": "STEN 20-round makeshift magazine"
+        },
+        "pocket_data": [
+            {
+                "pocket_type": "MAGAZINE",
+                "rigid": true,
+                "ammo_restriction": {
+                    "9mm": 20
+                },
+                "max_contains_weight": "1000 kg",
+                "max_item_length": "1 km"
+            }
+        ]
+    },
+    {
+        "type": "MAGAZINE",
+        "id": "tec9mag_10rd",
+        "copy-from": "tec9mag_10rd",
+        "name": {
+            "str": "TEC-9 10-round magazine"
+        },
+        "pocket_data": [
+            {
+                "pocket_type": "MAGAZINE",
+                "rigid": true,
+                "ammo_restriction": {
+                    "9mm": 10
+                },
+                "max_contains_weight": "1000 kg",
+                "max_item_length": "1 km"
+            }
+        ]
+    },
+    {
+        "type": "MAGAZINE",
+        "id": "tec9mag_20rd",
+        "copy-from": "tec9mag_20rd",
+        "name": {
+            "str": "TEC-9 20-round magazine"
+        },
+        "pocket_data": [
+            {
+                "pocket_type": "MAGAZINE",
+                "rigid": true,
+                "ammo_restriction": {
+                    "9mm": 20
+                },
+                "max_contains_weight": "1000 kg",
+                "max_item_length": "1 km"
+            }
+        ]
+    },
+    {
+        "type": "MAGAZINE",
+        "id": "tec9mag_30rd",
+        "copy-from": "tec9mag_30rd",
+        "name": {
+            "str": "TEC-9 30-round magazine"
+        },
+        "pocket_data": [
+            {
+                "pocket_type": "MAGAZINE",
+                "rigid": true,
+                "ammo_restriction": {
+                    "9mm": 30
+                },
+                "max_contains_weight": "1000 kg",
+                "max_item_length": "1 km"
+            }
+        ]
+    },
+    {
+        "type": "MAGAZINE",
+        "id": "tec9mag",
+        "copy-from": "tec9mag",
+        "name": {
+            "str": "TEC-9 32-round magazine"
+        },
+        "pocket_data": [
+            {
+                "pocket_type": "MAGAZINE",
+                "rigid": true,
+                "ammo_restriction": {
+                    "9mm": 32
+                },
+                "max_contains_weight": "1000 kg",
+                "max_item_length": "1 km"
+            }
+        ]
+    },
+    {
+        "type": "MAGAZINE",
+        "id": "tec9mag_36rd",
+        "copy-from": "tec9mag_36rd",
+        "name": {
+            "str": "TEC-9 36-round magazine"
+        },
+        "pocket_data": [
+            {
+                "pocket_type": "MAGAZINE",
+                "rigid": true,
+                "ammo_restriction": {
+                    "9mm": 36
+                },
+                "max_contains_weight": "1000 kg",
+                "max_item_length": "1 km"
+            }
+        ]
+    },
+    {
+        "type": "MAGAZINE",
+        "id": "tec9mag_50rd",
+        "copy-from": "tec9mag_50rd",
+        "name": {
+            "str": "TEC-9 50-round magazine"
+        },
+        "pocket_data": [
+            {
+                "pocket_type": "MAGAZINE",
+                "rigid": true,
+                "ammo_restriction": {
+                    "9mm": 50
+                },
+                "max_contains_weight": "1000 kg",
+                "max_item_length": "1 km"
+            }
+        ]
+    },
+    {
+        "type": "MAGAZINE",
+        "id": "tec9mag_72rd",
+        "copy-from": "tec9mag_72rd",
+        "name": {
+            "str": "TEC-9 72-round drum magazine"
+        },
+        "pocket_data": [
+            {
+                "pocket_type": "MAGAZINE",
+                "rigid": true,
+                "ammo_restriction": {
+                    "9mm": 72
+                },
+                "max_contains_weight": "1000 kg",
+                "max_item_length": "1 km"
+            }
+        ]
+    },
+    {
+        "type": "MAGAZINE",
+        "id": "usp9mag_10rd",
+        "copy-from": "usp9mag_10rd",
+        "name": {
+            "str": "USP 9x19mm 10-round magazine"
+        },
+        "pocket_data": [
+            {
+                "pocket_type": "MAGAZINE",
+                "rigid": true,
+                "ammo_restriction": {
+                    "9mm": 10
+                },
+                "max_contains_weight": "1000 kg",
+                "max_item_length": "1 km"
+            }
+        ]
+    },
+    {
+        "type": "MAGAZINE",
+        "id": "usp9mag",
+        "copy-from": "usp9mag",
+        "name": {
+            "str": "USP 9x19mm 15-round magazine"
+        },
+        "pocket_data": [
+            {
+                "pocket_type": "MAGAZINE",
+                "rigid": true,
+                "ammo_restriction": {
+                    "9mm": 15
+                },
+                "max_contains_weight": "1000 kg",
+                "max_item_length": "1 km"
+            }
+        ]
+    },
+    {
+        "type": "MAGAZINE",
+        "id": "usp9mag_18rd",
+        "copy-from": "usp9mag_18rd",
+        "name": {
+            "str": "USP 9x19mm 18-round magazine"
+        },
+        "pocket_data": [
+            {
+                "pocket_type": "MAGAZINE",
+                "rigid": true,
+                "ammo_restriction": {
+                    "9mm": 18
+                },
+                "max_contains_weight": "1000 kg",
+                "max_item_length": "1 km"
+            }
+        ]
+    },
+    {
+        "type": "MAGAZINE",
+        "id": "usp9mag_20rd",
+        "copy-from": "usp9mag_20rd",
+        "name": {
+            "str": "USP 9x19mm 20-round magazine"
+        },
+        "pocket_data": [
+            {
+                "pocket_type": "MAGAZINE",
+                "rigid": true,
+                "ammo_restriction": {
+                    "9mm": 20
+                },
+                "max_contains_weight": "1000 kg",
+                "max_item_length": "1 km"
+            }
+        ]
+    },
+    {
+        "type": "MAGAZINE",
+        "id": "usp9mag_32rd",
+        "copy-from": "usp9mag_32rd",
+        "name": {
+            "str": "USP 9x19mm 32-round magazine"
+        },
+        "pocket_data": [
+            {
+                "pocket_type": "MAGAZINE",
+                "rigid": true,
+                "ammo_restriction": {
+                    "9mm": 32
+                },
+                "max_contains_weight": "1000 kg",
+                "max_item_length": "1 km"
+            }
+        ]
+    },
+    {
+        "type": "MAGAZINE",
+        "id": "uzimag_20rd",
+        "copy-from": "uzimag_20rd",
+        "name": {
+            "str": "Uzi 20-round magazine"
+        },
+        "pocket_data": [
+            {
+                "pocket_type": "MAGAZINE",
+                "rigid": true,
+                "ammo_restriction": {
+                    "9mm": 20
+                },
+                "max_contains_weight": "1000 kg",
+                "max_item_length": "1 km"
+            }
+        ]
+    },
+    {
+        "type": "MAGAZINE",
+        "id": "uzimag_25rd",
+        "copy-from": "uzimag_25rd",
+        "name": {
+            "str": "Uzi 25-round magazine"
+        },
+        "pocket_data": [
+            {
+                "pocket_type": "MAGAZINE",
+                "rigid": true,
+                "ammo_restriction": {
+                    "9mm": 25
+                },
+                "max_contains_weight": "1000 kg",
+                "max_item_length": "1 km"
+            }
+        ]
+    },
+    {
+        "type": "MAGAZINE",
+        "id": "uzimag",
+        "copy-from": "uzimag",
+        "name": {
+            "str": "Uzi 32-round magazine"
+        },
+        "pocket_data": [
+            {
+                "pocket_type": "MAGAZINE",
+                "rigid": true,
+                "ammo_restriction": {
+                    "9mm": 32
+                },
+                "max_contains_weight": "1000 kg",
+                "max_item_length": "1 km"
+            }
+        ]
+    },
+    {
+        "type": "MAGAZINE",
+        "id": "uzimag_40rd",
+        "copy-from": "uzimag_40rd",
+        "name": {
+            "str": "Uzi 40-round magazine"
+        },
+        "pocket_data": [
+            {
+                "pocket_type": "MAGAZINE",
+                "rigid": true,
+                "ammo_restriction": {
+                    "9mm": 40
+                },
+                "max_contains_weight": "1000 kg",
+                "max_item_length": "1 km"
+            }
+        ]
+    },
+    {
+        "type": "MAGAZINE",
+        "id": "uzimag_50rd",
+        "copy-from": "uzimag_50rd",
+        "name": {
+            "str": "Uzi 50-round magazine"
+        },
+        "pocket_data": [
+            {
+                "pocket_type": "MAGAZINE",
+                "rigid": true,
+                "ammo_restriction": {
+                    "9mm": 50
+                },
+                "max_contains_weight": "1000 kg",
+                "max_item_length": "1 km"
+            }
+        ]
+    },
+    {
+        "type": "MAGAZINE",
+        "id": "uzimag_100rd",
+        "copy-from": "uzimag_100rd",
+        "name": {
+            "str": "Uzi 100-round double drum magazine"
+        },
+        "pocket_data": [
+            {
+                "pocket_type": "MAGAZINE",
+                "rigid": true,
+                "ammo_restriction": {
+                    "9mm": 100
+                },
+                "max_contains_weight": "1000 kg",
+                "max_item_length": "1 km"
+            }
+        ]
+    },
+    {
+        "type": "MAGAZINE",
+        "id": "kpf9mag",
+        "copy-from": "kpf9mag",
+        "name": {
+            "str": "PF-9 7-round magazine"
+        },
+        "pocket_data": [
+            {
+                "pocket_type": "MAGAZINE",
+                "rigid": true,
+                "ammo_restriction": {
+                    "9mm": 7
+                },
+                "max_contains_weight": "1000 kg",
+                "max_item_length": "1 km"
+            }
+        ]
+    },
+    {
+        "type": "MAGAZINE",
+        "id": "kpf9mag_8rd",
+        "copy-from": "kpf9mag_8rd",
+        "name": {
+            "str": "PF-9 8-round magazine"
+        },
+        "pocket_data": [
+            {
+                "pocket_type": "MAGAZINE",
+                "rigid": true,
+                "ammo_restriction": {
+                    "9mm": 8
+                },
+                "max_contains_weight": "1000 kg",
+                "max_item_length": "1 km"
+            }
+        ]
+    },
+    {
+        "type": "MAGAZINE",
+        "id": "p226mag_10rd_9x19mm",
+        "copy-from": "p226mag_10rd_9x19mm",
+        "name": {
+            "str": "P226 9x19mm 10-round magazine"
+        },
+        "pocket_data": [
+            {
+                "pocket_type": "MAGAZINE",
+                "rigid": true,
+                "ammo_restriction": {
+                    "9mm": 10
+                },
+                "max_contains_weight": "1000 kg",
+                "max_item_length": "1 km"
+            }
+        ]
+    },
+    {
+        "type": "MAGAZINE",
+        "id": "p226mag_15rd_9x19mm",
+        "copy-from": "p226mag_15rd_9x19mm",
+        "name": {
+            "str": "P226 9x19mm 15-round magazine"
+        },
+        "pocket_data": [
+            {
+                "pocket_type": "MAGAZINE",
+                "rigid": true,
+                "ammo_restriction": {
+                    "9mm": 15
+                },
+                "max_contains_weight": "1000 kg",
+                "max_item_length": "1 km"
+            }
+        ]
+    },
+    {
+        "type": "MAGAZINE",
+        "id": "p228mag_13rd_9x19mm",
+        "copy-from": "p228mag_13rd_9x19mm",
+        "name": {
+            "str": "M11 13-round magazine"
+        },
+        "pocket_data": [
+            {
+                "pocket_type": "MAGAZINE",
+                "rigid": true,
+                "ammo_restriction": {
+                    "9mm": 13
+                },
+                "max_contains_weight": "1000 kg",
+                "max_item_length": "1 km"
+            }
+        ]
+    },
+    {
+        "type": "MAGAZINE",
+        "id": "p320mag_10rd_9x19mm",
+        "copy-from": "p320mag_10rd_9x19mm",
+        "name": {
+            "str": "M17 10-round magazine"
+        },
+        "pocket_data": [
+            {
+                "pocket_type": "MAGAZINE",
+                "rigid": true,
+                "ammo_restriction": {
+                    "9mm": 10
+                },
+                "max_contains_weight": "1000 kg",
+                "max_item_length": "1 km"
+            }
+        ]
+    },
+    {
+        "type": "MAGAZINE",
+        "id": "p320mag_17rd_9x19mm",
+        "copy-from": "p320mag_17rd_9x19mm",
+        "name": {
+            "str": "M17 17-round magazine"
+        },
+        "pocket_data": [
+            {
+                "pocket_type": "MAGAZINE",
+                "rigid": true,
+                "ammo_restriction": {
+                    "9mm": 17
+                },
+                "max_contains_weight": "1000 kg",
+                "max_item_length": "1 km"
+            }
+        ]
+    },
+    {
+        "type": "MAGAZINE",
+        "id": "p320mag_21rd_9x19mm",
+        "copy-from": "p320mag_21rd_9x19mm",
+        "name": {
+            "str": "M17 21-round magazine"
+        },
+        "pocket_data": [
+            {
+                "pocket_type": "MAGAZINE",
+                "rigid": true,
+                "ammo_restriction": {
+                    "9mm": 21
+                },
+                "max_contains_weight": "1000 kg",
+                "max_item_length": "1 km"
+            }
+        ]
+    },
+    {
+        "type": "MAGAZINE",
+        "id": "sp2022mag_10rd_9mm",
+        "copy-from": "sp2022mag_10rd_9mm",
+        "name": {
+            "str": "SP2022 10-round magazine"
+        },
+        "pocket_data": [
+            {
+                "pocket_type": "MAGAZINE",
+                "rigid": true,
+                "ammo_restriction": {
+                    "9mm": 10
+                },
+                "max_contains_weight": "1000 kg",
+                "max_item_length": "1 km"
+            }
+        ]
+    },
+    {
+        "type": "MAGAZINE",
+        "id": "sp2022mag_12rd_9mm",
+        "copy-from": "sp2022mag_12rd_9mm",
+        "name": {
+            "str": "SP2022 12-round magazine"
+        },
+        "pocket_data": [
+            {
+                "pocket_type": "MAGAZINE",
+                "rigid": true,
+                "ammo_restriction": {
+                    "9mm": 12
+                },
+                "max_contains_weight": "1000 kg",
+                "max_item_length": "1 km"
+            }
+        ]
+    },
+    {
+        "type": "MAGAZINE",
+        "id": "sp2022mag_15rd_9mm",
+        "copy-from": "sp2022mag_15rd_9mm",
+        "name": {
+            "str": "SP2022 15-round magazine"
+        },
+        "pocket_data": [
+            {
+                "pocket_type": "MAGAZINE",
+                "rigid": true,
+                "ammo_restriction": {
+                    "9mm": 15
+                },
+                "max_contains_weight": "1000 kg",
+                "max_item_length": "1 km"
+            }
+        ]
+    },
+    {
+        "type": "MAGAZINE",
+        "id": "bhp9mag_13rd",
+        "copy-from": "bhp9mag_13rd",
+        "name": {
+            "str": "Hi-Power 9x19mm 13-round magazine"
+        },
+        "pocket_data": [
+            {
+                "pocket_type": "MAGAZINE",
+                "rigid": true,
+                "ammo_restriction": {
+                    "9mm": 13
+                },
+                "max_contains_weight": "1000 kg",
+                "max_item_length": "1 km"
+            }
+        ]
+    },
+    {
+        "type": "MAGAZINE",
+        "id": "bhp9mag_15rd",
+        "copy-from": "bhp9mag_15rd",
+        "name": {
+            "str": "Hi-Power 9x19mm 15-round magazine"
+        },
+        "pocket_data": [
+            {
+                "pocket_type": "MAGAZINE",
+                "rigid": true,
+                "ammo_restriction": {
+                    "9mm": 15
+                },
+                "max_contains_weight": "1000 kg",
+                "max_item_length": "1 km"
+            }
+        ]
+    },
+    {
+        "type": "MAGAZINE",
+        "id": "p38mag",
+        "copy-from": "p38mag",
+        "name": {
+            "str": "P38 8-round magazine"
+        },
+        "pocket_data": [
+            {
+                "pocket_type": "MAGAZINE",
+                "rigid": true,
+                "ammo_restriction": {
+                    "9mm": 8
+                },
+                "max_contains_weight": "1000 kg",
+                "max_item_length": "1 km"
+            }
+        ]
+    },
+    {
+        "type": "MAGAZINE",
+        "id": "ppq9mag_10rd",
+        "copy-from": "ppq9mag_10rd",
+        "name": {
+            "str": "PPQ 9x19mm 10-round magazine"
+        },
+        "pocket_data": [
+            {
+                "pocket_type": "MAGAZINE",
+                "rigid": true,
+                "ammo_restriction": {
+                    "9mm": 10
+                },
+                "max_contains_weight": "1000 kg",
+                "max_item_length": "1 km"
+            }
+        ]
+    },
+    {
+        "type": "MAGAZINE",
+        "id": "ppq9mag_15rd",
+        "copy-from": "ppq9mag_15rd",
+        "name": {
+            "str": "PPQ 9x19mm 15-round magazine"
+        },
+        "pocket_data": [
+            {
+                "pocket_type": "MAGAZINE",
+                "rigid": true,
+                "ammo_restriction": {
+                    "9mm": 15
+                },
+                "max_contains_weight": "1000 kg",
+                "max_item_length": "1 km"
+            }
+        ]
+    },
+    {
+        "type": "MAGAZINE",
+        "id": "ppq9mag_17rd",
+        "copy-from": "ppq9mag_17rd",
+        "name": {
+            "str": "PPQ 9x19mm 17-round magazine"
+        },
+        "pocket_data": [
+            {
+                "pocket_type": "MAGAZINE",
+                "rigid": true,
+                "ammo_restriction": {
+                    "9mm": 17
+                },
+                "max_contains_weight": "1000 kg",
+                "max_item_length": "1 km"
+            }
+        ]
+    },
+    {
+        "type": "MAGAZINE",
+        "id": "hptc9mag_8rd",
+        "copy-from": "hptc9mag_8rd",
+        "name": {
+            "str": "C-9 8-round magazine"
+        },
+        "pocket_data": [
+            {
+                "pocket_type": "MAGAZINE",
+                "rigid": true,
+                "ammo_restriction": {
+                    "9mm": 8
+                },
+                "max_contains_weight": "1000 kg",
+                "max_item_length": "1 km"
+            }
+        ]
+    },
+    {
+        "type": "MAGAZINE",
+        "id": "hptc9mag_10rd",
+        "copy-from": "hptc9mag_10rd",
+        "name": {
+            "str": "C-9 10-round magazine"
+        },
+        "pocket_data": [
+            {
+                "pocket_type": "MAGAZINE",
+                "rigid": true,
+                "ammo_restriction": {
+                    "9mm": 10
+                },
+                "max_contains_weight": "1000 kg",
+                "max_item_length": "1 km"
+            }
+        ]
+    },
+    {
+        "type": "MAGAZINE",
+        "id": "hptc9mag_15rd",
+        "copy-from": "hptc9mag_15rd",
+        "name": {
+            "str": "C-9 15-round magazine"
+        },
+        "pocket_data": [
+            {
+                "pocket_type": "MAGAZINE",
+                "rigid": true,
+                "ammo_restriction": {
+                    "9mm": 15
+                },
+                "max_contains_weight": "1000 kg",
+                "max_item_length": "1 km"
+            }
+        ]
+    },
+    {
+        "type": "MAGAZINE",
+        "id": "cz75mag_12rd",
+        "copy-from": "cz75mag_12rd",
+        "name": {
+            "str": "CZ 75 12-round magazine"
+        },
+        "pocket_data": [
+            {
+                "pocket_type": "MAGAZINE",
+                "rigid": true,
+                "ammo_restriction": {
+                    "9mm": 12
+                },
+                "max_contains_weight": "1000 kg",
+                "max_item_length": "1 km"
+            }
+        ]
+    },
+    {
+        "type": "MAGAZINE",
+        "id": "cz75mag_20rd",
+        "copy-from": "cz75mag_20rd",
+        "name": {
+            "str": "CZ 75 20-round magazine"
+        },
+        "pocket_data": [
+            {
+                "pocket_type": "MAGAZINE",
+                "rigid": true,
+                "ammo_restriction": {
+                    "9mm": 20
+                },
+                "max_contains_weight": "1000 kg",
+                "max_item_length": "1 km"
+            }
+        ]
+    },
+    {
+        "type": "MAGAZINE",
+        "id": "cz75mag_26rd",
+        "copy-from": "cz75mag_26rd",
+        "name": {
+            "str": "CZ 75 26-round magazine"
+        },
+        "pocket_data": [
+            {
+                "pocket_type": "MAGAZINE",
+                "rigid": true,
+                "ammo_restriction": {
+                    "9mm": 26
+                },
+                "max_contains_weight": "1000 kg",
+                "max_item_length": "1 km"
+            }
+        ]
+    },
+    {
+        "type": "MAGAZINE",
+        "id": "ccpmag",
+        "copy-from": "ccpmag",
+        "name": {
+            "str": "CCP 8-round magazine"
+        },
+        "pocket_data": [
+            {
+                "pocket_type": "MAGAZINE",
+                "rigid": true,
+                "ammo_restriction": {
+                    "9mm": 8
+                },
+                "max_contains_weight": "1000 kg",
+                "max_item_length": "1 km"
+            }
+        ]
+    },
+    {
+        "type": "MAGAZINE",
+        "id": "ccpmag_9rd",
+        "copy-from": "ccpmag_9rd",
+        "name": {
+            "str": "CCP 9-round magazine"
+        },
+        "pocket_data": [
+            {
+                "pocket_type": "MAGAZINE",
+                "rigid": true,
+                "ammo_restriction": {
+                    "9mm": 9
+                },
+                "max_contains_weight": "1000 kg",
+                "max_item_length": "1 km"
+            }
+        ]
+    },
+    {
+        "type": "MAGAZINE",
+        "id": "btmp9mag_9x19mm_10rd",
+        "copy-from": "btmp9mag_9x19mm_10rd",
+        "name": {
+            "str": "APC9 10-round magazine"
+        },
+        "pocket_data": [
+            {
+                "pocket_type": "MAGAZINE",
+                "rigid": true,
+                "ammo_restriction": {
+                    "9mm": 10
+                },
+                "max_contains_weight": "1000 kg",
+                "max_item_length": "1 km"
+            }
+        ]
+    },
+    {
+        "type": "MAGAZINE",
+        "id": "btmp9mag_9x19mm_15",
+        "copy-from": "btmp9mag_9x19mm_15",
+        "name": {
+            "str": "APC9 15-round magazine"
+        },
+        "pocket_data": [
+            {
+                "pocket_type": "MAGAZINE",
+                "rigid": true,
+                "ammo_restriction": {
+                    "9mm": 15
+                },
+                "max_contains_weight": "1000 kg",
+                "max_item_length": "1 km"
+            }
+        ]
+    },
+    {
+        "type": "MAGAZINE",
+        "id": "btmp9mag_9x19mm_20",
+        "copy-from": "btmp9mag_9x19mm_20",
+        "name": {
+            "str": "APC9 20-round magazine"
+        },
+        "pocket_data": [
+            {
+                "pocket_type": "MAGAZINE",
+                "rigid": true,
+                "ammo_restriction": {
+                    "9mm": 20
+                },
+                "max_contains_weight": "1000 kg",
+                "max_item_length": "1 km"
+            }
+        ]
+    },
+    {
+        "type": "MAGAZINE",
+        "id": "btmp9mag_9x19mm_25",
+        "copy-from": "btmp9mag_9x19mm_25",
+        "name": {
+            "str": "APC9 25-round magazine"
+        },
+        "pocket_data": [
+            {
+                "pocket_type": "MAGAZINE",
+                "rigid": true,
+                "ammo_restriction": {
+                    "9mm": 25
+                },
+                "max_contains_weight": "1000 kg",
+                "max_item_length": "1 km"
+            }
+        ]
+    },
+    {
+        "type": "MAGAZINE",
+        "id": "btmp9mag_9x19mm_30",
+        "copy-from": "btmp9mag_9x19mm_30",
+        "name": {
+            "str": "APC9 30-round magazine"
+        },
+        "pocket_data": [
+            {
+                "pocket_type": "MAGAZINE",
+                "rigid": true,
+                "ammo_restriction": {
+                    "9mm": 30
+                },
+                "max_contains_weight": "1000 kg",
+                "max_item_length": "1 km"
+            }
+        ]
+    },
+    {
+        "type": "MAGAZINE",
+        "id": "btmp9mag_9x19mm_50rd",
+        "copy-from": "btmp9mag_9x19mm_50rd",
+        "name": {
+            "str": "APC9 50-round drum magazine"
+        },
+        "pocket_data": [
+            {
+                "pocket_type": "MAGAZINE",
+                "rigid": true,
+                "ammo_restriction": {
+                    "9mm": 50
+                },
+                "max_contains_weight": "1000 kg",
+                "max_item_length": "1 km"
+            }
+        ]
+    }
+]

--- a/Kenan-Modpack/easy_containers/items/magazine/9x18.json
+++ b/Kenan-Modpack/easy_containers/items/magazine/9x18.json
@@ -1,0 +1,40 @@
+[
+    {
+        "type": "MAGAZINE",
+        "id": "makarovmag",
+        "copy-from": "makarovmag",
+        "name": {
+            "str": "PM 8-round magazine"
+        },
+        "pocket_data": [
+            {
+                "pocket_type": "MAGAZINE",
+                "rigid": true,
+                "ammo_restriction": {
+                    "9x18": 8
+                },
+                "max_contains_weight": "1000 kg",
+                "max_item_length": "1 km"
+            }
+        ]
+    },
+    {
+        "type": "MAGAZINE",
+        "id": "skorpion82mag",
+        "copy-from": "skorpion82mag",
+        "name": {
+            "str": "Skorpion Vz. 82 20-round magazine"
+        },
+        "pocket_data": [
+            {
+                "pocket_type": "MAGAZINE",
+                "rigid": true,
+                "ammo_restriction": {
+                    "9x18": 20
+                },
+                "max_contains_weight": "1000 kg",
+                "max_item_length": "1 km"
+            }
+        ]
+    }
+]

--- a/Kenan-Modpack/easy_containers/items/magazine/chemical_spray.json
+++ b/Kenan-Modpack/easy_containers/items/magazine/chemical_spray.json
@@ -1,0 +1,22 @@
+[
+    {
+        "type": "MAGAZINE",
+        "id": "pressurized_tank_chem",
+        "copy-from": "pressurized_tank_chem",
+        "name": {
+            "str": "2L pressurized chemical tank"
+        },
+        "pocket_data": [
+            {
+                "pocket_type": "MAGAZINE",
+                "rigid": true,
+                "ammo_restriction": {
+                    "chemical_spray": 800
+                },
+                "watertight": true,
+                "max_contains_weight": "1000 kg",
+                "max_item_length": "1 km"
+            }
+        ]
+    }
+]

--- a/Kenan-Modpack/easy_containers/items/magazine/exodii.json
+++ b/Kenan-Modpack/easy_containers/items/magazine/exodii.json
@@ -1,0 +1,38 @@
+[
+    {
+        "type": "MAGAZINE",
+        "id": "exodiiminimag",
+        "copy-from": "exodiiminimag",
+        "name": {
+            "str": "PA Md. 71 Exodii 10-round magazine"
+        },
+        "pocket_data": [
+            {
+                "pocket_type": "MAGAZINE",
+                "ammo_restriction": {
+                    "123ln": 10
+                },
+                "max_contains_weight": "1000 kg",
+                "max_item_length": "1 km"
+            }
+        ]
+    },
+    {
+        "type": "MAGAZINE",
+        "id": "exodiiBRmag",
+        "copy-from": "exodiiBRmag",
+        "name": {
+            "str": "PA Md. 68 Exodii 60-round magazine"
+        },
+        "pocket_data": [
+            {
+                "pocket_type": "MAGAZINE",
+                "ammo_restriction": {
+                    "123ln": 60
+                },
+                "max_contains_weight": "1000 kg",
+                "max_item_length": "1 km"
+            }
+        ]
+    }
+]

--- a/Kenan-Modpack/easy_containers/items/magazine/liquid.json
+++ b/Kenan-Modpack/easy_containers/items/magazine/liquid.json
@@ -1,0 +1,82 @@
+[
+    {
+        "type": "MAGAZINE",
+        "id": "pressurized_tank",
+        "copy-from": "pressurized_tank",
+        "name": {
+            "str": "3L pressurized fuel tank"
+        },
+        "pocket_data": [
+            {
+                "pocket_type": "MAGAZINE",
+                "rigid": true,
+                "ammo_restriction": {
+                    "flammable": 3000
+                },
+                "watertight": true,
+                "max_contains_weight": "1000 kg",
+                "max_item_length": "1 km"
+            }
+        ]
+    },
+    {
+        "type": "MAGAZINE",
+        "id": "aux_pressurized_tank",
+        "copy-from": "aux_pressurized_tank",
+        "name": {
+            "str": "0.5L pressurized fuel tank"
+        },
+        "pocket_data": [
+            {
+                "pocket_type": "MAGAZINE",
+                "rigid": true,
+                "ammo_restriction": {
+                    "flammable": 500
+                },
+                "watertight": true,
+                "max_contains_weight": "1000 kg",
+                "max_item_length": "1 km"
+            }
+        ]
+    },
+    {
+        "type": "MAGAZINE",
+        "id": "rm4502",
+        "copy-from": "rm4502",
+        "name": {
+            "str": "RM451 2L fuel canister"
+        },
+        "pocket_data": [
+            {
+                "pocket_type": "MAGAZINE",
+                "rigid": true,
+                "ammo_restriction": {
+                    "flammable": 2000
+                },
+                "watertight": true,
+                "max_contains_weight": "1000 kg",
+                "max_item_length": "1 km"
+            }
+        ]
+    },
+    {
+        "type": "MAGAZINE",
+        "id": "rm4504",
+        "copy-from": "rm4504",
+        "name": {
+            "str": "RM451 4L fuel canister"
+        },
+        "pocket_data": [
+            {
+                "pocket_type": "MAGAZINE",
+                "rigid": true,
+                "ammo_restriction": {
+                    "flammable": 4000
+                },
+                "watertight": true,
+                "max_contains_weight": "1000 kg",
+                "max_item_length": "1 km"
+            }
+        ]
+    }
+]

--- a/Kenan-Modpack/easy_containers/items/magazine/nail.json
+++ b/Kenan-Modpack/easy_containers/items/magazine/nail.json
@@ -1,0 +1,21 @@
+[
+    {
+        "type": "MAGAZINE",
+        "id": "nailmag",
+        "copy-from": "nailmag",
+        "name": {
+            "str": "coilgun 50-round makeshift magazine"
+        },
+        "pocket_data": [
+            {
+                "pocket_type": "MAGAZINE",
+                "rigid": true,
+                "ammo_restriction": {
+                    "nail": 50
+                },
+                "max_contains_weight": "1000 kg",
+                "max_item_length": "1 km"
+            }
+        ]
+    }
+]

--- a/Kenan-Modpack/easy_containers/items/magazine/shot.json
+++ b/Kenan-Modpack/easy_containers/items/magazine/shot.json
@@ -1,0 +1,97 @@
+[
+    {
+        "type": "MAGAZINE",
+        "id": "saiga10mag",
+        "copy-from": "saiga10mag",
+        "name": {
+            "str": "Saiga-12 10-round magazine"
+        },
+        "pocket_data": [
+            {
+                "pocket_type": "MAGAZINE",
+                "rigid": true,
+                "ammo_restriction": {
+                    "shot": 10
+                },
+                "max_contains_weight": "1000 kg",
+                "max_item_length": "1 km"
+            }
+        ]
+    },
+    {
+        "type": "MAGAZINE",
+        "id": "saiga30mag",
+        "copy-from": "saiga30mag",
+        "name": {
+            "str": "Saiga-12 30-round drum magazine"
+        },
+        "pocket_data": [
+            {
+                "pocket_type": "MAGAZINE",
+                "rigid": true,
+                "ammo_restriction": {
+                    "shot": 30
+                },
+                "max_contains_weight": "1000 kg",
+                "max_item_length": "1 km"
+            }
+        ]
+    },
+    {
+        "type": "MAGAZINE",
+        "id": "shotbelt_20",
+        "copy-from": "shotbelt_20",
+        "name": {
+            "str": "20-round shotshell belt"
+        },
+        "pocket_data": [
+            {
+                "pocket_type": "MAGAZINE",
+                "rigid": true,
+                "ammo_restriction": {
+                    "shot": 20
+                },
+                "max_contains_weight": "1000 kg",
+                "max_item_length": "1 km"
+            }
+        ]
+    },
+    {
+        "type": "MAGAZINE",
+        "id": "shot_speedloader6",
+        "copy-from": "shot_speedloader6",
+        "name": {
+            "str": "shotgun 6-round speedloader"
+        },
+        "pocket_data": [
+            {
+                "pocket_type": "MAGAZINE",
+                "rigid": true,
+                "ammo_restriction": {
+                    "shot": 6
+                },
+                "max_contains_weight": "1000 kg",
+                "max_item_length": "1 km"
+            }
+        ]
+    },
+    {
+        "type": "MAGAZINE",
+        "id": "shot_speedloader8",
+        "copy-from": "shot_speedloader8",
+        "name": {
+            "str": "shotgun 8-round speedloader"
+        },
+        "pocket_data": [
+            {
+                "pocket_type": "MAGAZINE",
+                "rigid": true,
+                "ammo_restriction": {
+                    "shot": 8
+                },
+                "max_contains_weight": "1000 kg",
+                "max_item_length": "1 km"
+            }
+        ]
+    }
+]

--- a/Kenan-Modpack/easy_containers/items/magazine/weldgas.json
+++ b/Kenan-Modpack/easy_containers/items/magazine/weldgas.json
@@ -1,0 +1,42 @@
+[
+    {
+        "type": "MAGAZINE",
+        "id": "tinyweldtank",
+        "copy-from": "tinyweldtank",
+        "name": {
+            "str": "small welding tank"
+        },
+        "pocket_data": [
+            {
+                "pocket_type": "MAGAZINE",
+                "rigid": true,
+                "ammo_restriction": {
+                    "weldgas": 60
+                },
+                "watertight": true,
+                "max_contains_weight": "1000 kg",
+                "max_item_length": "1 km"
+            }
+        ]
+    },
+    {
+        "type": "MAGAZINE",
+        "id": "weldtank",
+        "copy-from": "weldtank",
+        "name": {
+            "str": "welding tank"
+        },
+        "pocket_data": [
+            {
+                "pocket_type": "MAGAZINE",
+                "rigid": true,
+                "ammo_restriction": {
+                    "weldgas": 240
+                },
+                "watertight": true,
+                "max_contains_weight": "1000 kg",
+                "max_item_length": "1 km"
+            }
+        ]
+    }
+]

--- a/Kenan-Modpack/easy_containers/items/melee/bludgeons.json
+++ b/Kenan-Modpack/easy_containers/items/melee/bludgeons.json
@@ -1,0 +1,77 @@
+[
+    {
+        "type": "TOOL",
+        "id": "l-stick",
+        "copy-from": "l-stick",
+        "name": {
+            "str": "L-stick (off)",
+            "str_pl": "L-sticks (off)"
+        },
+        "pocket_data": [
+            {
+                "pocket_type": "MAGAZINE_WELL",
+                "rigid": true,
+                "holster": true,
+                "max_contains_volume": "525 ml",
+                "max_contains_weight": "1000 kg",
+                "item_restriction": [
+                    "medium_plus_battery_cell",
+                    "medium_battery_cell",
+                    "medium_atomic_battery_cell",
+                    "medium_disposable_cell"
+                ],
+                "max_item_length": "1 km"
+            }
+        ]
+    },
+    {
+        "type": "TOOL",
+        "id": "shock_staff",
+        "copy-from": "shock_staff",
+        "name": {
+            "str": "powered quarterstaff",
+            "str_pl": "powered quarterstaves"
+        },
+        "pocket_data": [
+            {
+                "pocket_type": "MAGAZINE_WELL",
+                "rigid": true,
+                "holster": true,
+                "max_contains_volume": "20 L",
+                "max_contains_weight": "1000 kg",
+                "item_restriction": [
+                    "medium_battery_cell",
+                    "medium_plus_battery_cell",
+                    "medium_atomic_battery_cell",
+                    "medium_disposable_cell"
+                ],
+                "max_item_length": "1 km"
+            }
+        ]
+    },
+    {
+        "type": "TOOL",
+        "id": "shocktonfa_off",
+        "copy-from": "shocktonfa_off",
+        "name": {
+            "str": "tactical tonfa (off)",
+            "str_pl": "tactical tonfas (off)"
+        },
+        "pocket_data": [
+            {
+                "pocket_type": "MAGAZINE_WELL",
+                "rigid": true,
+                "holster": true,
+                "max_contains_volume": "20 L",
+                "max_contains_weight": "1000 kg",
+                "item_restriction": [
+                    "medium_battery_cell",
+                    "medium_plus_battery_cell",
+                    "medium_atomic_battery_cell",
+                    "medium_disposable_cell"
+                ],
+                "max_item_length": "1 km"
+            }
+        ]
+    }
+]

--- a/Kenan-Modpack/easy_containers/items/melee/misc.json
+++ b/Kenan-Modpack/easy_containers/items/melee/misc.json
@@ -1,0 +1,25 @@
+[
+    {
+        "type": "TOOL",
+        "id": "tazer",
+        "copy-from": "tazer",
+        "name": {
+            "str": "stun gun"
+        },
+        "pocket_data": [
+            {
+                "pocket_type": "MAGAZINE_WELL",
+                "holster": true,
+                "max_contains_volume": "20 L",
+                "max_contains_weight": "1000 kg",
+                "item_restriction": [
+                    "medium_battery_cell",
+                    "medium_plus_battery_cell",
+                    "medium_atomic_battery_cell",
+                    "medium_disposable_cell"
+                ],
+                "max_item_length": "1 km"
+            }
+        ]
+    }
+]

--- a/Kenan-Modpack/easy_containers/items/melee/swords_and_blades.json
+++ b/Kenan-Modpack/easy_containers/items/melee/swords_and_blades.json
@@ -1,0 +1,119 @@
+[
+    {
+        "type": "TOOL",
+        "id": "shock_foil",
+        "copy-from": "shock_foil",
+        "name": {
+            "str": "electrified foil"
+        },
+        "pocket_data": [
+            {
+                "pocket_type": "MAGAZINE_WELL",
+                "rigid": true,
+                "holster": true,
+                "max_contains_volume": "20 L",
+                "max_contains_weight": "1000 kg",
+                "item_restriction": [
+                    "medium_battery_cell",
+                    "medium_plus_battery_cell",
+                    "medium_atomic_battery_cell",
+                    "medium_disposable_cell"
+                ],
+                "max_item_length": "1 km"
+            }
+        ]
+    },
+    {
+        "type": "TOOL",
+        "id": "shock_epee",
+        "copy-from": "shock_epee",
+        "name": {
+            "str": "electrified \u00e9p\u00e9e"
+        },
+        "pocket_data": [
+            {
+                "pocket_type": "MAGAZINE_WELL",
+                "rigid": true,
+                "holster": true,
+                "max_contains_volume": "20 L",
+                "max_contains_weight": "1000 kg",
+                "item_restriction": [
+                    "medium_battery_cell",
+                    "medium_plus_battery_cell",
+                    "medium_atomic_battery_cell",
+                    "medium_disposable_cell"
+                ],
+                "max_item_length": "1 km"
+            }
+        ]
+    },
+    {
+        "type": "TOOL",
+        "id": "shock_sabre",
+        "copy-from": "shock_sabre",
+        "name": {
+            "str": "electrified saber"
+        },
+        "pocket_data": [
+            {
+                "pocket_type": "MAGAZINE_WELL",
+                "rigid": true,
+                "holster": true,
+                "max_contains_volume": "20 L",
+                "max_contains_weight": "1000 kg",
+                "item_restriction": [
+                    "medium_battery_cell",
+                    "medium_plus_battery_cell",
+                    "medium_atomic_battery_cell",
+                    "medium_disposable_cell"
+                ],
+                "max_item_length": "1 km"
+            }
+        ]
+    },
+    {
+        "type": "GENERIC",
+        "id": "hollow_cane",
+        "copy-from": "hollow_cane",
+        "name": {
+            "str": "hollow cane"
+        },
+        "pocket_data": [
+            {
+                "pocket_type": "CONTAINER",
+                "max_contains_volume": "1531 ml",
+                "max_contains_weight": "1000 kg",
+                "moves": 80,
+                "flag_restriction": [
+                    "SHEATH_SWORD"
+                ],
+                "max_item_length": "1 km"
+            }
+        ]
+    },
+    {
+        "type": "TOOL",
+        "id": "e_combatsaw_off",
+        "copy-from": "e_combatsaw_off",
+        "name": {
+            "str": "electric combat chainsaw (off)",
+            "str_pl": "electric combat chainsaws (off)"
+        },
+        "pocket_data": [
+            {
+                "pocket_type": "MAGAZINE_WELL",
+                "holster": true,
+                "magazine_well": "200 ml",
+                "max_contains_volume": "20 L",
+                "max_contains_weight": "1000 kg",
+                "item_restriction": [
+                    "medium_battery_cell",
+                    "medium_plus_battery_cell",
+                    "medium_atomic_battery_cell",
+                    "medium_disposable_cell"
+                ],
+                "max_item_length": "1 km"
+            }
+        ]
+    }
+]

--- a/Kenan-Modpack/easy_containers/items/obsolete.json
+++ b/Kenan-Modpack/easy_containers/items/obsolete.json
@@ -1,0 +1,428 @@
+[
+    {
+        "type": "GUN",
+        "id": "flamethrower_crude",
+        "copy-from": "flamethrower_crude",
+        "name": {
+            "str": "spraycan flamethrower"
+        },
+        "pocket_data": [
+            {
+                "pocket_type": "MAGAZINE",
+                "ammo_restriction": {
+                    "flammable": 100
+                },
+                "watertight": true,
+                "max_contains_weight": "1000 kg",
+                "max_item_length": "1 km"
+            }
+        ]
+    },
+    {
+        "type": "GUN",
+        "id": "flamethrower_simple",
+        "copy-from": "flamethrower_simple",
+        "name": {
+            "str": "simple flamethrower"
+        },
+        "pocket_data": [
+            {
+                "pocket_type": "MAGAZINE_WELL",
+                "holster": true,
+                "max_contains_volume": "20 L",
+                "max_contains_weight": "1000 kg",
+                "item_restriction": [
+                    "aux_pressurized_tank",
+                    "pressurized_tank"
+                ],
+                "max_item_length": "1 km"
+            }
+        ]
+    },
+    {
+        "type": "GUN",
+        "id": "TANK",
+        "copy-from": "TANK",
+        "name": {
+            "str_sp": "Tankbot Main Gun"
+        },
+        "pocket_data": [
+            {
+                "pocket_type": "MAGAZINE",
+                "ammo_restriction": {
+                    "120mm": 1
+                },
+                "max_contains_weight": "1000 kg",
+                "max_item_length": "1 km"
+            }
+        ]
+    },
+    {
+        "type": "GENERIC",
+        "id": "rock_pot",
+        "copy-from": "rock_pot",
+        "name": {
+            "str": "stone pot"
+        },
+        "pocket_data": [
+            {
+                "max_contains_volume": "1500 ml",
+                "max_contains_weight": "1000 kg",
+                "watertight": true,
+                "open_container": true,
+                "rigid": true,
+                "max_item_length": "1 km"
+            }
+        ]
+    },
+    {
+        "type": "GUN",
+        "id": "survivor_special_700",
+        "copy-from": "survivor_special_700",
+        "name": {
+            "str": "Special 700"
+        },
+        "pocket_data": [
+            {
+                "pocket_type": "MAGAZINE",
+                "ammo_restriction": {
+                    "3006": 1
+                },
+                "max_contains_weight": "1000 kg",
+                "max_item_length": "1 km"
+            }
+        ]
+    },
+    {
+        "type": "GUN",
+        "id": "l_bak_223",
+        "copy-from": "l_bak_223",
+        "name": {
+            "str": "L2037 Backup"
+        },
+        "pocket_data": [
+            {
+                "pocket_type": "MAGAZINE",
+                "holster": true,
+                "ammo_restriction": {
+                    "223": 5
+                },
+                "max_contains_weight": "1000 kg",
+                "max_item_length": "1 km"
+            }
+        ]
+    },
+    {
+        "type": "MAGAZINE",
+        "id": "223_speedloader5",
+        "copy-from": "223_speedloader5",
+        "name": {
+            "str": "LW-5 speedloader"
+        },
+        "pocket_data": [
+            {
+                "pocket_type": "MAGAZINE",
+                "ammo_restriction": {
+                    "223": 5
+                },
+                "max_contains_weight": "1000 kg",
+                "max_item_length": "1 km"
+            }
+        ]
+    },
+    {
+        "type": "GUNMOD",
+        "id": "aux_flamer",
+        "copy-from": "aux_flamer",
+        "name": {
+            "str": "aux flamethrower"
+        },
+        "pocket_data": [
+            {
+                "pocket_type": "MAGAZINE_WELL",
+                "holster": true,
+                "max_contains_volume": "20 L",
+                "max_contains_weight": "1000 kg",
+                "item_restriction": [
+                    "aux_pressurized_tank"
+                ],
+                "max_item_length": "1 km"
+            }
+        ]
+    },
+    {
+        "type": "GUN",
+        "id": "tihar",
+        "copy-from": "tihar",
+        "name": {
+            "str": "pneumatic assault rifle"
+        },
+        "pocket_data": [
+            {
+                "pocket_type": "MAGAZINE",
+                "ammo_restriction": {
+                    "pebble": 15
+                },
+                "max_contains_weight": "1000 kg",
+                "max_item_length": "1 km"
+            }
+        ]
+    },
+    {
+        "type": "GUN",
+        "id": "helsing",
+        "copy-from": "helsing",
+        "name": {
+            "str": "pneumatic bolt driver"
+        },
+        "pocket_data": [
+            {
+                "pocket_type": "MAGAZINE",
+                "ammo_restriction": {
+                    "bolt": 8
+                },
+                "max_contains_weight": "1000 kg",
+                "max_item_length": "1 km"
+            }
+        ]
+    },
+    {
+        "type": "GUN",
+        "id": "pneumatic_shotgun",
+        "copy-from": "pneumatic_shotgun",
+        "name": {
+            "str": "pneumatic shotgun"
+        },
+        "pocket_data": [
+            {
+                "pocket_type": "MAGAZINE",
+                "ammo_restriction": {
+                    "shotcanister": 2
+                },
+                "max_contains_weight": "1000 kg",
+                "max_item_length": "1 km"
+            }
+        ]
+    },
+    {
+        "type": "GUN",
+        "id": "mininuke_launcher",
+        "copy-from": "mininuke_launcher",
+        "name": {
+            "str": "mininuke launcher"
+        },
+        "pocket_data": [
+            {
+                "pocket_type": "MAGAZINE",
+                "ammo_restriction": {
+                    "mininuke_mod": 1
+                },
+                "max_contains_weight": "1000 kg",
+                "max_item_length": "1 km"
+            }
+        ]
+    },
+    {
+        "type": "GUN",
+        "id": "heavy_rail_rifle",
+        "copy-from": "heavy_rail_rifle",
+        "name": {
+            "str": "heavy rail rifle"
+        },
+        "pocket_data": [
+            {
+                "pocket_type": "MAGAZINE",
+                "ammo_restriction": {
+                    "metal_rail": 10
+                },
+                "max_contains_weight": "1000 kg",
+                "max_item_length": "1 km"
+            }
+        ]
+    },
+    {
+        "type": "GUN",
+        "id": "rebar_rifle",
+        "copy-from": "rebar_rifle",
+        "name": {
+            "str": "ferromagnetic rail rifle"
+        },
+        "pocket_data": [
+            {
+                "pocket_type": "MAGAZINE",
+                "ammo_restriction": {
+                    "metal_rail": 1
+                },
+                "max_contains_weight": "1000 kg",
+                "max_item_length": "1 km"
+            }
+        ]
+    },
+    {
+        "type": "GUN",
+        "id": "nailrifle",
+        "copy-from": "nailrifle",
+        "name": {
+            "str": "nail rifle"
+        },
+        "pocket_data": [
+            {
+                "pocket_type": "MAGAZINE_WELL",
+                "holster": true,
+                "max_contains_volume": "20 L",
+                "max_contains_weight": "1000 kg",
+                "item_restriction": [
+                    "nailmag"
+                ],
+                "max_item_length": "1 km"
+            }
+        ]
+    },
+    {
+        "type": "TOOL",
+        "id": "control_laptop",
+        "copy-from": "control_laptop",
+        "name": {
+            "str": "control laptop"
+        },
+        "pocket_data": [
+            {
+                "pocket_type": "MAGAZINE_WELL",
+                "rigid": true,
+                "holster": true,
+                "max_contains_volume": "20 L",
+                "max_contains_weight": "1000 kg",
+                "item_restriction": [
+                    "medium_battery_cell",
+                    "medium_plus_battery_cell",
+                    "medium_atomic_battery_cell",
+                    "medium_disposable_cell"
+                ],
+                "max_item_length": "1 km"
+            }
+        ]
+    },
+    {
+        "type": "GUN",
+        "id": "an94",
+        "copy-from": "an94",
+        "name": {
+            "str": "AN-94"
+        },
+        "pocket_data": [
+            {
+                "pocket_type": "MAGAZINE_WELL",
+                "holster": true,
+                "max_contains_volume": "20 L",
+                "max_contains_weight": "1000 kg",
+                "item_restriction": [
+                    "ak74mag",
+                    "rpk74mag"
+                ],
+                "max_item_length": "1 km"
+            }
+        ]
+    },
+    {
+        "type": "GUN",
+        "id": "hybridbow",
+        "copy-from": "hybridbow",
+        "name": {
+            "str": "hybrid longbow"
+        },
+        "pocket_data": [
+            {
+                "pocket_type": "MAGAZINE",
+                "ammo_restriction": {
+                    "arrow": 1
+                },
+                "max_contains_weight": "1000 kg",
+                "max_item_length": "1 km"
+            }
+        ]
+    },
+    {
+        "type": "TOOL",
+        "id": "ecs_lajatang_off",
+        "copy-from": "ecs_lajatang_off",
+        "name": {
+            "str": "electric chainsaw lajatang (off)",
+            "str_pl": "electric chainsaw lajatangs (off)"
+        },
+        "pocket_data": [
+            {
+                "pocket_type": "MAGAZINE_WELL",
+                "holster": true,
+                "magazine_well": "500 ml",
+                "max_contains_volume": "20 L",
+                "max_contains_weight": "1000 kg",
+                "item_restriction": [
+                    "heavy_battery_cell",
+                    "heavy_plus_battery_cell",
+                    "heavy_atomic_battery_cell",
+                    "heavy_disposable_cell"
+                ],
+                "max_item_length": "1 km"
+            }
+        ]
+    },
+    {
+        "type": "GUN",
+        "id": "USAS_12",
+        "copy-from": "USAS_12",
+        "name": {
+            "str": "USAS 12"
+        },
+        "pocket_data": [
+            {
+                "pocket_type": "MAGAZINE_WELL",
+                "holster": true,
+                "max_contains_volume": "20 L",
+                "max_contains_weight": "1000 kg",
+                "item_restriction": [
+                    "USAS10mag",
+                    "USAS20mag"
+                ],
+                "max_item_length": "1 km"
+            }
+        ]
+    },
+    {
+        "type": "MAGAZINE",
+        "id": "USAS10mag",
+        "copy-from": "USAS10mag",
+        "name": {
+            "str": "USAS-12 10-round magazine"
+        },
+        "pocket_data": [
+            {
+                "pocket_type": "MAGAZINE",
+                "rigid": true,
+                "ammo_restriction": {
+                    "shot": 10
+                },
+                "max_contains_weight": "1000 kg",
+                "max_item_length": "1 km"
+            }
+        ]
+    },
+    {
+        "type": "MAGAZINE",
+        "id": "USAS20mag",
+        "copy-from": "USAS20mag",
+        "name": {
+            "str": "USAS-12 20-round drum magazine"
+        },
+        "pocket_data": [
+            {
+                "pocket_type": "MAGAZINE",
+                "rigid": true,
+                "ammo_restriction": {
+                    "shot": 20
+                },
+                "max_contains_weight": "1000 kg",
+                "max_item_length": "1 km"
+            }
+        ]
+    }
+]

--- a/Kenan-Modpack/easy_containers/items/ranged/archery.json
+++ b/Kenan-Modpack/easy_containers/items/ranged/archery.json
@@ -1,0 +1,166 @@
+[
+    {
+        "type": "GUN",
+        "id": "selfbow",
+        "copy-from": "selfbow",
+        "name": {
+            "str": "survival bow"
+        },
+        "pocket_data": [
+            {
+                "pocket_type": "MAGAZINE",
+                "ammo_restriction": {
+                    "arrow": 1
+                },
+                "max_contains_weight": "1000 kg",
+                "max_item_length": "1 km"
+            }
+        ]
+    },
+    {
+        "type": "GUN",
+        "id": "shortbow",
+        "copy-from": "shortbow",
+        "name": {
+            "str": "short bow"
+        },
+        "pocket_data": [
+            {
+                "pocket_type": "MAGAZINE",
+                "ammo_restriction": {
+                    "arrow": 1
+                },
+                "max_contains_weight": "1000 kg",
+                "max_item_length": "1 km"
+            }
+        ]
+    },
+    {
+        "type": "GUN",
+        "id": "compbow",
+        "copy-from": "compbow",
+        "name": {
+            "str": "compound hunting bow"
+        },
+        "pocket_data": [
+            {
+                "pocket_type": "MAGAZINE",
+                "ammo_restriction": {
+                    "arrow": 1
+                },
+                "max_contains_weight": "1000 kg",
+                "max_item_length": "1 km"
+            }
+        ]
+    },
+    {
+        "type": "GUN",
+        "id": "compositebow",
+        "copy-from": "compositebow",
+        "name": {
+            "str": "composite bow (heavy)",
+            "str_pl": "composite bows (heavy)"
+        },
+        "pocket_data": [
+            {
+                "pocket_type": "MAGAZINE",
+                "ammo_restriction": {
+                    "arrow": 1
+                },
+                "max_contains_weight": "1000 kg",
+                "max_item_length": "1 km"
+            }
+        ]
+    },
+    {
+        "type": "GUN",
+        "id": "reflexbow",
+        "copy-from": "reflexbow",
+        "name": {
+            "str": "composite bow (light)",
+            "str_pl": "composite bows (light)"
+        },
+        "pocket_data": [
+            {
+                "pocket_type": "MAGAZINE",
+                "ammo_restriction": {
+                    "arrow": 1
+                },
+                "max_contains_weight": "1000 kg",
+                "max_item_length": "1 km"
+            }
+        ]
+    },
+    {
+        "type": "GUN",
+        "id": "recurbow",
+        "copy-from": "recurbow",
+        "name": {
+            "str": "modern recurve bow"
+        },
+        "pocket_data": [
+            {
+                "pocket_type": "MAGAZINE",
+                "ammo_restriction": {
+                    "arrow": 1
+                },
+                "max_contains_weight": "1000 kg",
+                "max_item_length": "1 km"
+            }
+        ]
+    },
+    {
+        "type": "GUN",
+        "id": "longbow",
+        "copy-from": "longbow",
+        "name": {
+            "str": "longbow"
+        },
+        "pocket_data": [
+            {
+                "pocket_type": "MAGAZINE",
+                "ammo_restriction": {
+                    "arrow": 1
+                },
+                "max_contains_weight": "1000 kg",
+                "max_item_length": "1 km"
+            }
+        ]
+    },
+    {
+        "type": "GUN",
+        "id": "compgreatbow",
+        "copy-from": "compgreatbow",
+        "name": {
+            "str": "compound greatbow"
+        },
+        "pocket_data": [
+            {
+                "pocket_type": "MAGAZINE",
+                "ammo_restriction": {
+                    "arrow": 1
+                },
+                "max_contains_weight": "1000 kg",
+                "max_item_length": "1 km"
+            }
+        ]
+    },
+    {
+        "type": "GUN",
+        "id": "reflexrecurvebow",
+        "copy-from": "reflexrecurvebow",
+        "name": {
+            "str": "Olympic style target bow"
+        },
+        "pocket_data": [
+            {
+                "pocket_type": "MAGAZINE",
+                "ammo_restriction": {
+                    "arrow": 1
+                },
+                "max_contains_weight": "1000 kg",
+                "max_item_length": "1 km"
+            }
+        ]
+    }
+]

--- a/Kenan-Modpack/easy_containers/items/ranged/crossbows.json
+++ b/Kenan-Modpack/easy_containers/items/ranged/crossbows.json
@@ -1,0 +1,128 @@
+[
+    {
+        "type": "GUN",
+        "id": "bullet_crossbow",
+        "copy-from": "bullet_crossbow",
+        "name": {
+            "str": "bullet crossbow"
+        },
+        "pocket_data": [
+            {
+                "pocket_type": "MAGAZINE",
+                "ammo_restriction": {
+                    "pebble": 1
+                },
+                "max_contains_weight": "1000 kg",
+                "max_item_length": "1 km"
+            }
+        ]
+    },
+    {
+        "type": "GUN",
+        "id": "hand_crossbow",
+        "copy-from": "hand_crossbow",
+        "name": {
+            "str": "pistol crossbow"
+        },
+        "pocket_data": [
+            {
+                "pocket_type": "MAGAZINE",
+                "ammo_restriction": {
+                    "bolt": 1
+                },
+                "max_contains_weight": "1000 kg",
+                "max_item_length": "1 km"
+            }
+        ]
+    },
+    {
+        "type": "GUN",
+        "id": "crossbow",
+        "copy-from": "crossbow",
+        "name": {
+            "str": "wood crossbow"
+        },
+        "pocket_data": [
+            {
+                "pocket_type": "MAGAZINE",
+                "ammo_restriction": {
+                    "bolt": 1
+                },
+                "max_contains_weight": "1000 kg",
+                "max_item_length": "1 km"
+            }
+        ]
+    },
+    {
+        "type": "GUN",
+        "id": "compositecrossbow",
+        "copy-from": "compositecrossbow",
+        "name": {
+            "str": "composite crossbow"
+        },
+        "pocket_data": [
+            {
+                "pocket_type": "MAGAZINE",
+                "ammo_restriction": {
+                    "bolt": 1
+                },
+                "max_contains_weight": "1000 kg",
+                "max_item_length": "1 km"
+            }
+        ]
+    },
+    {
+        "type": "GUN",
+        "id": "compcrossbow",
+        "copy-from": "compcrossbow",
+        "name": {
+            "str": "compound crossbow"
+        },
+        "pocket_data": [
+            {
+                "pocket_type": "MAGAZINE",
+                "ammo_restriction": {
+                    "bolt": 1
+                },
+                "max_contains_weight": "1000 kg",
+                "max_item_length": "1 km"
+            }
+        ]
+    },
+    {
+        "type": "GUN",
+        "id": "huge_crossbow",
+        "copy-from": "huge_crossbow",
+        "name": {
+            "str": "heavy crossbow"
+        },
+        "pocket_data": [
+            {
+                "pocket_type": "MAGAZINE",
+                "ammo_restriction": {
+                    "bolt": 1
+                },
+                "max_contains_weight": "1000 kg",
+                "max_item_length": "1 km"
+            }
+        ]
+    },
+    {
+        "type": "GUN",
+        "id": "rep_crossbow",
+        "copy-from": "rep_crossbow",
+        "name": {
+            "str": "repeating crossbow"
+        },
+        "pocket_data": [
+            {
+                "pocket_type": "MAGAZINE",
+                "ammo_restriction": {
+                    "bolt": 10
+                },
+                "max_contains_weight": "1000 kg",
+                "max_item_length": "1 km"
+            }
+        ]
+    }
+]

--- a/Kenan-Modpack/easy_containers/items/ranged/energy.json
+++ b/Kenan-Modpack/easy_containers/items/ranged/energy.json
@@ -1,0 +1,38 @@
+[
+    {
+        "type": "GUN",
+        "id": "plasma_gun",
+        "copy-from": "plasma_gun",
+        "name": {
+            "str": "PPA-5"
+        },
+        "pocket_data": [
+            {
+                "pocket_type": "MAGAZINE",
+                "ammo_restriction": {
+                    "plasma": 25
+                },
+                "max_contains_weight": "1000 kg",
+                "max_item_length": "1 km"
+            }
+        ]
+    },
+    {
+        "type": "GUN",
+        "id": "plasma_rifle",
+        "copy-from": "plasma_rifle",
+        "name": {
+            "str": "Boeing XM-P plasma rifle"
+        },
+        "pocket_data": [
+            {
+                "pocket_type": "MAGAZINE",
+                "ammo_restriction": {
+                    "plasma": 25
+                },
+                "max_contains_weight": "1000 kg",
+                "max_item_length": "1 km"
+            }
+        ]
+    }
+]

--- a/Kenan-Modpack/easy_containers/items/ranged/launchers.json
+++ b/Kenan-Modpack/easy_containers/items/ranged/launchers.json
@@ -1,0 +1,75 @@
+[
+    {
+        "type": "GUN",
+        "id": "LAW",
+        "copy-from": "LAW",
+        "name": {
+            "str_sp": "M72 LAW"
+        },
+        "pocket_data": [
+            {
+                "pocket_type": "MAGAZINE",
+                "ammo_restriction": {
+                    "66mm": 1
+                },
+                "max_contains_weight": "1000 kg",
+                "max_item_length": "1 km"
+            }
+        ]
+    },
+    {
+        "type": "GUN",
+        "id": "RPG",
+        "copy-from": "RPG",
+        "name": {
+            "str_sp": "RPG-7"
+        },
+        "pocket_data": [
+            {
+                "pocket_type": "MAGAZINE",
+                "ammo_restriction": {
+                    "RPG-7": 1
+                },
+                "max_contains_weight": "1000 kg",
+                "max_item_length": "1 km"
+            }
+        ]
+    },
+    {
+        "type": "GUN",
+        "id": "surv_rocket_launcher",
+        "copy-from": "surv_rocket_launcher",
+        "name": {
+            "str": "crude rocket launcher"
+        },
+        "pocket_data": [
+            {
+                "pocket_type": "MAGAZINE",
+                "ammo_restriction": {
+                    "homebrew_rocket": 1
+                },
+                "max_contains_weight": "1000 kg",
+                "max_item_length": "1 km"
+            }
+        ]
+    },
+    {
+        "type": "GUN",
+        "id": "watercannon",
+        "copy-from": "watercannon",
+        "name": {
+            "str": "water cannon"
+        },
+        "pocket_data": [
+            {
+                "pocket_type": "MAGAZINE",
+                "ammo_restriction": {
+                    "water": 100
+                },
+                "watertight": true,
+                "max_contains_weight": "1000 kg",
+                "max_item_length": "1 km"
+            }
+        ]
+    }
+]

--- a/Kenan-Modpack/easy_containers/items/ranged/pneumatic.json
+++ b/Kenan-Modpack/easy_containers/items/ranged/pneumatic.json
@@ -1,0 +1,20 @@
+[
+    {
+        "type": "GUN",
+        "id": "bbgun",
+        "copy-from": "bbgun",
+        "name": {
+            "str": "BB gun"
+        },
+        "pocket_data": [
+            {
+                "pocket_type": "MAGAZINE",
+                "ammo_restriction": {
+                    "BB": 150
+                },
+                "max_contains_weight": "1000 kg",
+                "max_item_length": "1 km"
+            }
+        ]
+    }
+]

--- a/Kenan-Modpack/easy_containers/items/ranged/slings.json
+++ b/Kenan-Modpack/easy_containers/items/ranged/slings.json
@@ -1,0 +1,75 @@
+[
+    {
+        "type": "GUN",
+        "id": "sling",
+        "copy-from": "sling",
+        "name": {
+            "ctxt": "weapon",
+            "str": "sling"
+        },
+        "pocket_data": [
+            {
+                "pocket_type": "MAGAZINE",
+                "ammo_restriction": {
+                    "rock": 1
+                },
+                "max_contains_weight": "1000 kg",
+                "max_item_length": "1 km"
+            }
+        ]
+    },
+    {
+        "type": "GUN",
+        "id": "slingshot",
+        "copy-from": "slingshot",
+        "name": {
+            "str": "slingshot"
+        },
+        "pocket_data": [
+            {
+                "pocket_type": "MAGAZINE",
+                "ammo_restriction": {
+                    "pebble": 1
+                },
+                "max_contains_weight": "1000 kg",
+                "max_item_length": "1 km"
+            }
+        ]
+    },
+    {
+        "type": "GUN",
+        "id": "staff_sling",
+        "copy-from": "staff_sling",
+        "name": {
+            "str": "staff sling"
+        },
+        "pocket_data": [
+            {
+                "pocket_type": "MAGAZINE",
+                "ammo_restriction": {
+                    "rock": 1
+                },
+                "max_contains_weight": "1000 kg",
+                "max_item_length": "1 km"
+            }
+        ]
+    },
+    {
+        "type": "GUN",
+        "id": "wristrocket",
+        "copy-from": "wristrocket",
+        "name": {
+            "str": "brace slingshot"
+        },
+        "pocket_data": [
+            {
+                "pocket_type": "MAGAZINE",
+                "ammo_restriction": {
+                    "pebble": 1
+                },
+                "max_contains_weight": "1000 kg",
+                "max_item_length": "1 km"
+            }
+        ]
+    }
+]

--- a/Kenan-Modpack/easy_containers/items/ranged/spearguns.json
+++ b/Kenan-Modpack/easy_containers/items/ranged/spearguns.json
@@ -1,0 +1,74 @@
+[
+    {
+        "type": "GUN",
+        "id": "airspeargun",
+        "copy-from": "airspeargun",
+        "name": {
+            "str": "pneumatic speargun"
+        },
+        "pocket_data": [
+            {
+                "pocket_type": "MAGAZINE",
+                "ammo_restriction": {
+                    "fishspear": 4
+                },
+                "max_contains_weight": "1000 kg",
+                "max_item_length": "1 km"
+            }
+        ]
+    },
+    {
+        "type": "GUN",
+        "id": "doublespeargun",
+        "copy-from": "doublespeargun",
+        "name": {
+            "str": "double speargun"
+        },
+        "pocket_data": [
+            {
+                "pocket_type": "MAGAZINE",
+                "ammo_restriction": {
+                    "fishspear": 2
+                },
+                "max_contains_weight": "1000 kg",
+                "max_item_length": "1 km"
+            }
+        ]
+    },
+    {
+        "type": "GUN",
+        "id": "minispeargun",
+        "copy-from": "minispeargun",
+        "name": {
+            "str": "mini speargun"
+        },
+        "pocket_data": [
+            {
+                "pocket_type": "MAGAZINE",
+                "ammo_restriction": {
+                    "fishspear": 1
+                },
+                "max_contains_weight": "1000 kg",
+                "max_item_length": "1 km"
+            }
+        ]
+    },
+    {
+        "type": "GUN",
+        "id": "speargun",
+        "copy-from": "speargun",
+        "name": {
+            "str": "speargun"
+        },
+        "pocket_data": [
+            {
+                "pocket_type": "MAGAZINE",
+                "ammo_restriction": {
+                    "fishspear": 1
+                },
+                "max_contains_weight": "1000 kg",
+                "max_item_length": "1 km"
+            }
+        ]
+    }
+]

--- a/Kenan-Modpack/easy_containers/items/tool/container.json
+++ b/Kenan-Modpack/easy_containers/items/tool/container.json
@@ -1,0 +1,38 @@
+[
+    {
+        "type": "GENERIC",
+        "id": "bottle_metal",
+        "copy-from": "bottle_metal",
+        "name": {
+            "str": "steel bottle"
+        },
+        "pocket_data": [
+            {
+                "pocket_type": "CONTAINER",
+                "watertight": true,
+                "rigid": true,
+                "max_contains_volume": "750 ml",
+                "max_contains_weight": "1000 kg",
+                "max_item_length": "1 km"
+            }
+        ]
+    },
+    {
+        "type": "GENERIC",
+        "id": "bottle_folding",
+        "copy-from": "bottle_folding",
+        "name": {
+            "str": "foldable plastic bottle"
+        },
+        "pocket_data": [
+            {
+                "pocket_type": "CONTAINER",
+                "watertight": true,
+                "rigid": false,
+                "max_contains_volume": "500 ml",
+                "max_contains_weight": "1000 kg",
+                "max_item_length": "1 km"
+            }
+        ]
+    }
+]

--- a/Kenan-Modpack/easy_containers/items/tool/cooking.json
+++ b/Kenan-Modpack/easy_containers/items/tool/cooking.json
@@ -1,0 +1,518 @@
+[
+    {
+        "type": "TOOL",
+        "id": "carver_off",
+        "copy-from": "carver_off",
+        "name": {
+            "str": "electric carver (off)",
+            "str_pl": "electric carvers (off)"
+        },
+        "pocket_data": [
+            {
+                "pocket_type": "MAGAZINE_WELL",
+                "rigid": true,
+                "holster": true,
+                "max_contains_volume": "20 L",
+                "max_contains_weight": "1000 kg",
+                "item_restriction": [
+                    "medium_battery_cell",
+                    "medium_plus_battery_cell",
+                    "medium_atomic_battery_cell",
+                    "medium_disposable_cell"
+                ],
+                "max_item_length": "1 km"
+            }
+        ]
+    },
+    {
+        "type": "TOOL",
+        "id": "char_purifier",
+        "copy-from": "char_purifier",
+        "name": {
+            "str": "charcoal water purifier"
+        },
+        "pocket_data": [
+            {
+                "pocket_type": "MAGAZINE",
+                "ammo_restriction": {
+                    "charcoal": 150
+                },
+                "max_contains_weight": "1000 kg",
+                "max_item_length": "1 km"
+            }
+        ]
+    },
+    {
+        "type": "TOOL",
+        "id": "char_smoker",
+        "copy-from": "char_smoker",
+        "name": {
+            "str": "charcoal smoker"
+        },
+        "pocket_data": [
+            {
+                "pocket_type": "MAGAZINE",
+                "rigid": true,
+                "ammo_restriction": {
+                    "charcoal": 375
+                },
+                "max_contains_weight": "1000 kg",
+                "max_item_length": "1 km"
+            }
+        ]
+    },
+    {
+        "type": "TOOL",
+        "id": "charcoal_cooker",
+        "copy-from": "charcoal_cooker",
+        "name": {
+            "str": "charcoal cooker"
+        },
+        "pocket_data": [
+            {
+                "pocket_type": "MAGAZINE",
+                "ammo_restriction": {
+                    "charcoal": 50
+                },
+                "max_contains_weight": "1000 kg",
+                "max_item_length": "1 km"
+            }
+        ]
+    },
+    {
+        "type": "GENERIC",
+        "id": "clay_pot",
+        "copy-from": "clay_pot",
+        "name": {
+            "str": "clay pot"
+        },
+        "pocket_data": [
+            {
+                "max_contains_volume": "2 L",
+                "max_contains_weight": "1000 kg",
+                "watertight": true,
+                "rigid": true,
+                "max_item_length": "1 km"
+            }
+        ]
+    },
+    {
+        "type": "GENERIC",
+        "id": "clay_teapot",
+        "copy-from": "clay_teapot",
+        "name": {
+            "str": "clay teapot"
+        },
+        "pocket_data": [
+            {
+                "max_contains_volume": "750 ml",
+                "max_contains_weight": "1000 kg",
+                "watertight": true,
+                "rigid": true,
+                "max_item_length": "1 km"
+            }
+        ]
+    },
+    {
+        "type": "TOOL",
+        "id": "coffeemaker",
+        "copy-from": "coffeemaker",
+        "name": {
+            "str": "coffeemaker"
+        },
+        "pocket_data": [
+            {
+                "pocket_type": "MAGAZINE_WELL",
+                "rigid": true,
+                "holster": true,
+                "max_contains_volume": "20 L",
+                "max_contains_weight": "1000 kg",
+                "item_restriction": [
+                    "medium_battery_cell",
+                    "medium_plus_battery_cell",
+                    "medium_atomic_battery_cell",
+                    "medium_disposable_cell"
+                ],
+                "max_item_length": "1 km"
+            }
+        ]
+    },
+    {
+        "type": "TOOL",
+        "id": "dehydrator",
+        "copy-from": "dehydrator",
+        "name": {
+            "str": "food dehydrator"
+        },
+        "pocket_data": [
+            {
+                "pocket_type": "MAGAZINE_WELL",
+                "rigid": true,
+                "holster": true,
+                "max_contains_volume": "20 L",
+                "max_contains_weight": "1000 kg",
+                "item_restriction": [
+                    "medium_battery_cell",
+                    "medium_plus_battery_cell",
+                    "medium_atomic_battery_cell",
+                    "medium_disposable_cell"
+                ],
+                "max_item_length": "1 km"
+            }
+        ]
+    },
+    {
+        "type": "TOOL",
+        "id": "esbit_stove",
+        "copy-from": "esbit_stove",
+        "name": {
+            "str": "hexamine stove"
+        },
+        "pocket_data": [
+            {
+                "pocket_type": "MAGAZINE",
+                "ammo_restriction": {
+                    "esbit": 50
+                },
+                "max_contains_weight": "1000 kg",
+                "max_item_length": "1 km"
+            }
+        ]
+    },
+    {
+        "type": "TOOL",
+        "id": "food_processor",
+        "copy-from": "food_processor",
+        "name": {
+            "str": "food processor"
+        },
+        "pocket_data": [
+            {
+                "pocket_type": "MAGAZINE_WELL",
+                "rigid": true,
+                "holster": true,
+                "max_contains_volume": "20 L",
+                "max_contains_weight": "1000 kg",
+                "item_restriction": [
+                    "medium_battery_cell",
+                    "medium_plus_battery_cell",
+                    "medium_atomic_battery_cell",
+                    "medium_disposable_cell"
+                ],
+                "max_item_length": "1 km"
+            }
+        ]
+    },
+    {
+        "type": "TOOL",
+        "id": "gasoline_cooker",
+        "copy-from": "gasoline_cooker",
+        "name": {
+            "str": "gasoline cooker"
+        },
+        "pocket_data": [
+            {
+                "pocket_type": "MAGAZINE",
+                "ammo_restriction": {
+                    "gasoline": 500
+                },
+                "watertight": true,
+                "rigid": true,
+                "max_contains_weight": "1000 kg",
+                "max_item_length": "1 km"
+            }
+        ]
+    },
+    {
+        "type": "TOOL",
+        "id": "hobo_stove",
+        "copy-from": "hobo_stove",
+        "name": {
+            "str": "hobo stove"
+        },
+        "pocket_data": [
+            {
+                "pocket_type": "MAGAZINE",
+                "ammo_restriction": {
+                    "tinder": 100
+                },
+                "max_contains_weight": "1000 kg",
+                "max_item_length": "1 km"
+            }
+        ]
+    },
+    {
+        "type": "TOOL",
+        "id": "hotplate",
+        "copy-from": "hotplate",
+        "name": {
+            "str": "hotplate"
+        },
+        "pocket_data": [
+            {
+                "pocket_type": "MAGAZINE_WELL",
+                "rigid": true,
+                "holster": true,
+                "max_contains_volume": "20 L",
+                "max_contains_weight": "1000 kg",
+                "item_restriction": [
+                    "medium_battery_cell",
+                    "medium_plus_battery_cell",
+                    "medium_atomic_battery_cell",
+                    "medium_disposable_cell"
+                ],
+                "max_item_length": "1 km"
+            }
+        ]
+    },
+    {
+        "type": "TOOL",
+        "id": "makeshift_sealer",
+        "copy-from": "makeshift_sealer",
+        "name": {
+            "str": "makeshift vacuum sealer"
+        },
+        "pocket_data": [
+            {
+                "pocket_type": "MAGAZINE_WELL",
+                "rigid": true,
+                "holster": true,
+                "max_contains_volume": "20 L",
+                "max_contains_weight": "1000 kg",
+                "item_restriction": [
+                    "medium_battery_cell",
+                    "medium_plus_battery_cell",
+                    "medium_atomic_battery_cell",
+                    "medium_disposable_cell"
+                ],
+                "max_item_length": "1 km"
+            }
+        ]
+    },
+    {
+        "type": "TOOL",
+        "id": "mess_kit",
+        "copy-from": "mess_kit",
+        "name": {
+            "str": "mess kit"
+        },
+        "pocket_data": [
+            {
+                "pocket_type": "MAGAZINE_WELL",
+                "rigid": true,
+                "holster": true,
+                "max_contains_volume": "20 L",
+                "max_contains_weight": "1000 kg",
+                "item_restriction": [
+                    "medium_battery_cell",
+                    "medium_plus_battery_cell",
+                    "medium_atomic_battery_cell",
+                    "medium_disposable_cell"
+                ],
+                "max_item_length": "1 km"
+            }
+        ]
+    },
+    {
+        "type": "TOOL",
+        "id": "mil_mess_kit",
+        "copy-from": "mil_mess_kit",
+        "name": {
+            "str": "military mess kit"
+        },
+        "pocket_data": [
+            {
+                "pocket_type": "MAGAZINE_WELL",
+                "rigid": true,
+                "holster": true,
+                "max_contains_volume": "20 L",
+                "max_contains_weight": "1000 kg",
+                "item_restriction": [
+                    "medium_plus_battery_cell",
+                    "medium_battery_cell",
+                    "medium_atomic_battery_cell",
+                    "medium_disposable_cell"
+                ],
+                "max_item_length": "1 km"
+            }
+        ]
+    },
+    {
+        "type": "TOOL",
+        "id": "multi_cooker",
+        "copy-from": "multi_cooker",
+        "name": {
+            "str": "multi cooker"
+        },
+        "pocket_data": [
+            {
+                "pocket_type": "MAGAZINE_WELL",
+                "rigid": true,
+                "holster": true,
+                "max_contains_volume": "20 L",
+                "max_contains_weight": "1000 kg",
+                "item_restriction": [
+                    "medium_battery_cell",
+                    "medium_plus_battery_cell",
+                    "medium_atomic_battery_cell",
+                    "medium_disposable_cell"
+                ],
+                "max_item_length": "1 km"
+            },
+            {
+                "pocket_type": "CONTAINER",
+                "watertight": true,
+                "rigid": true,
+                "max_contains_volume": "2 L",
+                "max_contains_weight": "1000 kg",
+                "max_item_length": "1 km",
+                "moves": 50
+            }
+        ]
+    },
+    {
+        "type": "TOOL",
+        "id": "oil_cooker",
+        "copy-from": "oil_cooker",
+        "name": {
+            "str": "lamp oil cooker"
+        },
+        "pocket_data": [
+            {
+                "pocket_type": "MAGAZINE",
+                "ammo_restriction": {
+                    "lamp_oil": 800
+                },
+                "watertight": true,
+                "rigid": true,
+                "max_contains_weight": "1000 kg",
+                "max_item_length": "1 km"
+            }
+        ]
+    },
+    {
+        "type": "TOOL",
+        "id": "popcan_stove",
+        "copy-from": "popcan_stove",
+        "name": {
+            "str": "soda can stove kit"
+        },
+        "pocket_data": [
+            {
+                "pocket_type": "MAGAZINE",
+                "ammo_restriction": {
+                    "conc_alcohol": 500
+                },
+                "watertight": true,
+                "rigid": true,
+                "max_contains_weight": "1000 kg",
+                "max_item_length": "1 km"
+            }
+        ]
+    },
+    {
+        "type": "GENERIC",
+        "id": "pressure_cooker",
+        "copy-from": "pressure_cooker",
+        "name": {
+            "str": "pressure cooker"
+        },
+        "pocket_data": [
+            {
+                "max_contains_volume": "2 L",
+                "max_contains_weight": "1000 kg",
+                "watertight": true,
+                "rigid": true,
+                "max_item_length": "1 km"
+            }
+        ]
+    },
+    {
+        "type": "TOOL",
+        "id": "survivor_mess_kit",
+        "copy-from": "survivor_mess_kit",
+        "name": {
+            "str": "survivor mess kit"
+        },
+        "pocket_data": [
+            {
+                "pocket_type": "MAGAZINE",
+                "ammo_restriction": {
+                    "lamp_oil": 800
+                },
+                "watertight": true,
+                "rigid": true,
+                "max_contains_weight": "1000 kg",
+                "max_item_length": "1 km"
+            }
+        ]
+    },
+    {
+        "type": "GENERIC",
+        "id": "teapot",
+        "copy-from": "teapot",
+        "name": {
+            "str": "teapot"
+        },
+        "pocket_data": [
+            {
+                "max_contains_volume": "500 ml",
+                "max_contains_weight": "1000 kg",
+                "watertight": true,
+                "rigid": true,
+                "max_item_length": "1 km"
+            }
+        ]
+    },
+    {
+        "type": "TOOL",
+        "id": "vac_sealer",
+        "copy-from": "vac_sealer",
+        "name": {
+            "str": "vacuum sealer"
+        },
+        "pocket_data": [
+            {
+                "pocket_type": "MAGAZINE_WELL",
+                "rigid": true,
+                "holster": true,
+                "max_contains_volume": "20 L",
+                "max_contains_weight": "1000 kg",
+                "item_restriction": [
+                    "medium_battery_cell",
+                    "medium_plus_battery_cell",
+                    "medium_atomic_battery_cell",
+                    "medium_disposable_cell"
+                ],
+                "max_item_length": "1 km"
+            }
+        ]
+    },
+    {
+        "type": "TOOL",
+        "id": "water_purifier",
+        "copy-from": "water_purifier",
+        "name": {
+            "str": "water purifier"
+        },
+        "pocket_data": [
+            {
+                "pocket_type": "MAGAZINE_WELL",
+                "rigid": true,
+                "holster": true,
+                "max_contains_volume": "20 L",
+                "max_contains_weight": "1000 kg",
+                "item_restriction": [
+                    "light_battery_cell",
+                    "light_plus_battery_cell",
+                    "light_minus_battery_cell",
+                    "light_atomic_battery_cell",
+                    "light_minus_atomic_battery_cell",
+                    "light_minus_disposable_cell",
+                    "light_disposable_cell"
+                ],
+                "max_item_length": "1 km"
+            }
+        ]
+    }
+]

--- a/Kenan-Modpack/easy_containers/items/tool/electronics.json
+++ b/Kenan-Modpack/easy_containers/items/tool/electronics.json
@@ -1,0 +1,371 @@
+[
+    {
+        "type": "TOOL",
+        "id": "adv_UPS_off",
+        "copy-from": "adv_UPS_off",
+        "name": {
+            "str": "advanced UPS",
+            "str_pl": "advanced UPS's"
+        },
+        "pocket_data": [
+            {
+                "pocket_type": "MAGAZINE_WELL",
+                "holster": true,
+                "max_contains_volume": "20 L",
+                "max_contains_weight": "1000 kg",
+                "item_restriction": [
+                    "heavy_atomic_battery_cell"
+                ],
+                "max_item_length": "1 km"
+            }
+        ]
+    },
+    {
+        "type": "TOOL",
+        "id": "camera",
+        "copy-from": "camera",
+        "name": {
+            "str": "camera"
+        },
+        "pocket_data": [
+            {
+                "pocket_type": "MAGAZINE_WELL",
+                "rigid": true,
+                "holster": true,
+                "max_contains_volume": "20 L",
+                "max_contains_weight": "1000 kg",
+                "item_restriction": [
+                    "light_plus_battery_cell",
+                    "light_minus_battery_cell",
+                    "light_battery_cell",
+                    "light_atomic_battery_cell",
+                    "light_minus_atomic_battery_cell",
+                    "light_minus_disposable_cell",
+                    "light_disposable_cell"
+                ],
+                "max_item_length": "1 km"
+            }
+        ]
+    },
+    {
+        "type": "TOOL",
+        "id": "camera_pro",
+        "copy-from": "camera_pro",
+        "name": {
+            "str": "professional camera"
+        },
+        "pocket_data": [
+            {
+                "pocket_type": "MAGAZINE_WELL",
+                "rigid": true,
+                "holster": true,
+                "max_contains_volume": "20 L",
+                "max_contains_weight": "1000 kg",
+                "item_restriction": [
+                    "light_plus_battery_cell",
+                    "light_minus_battery_cell",
+                    "light_battery_cell",
+                    "light_atomic_battery_cell",
+                    "light_minus_atomic_battery_cell",
+                    "light_minus_disposable_cell",
+                    "light_disposable_cell"
+                ],
+                "max_item_length": "1 km"
+            }
+        ]
+    },
+    {
+        "type": "TOOL",
+        "id": "cell_phone",
+        "copy-from": "cell_phone",
+        "name": {
+            "str": "cellphone"
+        },
+        "pocket_data": [
+            {
+                "pocket_type": "MAGAZINE_WELL",
+                "rigid": true,
+                "holster": true,
+                "max_contains_volume": "20 L",
+                "max_contains_weight": "1000 kg",
+                "item_restriction": [
+                    "light_plus_battery_cell",
+                    "light_minus_battery_cell",
+                    "light_minus_disposable_cell",
+                    "light_battery_cell",
+                    "light_disposable_cell",
+                    "light_atomic_battery_cell",
+                    "light_minus_atomic_battery_cell"
+                ],
+                "max_item_length": "1 km"
+            }
+        ]
+    },
+    {
+        "type": "TOOL",
+        "id": "eink_tablet_pc",
+        "copy-from": "eink_tablet_pc",
+        "name": {
+            "str": "e-ink tablet PC"
+        },
+        "pocket_data": [
+            {
+                "pocket_type": "MAGAZINE_WELL",
+                "rigid": true,
+                "holster": true,
+                "max_contains_volume": "20 L",
+                "max_contains_weight": "1000 kg",
+                "item_restriction": [
+                    "light_plus_battery_cell",
+                    "light_battery_cell",
+                    "light_minus_battery_cell",
+                    "light_atomic_battery_cell",
+                    "light_minus_atomic_battery_cell",
+                    "light_minus_disposable_cell",
+                    "light_disposable_cell"
+                ],
+                "max_item_length": "1 km"
+            }
+        ]
+    },
+    {
+        "type": "TOOL",
+        "id": "electrohack",
+        "copy-from": "electrohack",
+        "name": {
+            "str": "electrohack"
+        },
+        "pocket_data": [
+            {
+                "pocket_type": "MAGAZINE_WELL",
+                "rigid": true,
+                "holster": true,
+                "max_contains_volume": "20 L",
+                "max_contains_weight": "1000 kg",
+                "item_restriction": [
+                    "light_battery_cell",
+                    "light_plus_battery_cell",
+                    "light_minus_battery_cell",
+                    "light_atomic_battery_cell",
+                    "light_minus_atomic_battery_cell",
+                    "light_minus_disposable_cell",
+                    "light_disposable_cell"
+                ],
+                "max_item_length": "1 km"
+            }
+        ]
+    },
+    {
+        "type": "TOOL",
+        "id": "geiger_off",
+        "copy-from": "geiger_off",
+        "name": {
+            "str": "geiger counter (off)",
+            "str_pl": "geiger counters (off)"
+        },
+        "pocket_data": [
+            {
+                "pocket_type": "MAGAZINE_WELL",
+                "rigid": true,
+                "holster": true,
+                "max_contains_volume": "20 L",
+                "max_contains_weight": "1000 kg",
+                "item_restriction": [
+                    "light_battery_cell",
+                    "light_plus_battery_cell",
+                    "light_minus_battery_cell",
+                    "light_atomic_battery_cell",
+                    "light_minus_atomic_battery_cell",
+                    "light_minus_disposable_cell",
+                    "light_disposable_cell"
+                ],
+                "max_item_length": "1 km"
+            }
+        ]
+    },
+    {
+        "type": "TOOL",
+        "id": "hand_crank_charger",
+        "copy-from": "hand_crank_charger",
+        "name": {
+            "str": "hand-crank charger"
+        },
+        "pocket_data": [
+            {
+                "pocket_type": "MAGAZINE_WELL",
+                "holster": true,
+                "magazine_well": "100 ml",
+                "max_contains_volume": "20 L",
+                "max_contains_weight": "1000 kg",
+                "item_restriction": [
+                    "light_battery_cell",
+                    "light_plus_battery_cell",
+                    "light_minus_battery_cell",
+                    "medium_battery_cell",
+                    "medium_plus_battery_cell",
+                    "heavy_battery_cell",
+                    "heavy_plus_battery_cell"
+                ],
+                "max_item_length": "1 km"
+            }
+        ]
+    },
+    {
+        "type": "TOOL",
+        "id": "laptop",
+        "copy-from": "laptop",
+        "name": {
+            "str": "laptop computer"
+        },
+        "pocket_data": [
+            {
+                "pocket_type": "MAGAZINE_WELL",
+                "rigid": true,
+                "holster": true,
+                "max_contains_volume": "20 L",
+                "max_contains_weight": "1000 kg",
+                "item_restriction": [
+                    "medium_battery_cell",
+                    "medium_plus_battery_cell",
+                    "medium_atomic_battery_cell",
+                    "medium_disposable_cell"
+                ],
+                "max_item_length": "1 km"
+            }
+        ]
+    },
+    {
+        "type": "TOOL",
+        "id": "mp3",
+        "copy-from": "mp3",
+        "name": {
+            "str": "mp3 player (off)",
+            "str_pl": "mp3 players (off)"
+        },
+        "pocket_data": [
+            {
+                "pocket_type": "MAGAZINE_WELL",
+                "rigid": true,
+                "holster": true,
+                "max_contains_volume": "20 L",
+                "max_contains_weight": "1000 kg",
+                "item_restriction": [
+                    "light_battery_cell",
+                    "light_plus_battery_cell",
+                    "light_minus_battery_cell",
+                    "light_atomic_battery_cell",
+                    "light_minus_atomic_battery_cell",
+                    "light_disposable_cell",
+                    "light_minus_disposable_cell"
+                ],
+                "max_item_length": "1 km"
+            }
+        ]
+    },
+    {
+        "type": "TOOL",
+        "id": "noise_emitter",
+        "copy-from": "noise_emitter",
+        "name": {
+            "str": "noise emitter (off)",
+            "str_pl": "noise emitters (off)"
+        },
+        "pocket_data": [
+            {
+                "pocket_type": "MAGAZINE_WELL",
+                "rigid": true,
+                "holster": true,
+                "max_contains_volume": "20 L",
+                "max_contains_weight": "1000 kg",
+                "item_restriction": [
+                    "light_battery_cell",
+                    "light_plus_battery_cell",
+                    "light_minus_battery_cell",
+                    "light_atomic_battery_cell",
+                    "light_minus_atomic_battery_cell",
+                    "light_minus_disposable_cell",
+                    "light_disposable_cell"
+                ],
+                "max_item_length": "1 km"
+            }
+        ]
+    },
+    {
+        "type": "TOOL",
+        "id": "portable_game",
+        "copy-from": "portable_game",
+        "name": {
+            "str": "handheld game system"
+        },
+        "pocket_data": [
+            {
+                "pocket_type": "MAGAZINE_WELL",
+                "rigid": true,
+                "holster": true,
+                "max_contains_volume": "20 L",
+                "max_contains_weight": "1000 kg",
+                "item_restriction": [
+                    "light_disposable_cell",
+                    "light_minus_disposable_cell",
+                    "light_battery_cell",
+                    "light_plus_battery_cell",
+                    "light_minus_battery_cell",
+                    "light_atomic_battery_cell",
+                    "light_minus_atomic_battery_cell"
+                ],
+                "max_item_length": "1 km"
+            }
+        ]
+    },
+    {
+        "type": "TOOL",
+        "id": "UPS_off",
+        "copy-from": "UPS_off",
+        "name": {
+            "str": "UPS",
+            "str_pl": "UPS's"
+        },
+        "pocket_data": [
+            {
+                "pocket_type": "MAGAZINE_WELL",
+                "holster": true,
+                "max_contains_volume": "20 L",
+                "max_contains_weight": "1000 kg",
+                "item_restriction": [
+                    "heavy_plus_battery_cell",
+                    "heavy_battery_cell",
+                    "heavy_atomic_battery_cell",
+                    "heavy_disposable_cell"
+                ],
+                "max_item_length": "1 km"
+            }
+        ]
+    },
+    {
+        "type": "TOOL",
+        "id": "vibrator",
+        "copy-from": "vibrator",
+        "name": {
+            "str": "vibrator"
+        },
+        "pocket_data": [
+            {
+                "pocket_type": "MAGAZINE_WELL",
+                "rigid": true,
+                "holster": true,
+                "max_contains_volume": "20 L",
+                "max_contains_weight": "1000 kg",
+                "item_restriction": [
+                    "light_battery_cell",
+                    "light_plus_battery_cell",
+                    "light_minus_battery_cell",
+                    "light_atomic_battery_cell",
+                    "light_minus_atomic_battery_cell",
+                    "light_minus_disposable_cell",
+                    "light_disposable_cell"
+                ],
+                "max_item_length": "1 km"
+            }
+        ]
+    }
+]

--- a/Kenan-Modpack/easy_containers/items/tool/fire.json
+++ b/Kenan-Modpack/easy_containers/items/tool/fire.json
@@ -1,0 +1,151 @@
+[
+    {
+        "type": "TOOL",
+        "id": "crude_firestarter",
+        "copy-from": "crude_firestarter",
+        "name": {
+            "str": "electric firestarter"
+        },
+        "pocket_data": [
+            {
+                "pocket_type": "MAGAZINE_WELL",
+                "rigid": true,
+                "holster": true,
+                "max_contains_volume": "20 L",
+                "max_contains_weight": "1000 kg",
+                "item_restriction": [
+                    "light_battery_cell",
+                    "light_minus_battery_cell",
+                    "light_plus_battery_cell",
+                    "light_atomic_battery_cell",
+                    "light_minus_atomic_battery_cell",
+                    "light_minus_disposable_cell",
+                    "light_disposable_cell"
+                ],
+                "max_item_length": "1 km"
+            }
+        ]
+    },
+    {
+        "type": "TOOL",
+        "id": "lighter",
+        "copy-from": "lighter",
+        "name": {
+            "str": "lighter"
+        },
+        "pocket_data": [
+            {
+                "pocket_type": "MAGAZINE",
+                "rigid": true,
+                "airtight": true,
+                "ammo_restriction": {
+                    "butane": 100
+                },
+                "watertight": true,
+                "max_contains_weight": "1000 kg",
+                "max_item_length": "1 km"
+            }
+        ]
+    },
+    {
+        "type": "TOOL",
+        "id": "matches",
+        "copy-from": "matches",
+        "name": {
+            "str": "matchbook"
+        },
+        "pocket_data": [
+            {
+                "pocket_type": "MAGAZINE",
+                "rigid": true,
+                "holster": true,
+                "ammo_restriction": {
+                    "match": 20
+                },
+                "max_contains_weight": "1000 kg",
+                "max_item_length": "1 km"
+            }
+        ]
+    },
+    {
+        "type": "TOOL",
+        "id": "ref_lighter",
+        "copy-from": "ref_lighter",
+        "name": {
+            "str": "refillable lighter"
+        },
+        "pocket_data": [
+            {
+                "pocket_type": "MAGAZINE",
+                "rigid": true,
+                "airtight": true,
+                "ammo_restriction": {
+                    "gasoline": 50
+                },
+                "watertight": true,
+                "max_contains_weight": "1000 kg",
+                "max_item_length": "1 km"
+            }
+        ]
+    },
+    {
+        "type": "TOOL",
+        "id": "ref_lighter_on",
+        "copy-from": "ref_lighter_on",
+        "name": {
+            "str": "refillable lighter"
+        },
+        "pocket_data": [
+            {
+                "pocket_type": "MAGAZINE",
+                "rigid": true,
+                "airtight": true,
+                "ammo_restriction": {
+                    "gasoline": 50
+                },
+                "watertight": true,
+                "max_contains_weight": "1000 kg",
+                "max_item_length": "1 km"
+            }
+        ]
+    },
+    {
+        "type": "TOOL",
+        "id": "tinderbox",
+        "copy-from": "tinderbox",
+        "name": {
+            "str": "ember carrier"
+        },
+        "pocket_data": [
+            {
+                "pocket_type": "MAGAZINE",
+                "rigid": true,
+                "ammo_restriction": {
+                    "tinder": 100
+                },
+                "max_contains_weight": "1000 kg",
+                "max_item_length": "1 km"
+            }
+        ]
+    },
+    {
+        "type": "TOOL",
+        "id": "tinderbox_on",
+        "copy-from": "tinderbox_on",
+        "name": {
+            "str": "ember carrier (lit)",
+            "str_pl": "ember carriers (lit)"
+        },
+        "pocket_data": [
+            {
+                "pocket_type": "MAGAZINE",
+                "rigid": true,
+                "ammo_restriction": {
+                    "tinder": 100
+                },
+                "max_contains_weight": "1000 kg",
+                "max_item_length": "1 km"
+            }
+        ]
+    }
+]

--- a/Kenan-Modpack/easy_containers/items/tool/firefighting.json
+++ b/Kenan-Modpack/easy_containers/items/tool/firefighting.json
@@ -1,0 +1,64 @@
+[
+    {
+        "type": "TOOL",
+        "id": "extinguisher",
+        "copy-from": "extinguisher",
+        "name": {
+            "str": "large fire extinguisher"
+        },
+        "pocket_data": [
+            {
+                "pocket_type": "MAGAZINE",
+                "airtight": true,
+                "watertight": true,
+                "rigid": true,
+                "ammo_restriction": {
+                    "extinguishing_agent": 100
+                },
+                "max_contains_weight": "1000 kg",
+                "max_item_length": "1 km"
+            }
+        ]
+    },
+    {
+        "type": "TOOL",
+        "id": "fire_ax",
+        "copy-from": "fire_ax",
+        "name": {
+            "str": "fire axe"
+        },
+        "pocket_data": [
+            {
+                "max_contains_volume": "550 ml",
+                "max_contains_weight": "1000 kg",
+                "max_item_length": "1 km",
+                "moves": 150,
+                "item_restriction": [
+                    "halligan"
+                ],
+                "holster": true
+            }
+        ]
+    },
+    {
+        "type": "TOOL",
+        "id": "sm_extinguisher",
+        "copy-from": "sm_extinguisher",
+        "name": {
+            "str": "small fire extinguisher"
+        },
+        "pocket_data": [
+            {
+                "pocket_type": "MAGAZINE",
+                "airtight": true,
+                "watertight": true,
+                "rigid": true,
+                "ammo_restriction": {
+                    "extinguishing_agent": 10
+                },
+                "max_contains_weight": "1000 kg",
+                "max_item_length": "1 km"
+            }
+        ]
+    }
+]

--- a/Kenan-Modpack/easy_containers/items/tool/fishing.json
+++ b/Kenan-Modpack/easy_containers/items/tool/fishing.json
@@ -1,0 +1,20 @@
+[
+    {
+        "type": "TOOL",
+        "id": "fish_trap",
+        "copy-from": "fish_trap",
+        "name": {
+            "str": "plastic fish trap"
+        },
+        "pocket_data": [
+            {
+                "pocket_type": "MAGAZINE",
+                "ammo_restriction": {
+                    "fish_bait": 5
+                },
+                "max_contains_weight": "1000 kg",
+                "max_item_length": "1 km"
+            }
+        ]
+    }
+]

--- a/Kenan-Modpack/easy_containers/items/tool/lighting.json
+++ b/Kenan-Modpack/easy_containers/items/tool/lighting.json
@@ -1,0 +1,303 @@
+[
+    {
+        "type": "TOOL",
+        "id": "candle",
+        "copy-from": "candle",
+        "name": {
+            "str": "candle"
+        },
+        "pocket_data": [
+            {
+                "pocket_type": "MAGAZINE",
+                "ammo_restriction": {
+                    "candle_wax": 100
+                },
+                "rigid": true,
+                "max_contains_weight": "1000 kg",
+                "max_item_length": "1 km"
+            }
+        ]
+    },
+    {
+        "type": "TOOL",
+        "id": "electric_lantern",
+        "copy-from": "electric_lantern",
+        "name": {
+            "str": "electric lantern (off)",
+            "str_pl": "electric lanterns (off)"
+        },
+        "pocket_data": [
+            {
+                "pocket_type": "MAGAZINE_WELL",
+                "rigid": true,
+                "holster": true,
+                "max_contains_volume": "20 L",
+                "max_contains_weight": "1000 kg",
+                "item_restriction": [
+                    "light_minus_battery_cell",
+                    "light_minus_disposable_cell",
+                    "light_minus_atomic_battery_cell",
+                    "light_battery_cell",
+                    "light_disposable_cell",
+                    "light_plus_battery_cell",
+                    "light_atomic_battery_cell"
+                ],
+                "max_item_length": "1 km"
+            }
+        ]
+    },
+    {
+        "type": "TOOL",
+        "id": "flashlight",
+        "copy-from": "flashlight",
+        "name": {
+            "str": "flashlight (off)",
+            "str_pl": "flashlights (off)"
+        },
+        "pocket_data": [
+            {
+                "pocket_type": "MAGAZINE_WELL",
+                "holster": true,
+                "rigid": true,
+                "max_contains_volume": "20 L",
+                "max_contains_weight": "1000 kg",
+                "item_restriction": [
+                    "light_disposable_cell",
+                    "light_minus_disposable_cell",
+                    "light_battery_cell",
+                    "light_plus_battery_cell",
+                    "light_minus_battery_cell",
+                    "light_atomic_battery_cell",
+                    "light_minus_atomic_battery_cell"
+                ],
+                "max_item_length": "1 km"
+            }
+        ]
+    },
+    {
+        "type": "TOOL",
+        "id": "gasoline_lantern",
+        "copy-from": "gasoline_lantern",
+        "name": {
+            "str": "gasoline lantern (off)",
+            "str_pl": "gasoline lanterns (off)"
+        },
+        "pocket_data": [
+            {
+                "pocket_type": "MAGAZINE",
+                "watertight": true,
+                "ammo_restriction": {
+                    "gasoline": 500
+                },
+                "max_contains_weight": "1000 kg",
+                "max_item_length": "1 km"
+            }
+        ]
+    },
+    {
+        "type": "TOOL",
+        "id": "glowstick",
+        "copy-from": "glowstick",
+        "name": {
+            "str": "glowstick"
+        },
+        "pocket_data": [
+            {
+                "pocket_type": "MAGAZINE",
+                "ammo_restriction": {
+                    "glowstick_juice": 1400
+                },
+                "rigid": true,
+                "max_contains_weight": "1000 kg",
+                "max_item_length": "1 km"
+            }
+        ]
+    },
+    {
+        "type": "TOOL",
+        "id": "glowstick_lit",
+        "copy-from": "glowstick_lit",
+        "name": {
+            "str": "active glowstick"
+        },
+        "pocket_data": [
+            {
+                "pocket_type": "MAGAZINE",
+                "ammo_restriction": {
+                    "glowstick_juice": 1400
+                },
+                "rigid": true,
+                "max_contains_weight": "1000 kg",
+                "max_item_length": "1 km"
+            }
+        ]
+    },
+    {
+        "type": "TOOL",
+        "id": "handflare",
+        "copy-from": "handflare",
+        "name": {
+            "str": "flare"
+        },
+        "pocket_data": [
+            {
+                "pocket_type": "MAGAZINE",
+                "ammo_restriction": {
+                    "flare_nitrate": 300
+                },
+                "rigid": true,
+                "max_contains_weight": "1000 kg",
+                "max_item_length": "1 km"
+            }
+        ]
+    },
+    {
+        "type": "TOOL",
+        "id": "heavy_flashlight",
+        "copy-from": "heavy_flashlight",
+        "name": {
+            "str": "heavy duty flashlight (off)",
+            "str_pl": "heavy duty flashlights (off)"
+        },
+        "pocket_data": [
+            {
+                "pocket_type": "MAGAZINE_WELL",
+                "holster": true,
+                "rigid": true,
+                "max_contains_volume": "20 L",
+                "max_contains_weight": "1000 kg",
+                "item_restriction": [
+                    "light_disposable_cell",
+                    "light_minus_disposable_cell",
+                    "light_plus_battery_cell",
+                    "light_battery_cell",
+                    "light_minus_battery_cell",
+                    "light_atomic_battery_cell",
+                    "light_minus_atomic_battery_cell"
+                ],
+                "max_item_length": "1 km"
+            }
+        ]
+    },
+    {
+        "type": "TOOL",
+        "id": "lightstrip_inactive",
+        "copy-from": "lightstrip_inactive",
+        "name": {
+            "str": "lightstrip (inactive)",
+            "str_pl": "lightstrips (inactive)"
+        },
+        "pocket_data": [
+            {
+                "pocket_type": "MAGAZINE_WELL",
+                "rigid": true,
+                "holster": true,
+                "max_contains_volume": "20 L",
+                "max_contains_weight": "1000 kg",
+                "item_restriction": [
+                    "light_battery_cell",
+                    "light_plus_battery_cell",
+                    "light_minus_battery_cell",
+                    "light_atomic_battery_cell",
+                    "light_minus_atomic_battery_cell",
+                    "light_minus_disposable_cell",
+                    "light_disposable_cell"
+                ],
+                "max_item_length": "1 km"
+            }
+        ]
+    },
+    {
+        "type": "TOOL",
+        "id": "oil_lamp",
+        "copy-from": "oil_lamp",
+        "name": {
+            "str": "oil lamp (off)",
+            "str_pl": "oil lamps (off)"
+        },
+        "pocket_data": [
+            {
+                "pocket_type": "MAGAZINE",
+                "watertight": true,
+                "ammo_restriction": {
+                    "lamp_oil": 750
+                },
+                "max_contains_weight": "1000 kg",
+                "max_item_length": "1 km"
+            }
+        ]
+    },
+    {
+        "type": "TOOL",
+        "id": "oxylamp",
+        "copy-from": "oxylamp",
+        "name": {
+            "str": "acetylene lamp (off)",
+            "str_pl": "acetylene lamps (off)"
+        },
+        "pocket_data": [
+            {
+                "pocket_type": "MAGAZINE_WELL",
+                "holster": true,
+                "max_contains_volume": "20 L",
+                "max_contains_weight": "1000 kg",
+                "item_restriction": [
+                    "weldtank",
+                    "tinyweldtank"
+                ],
+                "max_item_length": "1 km"
+            }
+        ]
+    },
+    {
+        "type": "TOOL",
+        "id": "reading_light",
+        "copy-from": "reading_light",
+        "name": {
+            "str": "reading light"
+        },
+        "pocket_data": [
+            {
+                "pocket_type": "MAGAZINE_WELL",
+                "rigid": true,
+                "holster": true,
+                "max_contains_volume": "20 L",
+                "max_contains_weight": "1000 kg",
+                "item_restriction": [
+                    "light_minus_disposable_cell",
+                    "light_minus_battery_cell",
+                    "light_minus_atomic_battery_cell"
+                ],
+                "max_item_length": "1 km"
+            }
+        ]
+    },
+    {
+        "type": "TOOL",
+        "id": "smart_lamp",
+        "copy-from": "smart_lamp",
+        "name": {
+            "str": "smart lamp (off)",
+            "str_pl": "smart lamps (off)"
+        },
+        "pocket_data": [
+            {
+                "pocket_type": "MAGAZINE_WELL",
+                "rigid": true,
+                "holster": true,
+                "max_contains_volume": "20 L",
+                "max_contains_weight": "1000 kg",
+                "item_restriction": [
+                    "light_battery_cell",
+                    "light_plus_battery_cell",
+                    "light_minus_battery_cell",
+                    "light_atomic_battery_cell",
+                    "light_minus_atomic_battery_cell",
+                    "light_minus_disposable_cell",
+                    "light_disposable_cell"
+                ],
+                "max_item_length": "1 km"
+            }
+        ]
+    }
+]

--- a/Kenan-Modpack/easy_containers/items/tool/med.json
+++ b/Kenan-Modpack/easy_containers/items/tool/med.json
@@ -1,0 +1,154 @@
+[
+    {
+        "type": "TOOL",
+        "id": "anesthetic_kit",
+        "copy-from": "anesthetic_kit",
+        "name": {
+            "str": "anesthesia kit"
+        },
+        "pocket_data": [
+            {
+                "watertight": true,
+                "rigid": true,
+                "pocket_type": "MAGAZINE",
+                "ammo_restriction": {
+                    "anesthetic": 6000
+                },
+                "max_contains_weight": "1000 kg",
+                "max_item_length": "1 km"
+            }
+        ]
+    },
+    {
+        "type": "TOOL",
+        "id": "autoclave",
+        "copy-from": "autoclave",
+        "name": {
+            "str": "autoclave"
+        },
+        "pocket_data": [
+            {
+                "pocket_type": "MAGAZINE_WELL",
+                "holster": true,
+                "max_contains_volume": "20 L",
+                "max_contains_weight": "1000 kg",
+                "item_restriction": [
+                    "heavy_plus_battery_cell",
+                    "heavy_battery_cell",
+                    "heavy_atomic_battery_cell",
+                    "heavy_disposable_cell"
+                ],
+                "max_item_length": "1 km"
+            },
+            {
+                "pocket_type": "CONTAINER",
+                "holster": true,
+                "max_contains_volume": "20 L",
+                "max_contains_weight": "1000 kg",
+                "flag_restriction": [
+                    "CBM"
+                ],
+                "max_item_length": "1 km"
+            }
+        ]
+    },
+    {
+        "type": "TOOL",
+        "id": "inhaler",
+        "copy-from": "inhaler",
+        "name": {
+            "str": "inhaler"
+        },
+        "pocket_data": [
+            {
+                "pocket_type": "MAGAZINE",
+                "airtight": true,
+                "rigid": true,
+                "watertight": true,
+                "ammo_restriction": {
+                    "albuterol": 100
+                },
+                "max_contains_weight": "1000 kg",
+                "max_item_length": "1 km"
+            }
+        ]
+    },
+    {
+        "type": "TOOL",
+        "id": "rx12_injector",
+        "copy-from": "rx12_injector",
+        "name": {
+            "str": "RX12 jet injector"
+        },
+        "pocket_data": [
+            {
+                "pocket_type": "MAGAZINE",
+                "ammo_restriction": {
+                    "ampoule": 2
+                },
+                "max_contains_weight": "1000 kg",
+                "max_item_length": "1 km"
+            }
+        ]
+    },
+    {
+        "type": "TOOL",
+        "id": "smoxygen_tank",
+        "copy-from": "smoxygen_tank",
+        "name": {
+            "str": "emergency oxygen pack"
+        },
+        "pocket_data": [
+            {
+                "pocket_type": "MAGAZINE",
+                "airtight": true,
+                "watertight": true,
+                "rigid": true,
+                "ammo_restriction": {
+                    "oxygen": 12
+                },
+                "max_contains_weight": "1000 kg",
+                "max_item_length": "1 km"
+            }
+        ]
+    },
+    {
+        "type": "TOOL",
+        "id": "oxygen_tank",
+        "copy-from": "oxygen_tank",
+        "name": {
+            "str": "oxygen tank"
+        },
+        "pocket_data": [
+            {
+                "pocket_type": "MAGAZINE",
+                "airtight": true,
+                "watertight": true,
+                "rigid": true,
+                "ammo_restriction": {
+                    "oxygen": 24
+                },
+                "max_contains_weight": "1000 kg",
+                "max_item_length": "1 km"
+            }
+        ]
+    },
+    {
+        "type": "GENERIC",
+        "id": "vacutainer",
+        "copy-from": "vacutainer",
+        "name": {
+            "str": "blood draw kit"
+        },
+        "pocket_data": [
+            {
+                "pocket_type": "CONTAINER",
+                "watertight": true,
+                "rigid": true,
+                "max_contains_volume": "250 ml",
+                "max_contains_weight": "1000 kg",
+                "max_item_length": "1 km"
+            }
+        ]
+    }
+]

--- a/Kenan-Modpack/easy_containers/items/tool/metalworking.json
+++ b/Kenan-Modpack/easy_containers/items/tool/metalworking.json
@@ -1,0 +1,61 @@
+[
+    {
+        "type": "TOOL",
+        "id": "char_forge",
+        "copy-from": "char_forge",
+        "name": {
+            "str": "charcoal forge"
+        },
+        "pocket_data": [
+            {
+                "pocket_type": "MAGAZINE",
+                "ammo_restriction": {
+                    "charcoal": 500
+                },
+                "max_contains_weight": "1000 kg",
+                "max_item_length": "1 km"
+            }
+        ]
+    },
+    {
+        "type": "TOOL",
+        "id": "rock_forge_pseudo",
+        "copy-from": "rock_forge_pseudo",
+        "name": {
+            "str": "rock forge"
+        },
+        "pocket_data": [
+            {
+                "pocket_type": "MAGAZINE",
+                "ammo_restriction": {
+                    "charcoal": 40000
+                },
+                "max_contains_weight": "1000 kg",
+                "max_item_length": "1 km"
+            }
+        ]
+    },
+    {
+        "type": "TOOL",
+        "id": "forge",
+        "copy-from": "forge",
+        "name": {
+            "str": "electric forge"
+        },
+        "pocket_data": [
+            {
+                "pocket_type": "MAGAZINE_WELL",
+                "holster": true,
+                "max_contains_volume": "20 L",
+                "max_contains_weight": "1000 kg",
+                "item_restriction": [
+                    "heavy_battery_cell",
+                    "heavy_plus_battery_cell",
+                    "heavy_atomic_battery_cell",
+                    "heavy_disposable_cell"
+                ],
+                "max_item_length": "1 km"
+            }
+        ]
+    }
+]

--- a/Kenan-Modpack/easy_containers/items/tool/misc.json
+++ b/Kenan-Modpack/easy_containers/items/tool/misc.json
@@ -1,0 +1,179 @@
+[
+    {
+        "type": "TOOL",
+        "id": "butane_can",
+        "copy-from": "butane_can",
+        "name": {
+            "str": "can of butane",
+            "str_pl": "cans of butane"
+        },
+        "pocket_data": [
+            {
+                "pocket_type": "MAGAZINE",
+                "ammo_restriction": {
+                    "butane": 30
+                },
+                "watertight": true,
+                "rigid": true,
+                "max_contains_weight": "1000 kg",
+                "max_item_length": "1 km"
+            }
+        ]
+    },
+    {
+        "type": "TOOL",
+        "id": "dab_pen",
+        "copy-from": "dab_pen",
+        "name": {
+            "str": "dab pen"
+        },
+        "pocket_data": [
+            {
+                "pocket_type": "MAGAZINE_WELL",
+                "rigid": true,
+                "holster": true,
+                "max_contains_volume": "20 L",
+                "max_contains_weight": "1000 kg",
+                "item_restriction": [
+                    "light_minus_battery_cell",
+                    "light_minus_disposable_cell",
+                    "light_battery_cell",
+                    "light_disposable_cell"
+                ],
+                "max_item_length": "1 km"
+            }
+        ]
+    },
+    {
+        "type": "TOOL",
+        "id": "dab_pen_on",
+        "copy-from": "dab_pen_on",
+        "name": {
+            "str": "dab pen (on)",
+            "str_pl": "dab pens (on)"
+        },
+        "pocket_data": [
+            {
+                "pocket_type": "MAGAZINE_WELL",
+                "rigid": true,
+                "holster": true,
+                "max_contains_volume": "20 L",
+                "max_contains_weight": "1000 kg",
+                "item_restriction": [
+                    "light_minus_battery_cell",
+                    "light_minus_disposable_cell",
+                    "light_battery_cell",
+                    "light_disposable_cell"
+                ],
+                "max_item_length": "1 km"
+            }
+        ]
+    },
+    {
+        "type": "TOOL",
+        "id": "large_space_heater",
+        "copy-from": "large_space_heater",
+        "name": {
+            "str": "large space heater"
+        },
+        "pocket_data": [
+            {
+                "pocket_type": "MAGAZINE_WELL",
+                "holster": true,
+                "magazine_well": "2 L",
+                "max_contains_volume": "20 L",
+                "max_contains_weight": "1000 kg",
+                "item_restriction": [
+                    "heavy_battery_cell",
+                    "heavy_plus_battery_cell",
+                    "heavy_atomic_battery_cell",
+                    "heavy_disposable_cell"
+                ],
+                "max_item_length": "1 km"
+            }
+        ]
+    },
+    {
+        "type": "TOOL",
+        "id": "permanent_marker",
+        "copy-from": "permanent_marker",
+        "name": {
+            "str": "permanent marker"
+        },
+        "pocket_data": [
+            {
+                "pocket_type": "MAGAZINE",
+                "ammo_restriction": {
+                    "permanent_ink": 500
+                },
+                "watertight": true,
+                "rigid": true,
+                "max_contains_weight": "1000 kg",
+                "max_item_length": "1 km"
+            }
+        ]
+    },
+    {
+        "type": "TOOL",
+        "id": "small_space_heater",
+        "copy-from": "small_space_heater",
+        "name": {
+            "str": "small space heater"
+        },
+        "pocket_data": [
+            {
+                "pocket_type": "MAGAZINE_WELL",
+                "holster": true,
+                "rigid": true,
+                "max_contains_volume": "20 L",
+                "max_contains_weight": "1000 kg",
+                "item_restriction": [
+                    "medium_battery_cell",
+                    "medium_plus_battery_cell",
+                    "medium_atomic_battery_cell",
+                    "medium_disposable_cell"
+                ],
+                "max_item_length": "1 km"
+            }
+        ]
+    },
+    {
+        "type": "TOOL",
+        "id": "spray_can",
+        "copy-from": "spray_can",
+        "name": {
+            "str": "spray can"
+        },
+        "pocket_data": [
+            {
+                "pocket_type": "MAGAZINE",
+                "ammo_restriction": {
+                    "aerosol_paint": 10
+                },
+                "watertight": true,
+                "rigid": true,
+                "max_contains_weight": "1000 kg",
+                "max_item_length": "1 km"
+            }
+        ]
+    },
+    {
+        "type": "TOOL",
+        "id": "sandbox_kit",
+        "copy-from": "sandbox_kit",
+        "name": {
+            "str": "sandbox kit"
+        },
+        "pocket_data": [
+            {
+                "pocket_type": "CONTAINER",
+                "rigid": true,
+                "watertight": true,
+                "open_container": true,
+                "max_contains_volume": "1 L",
+                "max_contains_weight": "1000 kg",
+                "max_item_length": "1 km"
+            }
+        ]
+    }
+]

--- a/Kenan-Modpack/easy_containers/items/tool/pets.json
+++ b/Kenan-Modpack/easy_containers/items/tool/pets.json
@@ -1,0 +1,25 @@
+[
+    {
+        "type": "TOOL",
+        "id": "elec_shears",
+        "copy-from": "elec_shears",
+        "name": {
+            "str_sp": "electric shears"
+        },
+        "pocket_data": [
+            {
+                "pocket_type": "MAGAZINE_WELL",
+                "holster": true,
+                "max_contains_volume": "20 L",
+                "max_contains_weight": "1000 kg",
+                "item_restriction": [
+                    "light_minus_battery_cell",
+                    "light_minus_disposable_cell",
+                    "light_battery_cell",
+                    "light_disposable_cell"
+                ],
+                "max_item_length": "1 km"
+            }
+        ]
+    }
+]

--- a/Kenan-Modpack/easy_containers/items/tool/radio_tools.json
+++ b/Kenan-Modpack/easy_containers/items/tool/radio_tools.json
@@ -1,0 +1,144 @@
+[
+    {
+        "type": "TOOL",
+        "id": "radiocontrol",
+        "copy-from": "radiocontrol",
+        "name": {
+            "str": "RC control"
+        },
+        "pocket_data": [
+            {
+                "pocket_type": "MAGAZINE_WELL",
+                "rigid": true,
+                "holster": true,
+                "max_contains_volume": "20 L",
+                "max_contains_weight": "1000 kg",
+                "item_restriction": [
+                    "light_disposable_cell",
+                    "light_minus_disposable_cell",
+                    "light_battery_cell",
+                    "light_plus_battery_cell",
+                    "light_minus_battery_cell",
+                    "light_atomic_battery_cell",
+                    "light_minus_atomic_battery_cell"
+                ],
+                "max_item_length": "1 km"
+            }
+        ]
+    },
+    {
+        "type": "TOOL",
+        "id": "radio_car",
+        "copy-from": "radio_car",
+        "name": {
+            "str": "RC car"
+        },
+        "pocket_data": [
+            {
+                "pocket_type": "CONTAINER",
+                "rigid": true,
+                "max_contains_volume": "1250 ml",
+                "max_contains_weight": "1000 kg",
+                "flag_restriction": [
+                    "RADIOCARITEM"
+                ],
+                "max_item_length": "1 km"
+            },
+            {
+                "pocket_type": "MAGAZINE_WELL",
+                "rigid": true,
+                "holster": true,
+                "max_contains_volume": "20 L",
+                "max_contains_weight": "1000 kg",
+                "item_restriction": [
+                    "light_minus_disposable_cell",
+                    "light_minus_battery_cell",
+                    "light_minus_atomic_battery_cell"
+                ],
+                "max_item_length": "1 km"
+            }
+        ]
+    },
+    {
+        "type": "TOOL",
+        "id": "radio",
+        "copy-from": "radio",
+        "name": {
+            "str": "radio (off)",
+            "str_pl": "radios (off)"
+        },
+        "pocket_data": [
+            {
+                "pocket_type": "MAGAZINE_WELL",
+                "rigid": true,
+                "holster": true,
+                "max_contains_volume": "20 L",
+                "max_contains_weight": "1000 kg",
+                "item_restriction": [
+                    "light_disposable_cell",
+                    "light_minus_disposable_cell",
+                    "light_battery_cell",
+                    "light_plus_battery_cell",
+                    "light_minus_battery_cell",
+                    "light_atomic_battery_cell",
+                    "light_minus_atomic_battery_cell"
+                ],
+                "max_item_length": "1 km"
+            }
+        ]
+    },
+    {
+        "type": "TOOL",
+        "id": "two_way_radio",
+        "copy-from": "two_way_radio",
+        "name": {
+            "str": "two-way radio"
+        },
+        "pocket_data": [
+            {
+                "pocket_type": "MAGAZINE_WELL",
+                "rigid": true,
+                "holster": true,
+                "max_contains_volume": "20 L",
+                "max_contains_weight": "1000 kg",
+                "item_restriction": [
+                    "light_disposable_cell",
+                    "light_minus_disposable_cell",
+                    "light_battery_cell",
+                    "light_plus_battery_cell",
+                    "light_minus_battery_cell",
+                    "light_atomic_battery_cell",
+                    "light_minus_atomic_battery_cell"
+                ],
+                "max_item_length": "1 km"
+            }
+        ]
+    },
+    {
+        "type": "TOOL",
+        "id": "remotevehcontrol",
+        "copy-from": "remotevehcontrol",
+        "name": {
+            "str": "remote vehicle controller"
+        },
+        "pocket_data": [
+            {
+                "pocket_type": "MAGAZINE_WELL",
+                "rigid": true,
+                "holster": true,
+                "max_contains_volume": "20 L",
+                "max_contains_weight": "1000 kg",
+                "item_restriction": [
+                    "light_battery_cell",
+                    "light_plus_battery_cell",
+                    "light_minus_battery_cell",
+                    "light_atomic_battery_cell",
+                    "light_minus_atomic_battery_cell",
+                    "light_minus_disposable_cell",
+                    "light_disposable_cell"
+                ],
+                "max_item_length": "1 km"
+            }
+        ]
+    }
+]

--- a/Kenan-Modpack/easy_containers/items/tool/science.json
+++ b/Kenan-Modpack/easy_containers/items/tool/science.json
@@ -1,0 +1,541 @@
+[
+    {
+        "type": "TOOL",
+        "id": "chemistry_set",
+        "copy-from": "chemistry_set",
+        "name": {
+            "str": "chemistry set"
+        },
+        "pocket_data": [
+            {
+                "pocket_type": "MAGAZINE_WELL",
+                "rigid": true,
+                "holster": true,
+                "max_contains_volume": "20 L",
+                "max_contains_weight": "1000 kg",
+                "item_restriction": [
+                    "medium_battery_cell",
+                    "medium_plus_battery_cell",
+                    "medium_atomic_battery_cell",
+                    "medium_disposable_cell"
+                ],
+                "max_item_length": "1 km"
+            }
+        ]
+    },
+    {
+        "type": "TOOL",
+        "id": "electrolysis_kit",
+        "copy-from": "electrolysis_kit",
+        "name": {
+            "str": "electrolysis kit"
+        },
+        "pocket_data": [
+            {
+                "pocket_type": "MAGAZINE_WELL",
+                "holster": true,
+                "max_contains_volume": "25 L",
+                "max_contains_weight": "1000 kg",
+                "//": "this tool is small and has no actual battery compartment, but can connect to large batteries.",
+                "item_restriction": [
+                    "battery_car",
+                    "battery_motorbike",
+                    "small_storage_battery",
+                    "medium_storage_battery",
+                    "storage_battery"
+                ],
+                "max_item_length": "1 km"
+            }
+        ]
+    },
+    {
+        "type": "TOOL",
+        "id": "vac_oven_small",
+        "copy-from": "vac_oven_small",
+        "name": {
+            "str": "small vacuum oven"
+        },
+        "pocket_data": [
+            {
+                "pocket_type": "MAGAZINE_WELL",
+                "holster": true,
+                "magazine_well": "5 L",
+                "max_contains_volume": "50 L",
+                "max_contains_weight": "1000 kg",
+                "item_restriction": [
+                    "large_storage_battery",
+                    "storage_battery"
+                ],
+                "max_item_length": "1 km"
+            }
+        ]
+    },
+    {
+        "type": "TOOL",
+        "id": "vac_oven_small_full",
+        "copy-from": "vac_oven_small_full",
+        "name": {
+            "str": "filled small vacuum oven"
+        },
+        "pocket_data": [
+            {
+                "pocket_type": "MAGAZINE_WELL",
+                "holster": true,
+                "magazine_well": "5 L",
+                "max_contains_volume": "50 L",
+                "max_contains_weight": "1000 kg",
+                "item_restriction": [
+                    "large_storage_battery",
+                    "storage_battery"
+                ],
+                "max_item_length": "1 km"
+            }
+        ]
+    },
+    {
+        "type": "TOOL",
+        "id": "vac_oven_small_on",
+        "copy-from": "vac_oven_small_on",
+        "name": {
+            "str": "small vacuum oven (on)",
+            "str_pl": "small vacuum ovens (on)"
+        },
+        "pocket_data": [
+            {
+                "pocket_type": "MAGAZINE_WELL",
+                "holster": true,
+                "magazine_well": "5 L",
+                "max_contains_volume": "50 L",
+                "max_contains_weight": "1000 kg",
+                "item_restriction": [
+                    "large_storage_battery",
+                    "storage_battery"
+                ],
+                "max_item_length": "1 km"
+            }
+        ]
+    },
+    {
+        "type": "TOOL",
+        "id": "vac_oven_small_done",
+        "copy-from": "vac_oven_small_done",
+        "name": {
+            "str": "finished small vacuum oven"
+        },
+        "pocket_data": [
+            {
+                "pocket_type": "MAGAZINE_WELL",
+                "holster": true,
+                "magazine_well": "5 L",
+                "max_contains_volume": "50 L",
+                "max_contains_weight": "1000 kg",
+                "item_restriction": [
+                    "large_storage_battery",
+                    "storage_battery"
+                ],
+                "max_item_length": "1 km"
+            }
+        ]
+    },
+    {
+        "type": "TOOL",
+        "id": "closed_loop_extractor_small",
+        "copy-from": "closed_loop_extractor_small",
+        "name": {
+            "str": "small closed loop extractor"
+        },
+        "pocket_data": [
+            {
+                "pocket_type": "MAGAZINE_WELL",
+                "holster": true,
+                "magazine_well": "5 L",
+                "max_contains_volume": "50 L",
+                "max_contains_weight": "1000 kg",
+                "item_restriction": [
+                    "medium_battery_cell",
+                    "medium_plus_battery_cell",
+                    "medium_disposable_cell",
+                    "medium_atomic_battery_cell",
+                    "heavy_battery_cell",
+                    "heavy_plus_battery_cell",
+                    "heavy_disposable_cell",
+                    "heavy_atomic_battery_cell",
+                    "small_storage_battery",
+                    "medium_storage_battery",
+                    "large_storage_battery",
+                    "storage_battery"
+                ],
+                "max_item_length": "1 km"
+            }
+        ]
+    },
+    {
+        "type": "TOOL",
+        "id": "closed_loop_extractor_small_on",
+        "copy-from": "closed_loop_extractor_small_on",
+        "name": {
+            "str": "small closed loop extractor (on)",
+            "str_pl": "small closed loop extractors (on)"
+        },
+        "pocket_data": [
+            {
+                "pocket_type": "MAGAZINE_WELL",
+                "holster": true,
+                "magazine_well": "5 L",
+                "max_contains_volume": "50 L",
+                "max_contains_weight": "1000 kg",
+                "item_restriction": [
+                    "medium_battery_cell",
+                    "medium_plus_battery_cell",
+                    "medium_disposable_cell",
+                    "medium_atomic_battery_cell",
+                    "heavy_battery_cell",
+                    "heavy_plus_battery_cell",
+                    "heavy_disposable_cell",
+                    "heavy_atomic_battery_cell",
+                    "small_storage_battery",
+                    "medium_storage_battery",
+                    "large_storage_battery",
+                    "storage_battery"
+                ],
+                "max_item_length": "1 km"
+            }
+        ]
+    },
+    {
+        "type": "TOOL",
+        "id": "closed_loop_extractor_large",
+        "copy-from": "closed_loop_extractor_large",
+        "name": {
+            "str": "large closed loop extractor"
+        },
+        "pocket_data": [
+            {
+                "pocket_type": "MAGAZINE_WELL",
+                "holster": true,
+                "magazine_well": "5 L",
+                "max_contains_volume": "50 L",
+                "max_contains_weight": "1000 kg",
+                "item_restriction": [
+                    "medium_battery_cell",
+                    "medium_plus_battery_cell",
+                    "medium_disposable_cell",
+                    "medium_atomic_battery_cell",
+                    "heavy_battery_cell",
+                    "heavy_plus_battery_cell",
+                    "heavy_disposable_cell",
+                    "heavy_atomic_battery_cell",
+                    "small_storage_battery",
+                    "medium_storage_battery",
+                    "large_storage_battery",
+                    "storage_battery"
+                ],
+                "max_item_length": "1 km"
+            }
+        ]
+    },
+    {
+        "type": "TOOL",
+        "id": "closed_loop_extractor_large_on",
+        "copy-from": "closed_loop_extractor_large_on",
+        "name": {
+            "str": "large closed loop extractor (on)",
+            "str_pl": "large closed loop extractors (on)"
+        },
+        "pocket_data": [
+            {
+                "pocket_type": "MAGAZINE_WELL",
+                "holster": true,
+                "magazine_well": "5 L",
+                "max_contains_volume": "50 L",
+                "max_contains_weight": "1000 kg",
+                "item_restriction": [
+                    "medium_battery_cell",
+                    "medium_plus_battery_cell",
+                    "medium_disposable_cell",
+                    "medium_atomic_battery_cell",
+                    "heavy_battery_cell",
+                    "heavy_plus_battery_cell",
+                    "heavy_disposable_cell",
+                    "heavy_atomic_battery_cell",
+                    "small_storage_battery",
+                    "medium_storage_battery",
+                    "large_storage_battery",
+                    "storage_battery"
+                ],
+                "max_item_length": "1 km"
+            }
+        ]
+    },
+    {
+        "type": "TOOL",
+        "id": "vac_pump",
+        "copy-from": "vac_pump",
+        "name": {
+            "str": "vacuum pump"
+        },
+        "pocket_data": [
+            {
+                "pocket_type": "MAGAZINE_WELL",
+                "holster": true,
+                "magazine_well": "500 ml",
+                "max_contains_volume": "50 L",
+                "max_contains_weight": "1000 kg",
+                "item_restriction": [
+                    "medium_battery_cell",
+                    "medium_plus_battery_cell",
+                    "medium_disposable_cell",
+                    "medium_atomic_battery_cell",
+                    "heavy_battery_cell",
+                    "heavy_plus_battery_cell",
+                    "heavy_disposable_cell",
+                    "heavy_atomic_battery_cell",
+                    "small_storage_battery",
+                    "medium_storage_battery",
+                    "large_storage_battery",
+                    "storage_battery"
+                ],
+                "max_item_length": "1 km"
+            }
+        ]
+    },
+    {
+        "type": "TOOL",
+        "id": "vac_pump_on",
+        "copy-from": "vac_pump_on",
+        "name": {
+            "str": "vacuum pump (on)",
+            "str_pl": "vacuum pumps (on)"
+        },
+        "pocket_data": [
+            {
+                "pocket_type": "MAGAZINE_WELL",
+                "holster": true,
+                "magazine_well": "500 ml",
+                "max_contains_volume": "50 L",
+                "max_contains_weight": "1000 kg",
+                "item_restriction": [
+                    "medium_battery_cell",
+                    "medium_plus_battery_cell",
+                    "medium_disposable_cell",
+                    "medium_atomic_battery_cell",
+                    "heavy_battery_cell",
+                    "heavy_plus_battery_cell",
+                    "heavy_disposable_cell",
+                    "heavy_atomic_battery_cell",
+                    "small_storage_battery",
+                    "medium_storage_battery",
+                    "large_storage_battery",
+                    "storage_battery"
+                ],
+                "max_item_length": "1 km"
+            }
+        ]
+    },
+    {
+        "type": "TOOL",
+        "id": "butane_tank",
+        "copy-from": "butane_tank",
+        "name": {
+            "str": "butane tank",
+            "str_pl": "tanks of butane"
+        },
+        "pocket_data": [
+            {
+                "pocket_type": "MAGAZINE",
+                "rigid": true,
+                "airtight": true,
+                "ammo_restriction": {
+                    "butane": 2000
+                },
+                "watertight": true,
+                "max_contains_weight": "1000 kg",
+                "max_item_length": "1 km"
+            }
+        ]
+    },
+    {
+        "type": "TOOL",
+        "id": "weather_reader",
+        "copy-from": "weather_reader",
+        "name": {
+            "str": "Doppler Radar Turbo 2000"
+        },
+        "pocket_data": [
+            {
+                "pocket_type": "MAGAZINE_WELL",
+                "rigid": true,
+                "holster": true,
+                "max_contains_volume": "20 L",
+                "max_contains_weight": "1000 kg",
+                "item_restriction": [
+                    "light_battery_cell",
+                    "light_plus_battery_cell",
+                    "light_disposable_cell",
+                    "light_atomic_battery_cell",
+                    "light_minus_battery_cell",
+                    "light_minus_disposable_cell",
+                    "light_minus_atomic_battery_cell"
+                ],
+                "max_item_length": "1 km"
+            }
+        ]
+    },
+    {
+        "type": "TOOL",
+        "id": "analytical_set_basic",
+        "copy-from": "analytical_set_basic",
+        "name": {
+            "str": "basic laboratory analysis kit"
+        },
+        "pocket_data": [
+            {
+                "pocket_type": "MAGAZINE_WELL",
+                "rigid": true,
+                "holster": true,
+                "max_contains_volume": "20 L",
+                "max_contains_weight": "1000 kg",
+                "item_restriction": [
+                    "medium_battery_cell",
+                    "medium_plus_battery_cell",
+                    "medium_atomic_battery_cell",
+                    "medium_disposable_cell"
+                ],
+                "max_item_length": "1 km"
+            }
+        ]
+    },
+    {
+        "type": "TOOL",
+        "id": "spectrophotometer",
+        "copy-from": "spectrophotometer",
+        "name": {
+            "str": "spectrophotometer"
+        },
+        "pocket_data": [
+            {
+                "pocket_type": "MAGAZINE_WELL",
+                "rigid": true,
+                "holster": true,
+                "max_contains_volume": "20 L",
+                "max_contains_weight": "1000 kg",
+                "item_restriction": [
+                    "medium_battery_cell",
+                    "medium_plus_battery_cell",
+                    "medium_atomic_battery_cell",
+                    "medium_disposable_cell"
+                ],
+                "max_item_length": "1 km"
+            }
+        ]
+    },
+    {
+        "type": "TOOL",
+        "id": "ph_meter",
+        "copy-from": "ph_meter",
+        "name": {
+            "str": "pH meter"
+        },
+        "pocket_data": [
+            {
+                "pocket_type": "MAGAZINE_WELL",
+                "rigid": true,
+                "holster": true,
+                "max_contains_volume": "20 L",
+                "max_contains_weight": "1000 kg",
+                "item_restriction": [
+                    "light_battery_cell",
+                    "light_plus_battery_cell",
+                    "light_minus_battery_cell",
+                    "light_atomic_battery_cell",
+                    "light_minus_atomic_battery_cell",
+                    "light_minus_disposable_cell",
+                    "light_disposable_cell"
+                ],
+                "max_item_length": "1 km"
+            }
+        ]
+    },
+    {
+        "type": "TOOL",
+        "id": "voltmeter",
+        "copy-from": "voltmeter",
+        "name": {
+            "str": "voltmeter"
+        },
+        "pocket_data": [
+            {
+                "pocket_type": "MAGAZINE_WELL",
+                "rigid": true,
+                "holster": true,
+                "max_contains_volume": "20 L",
+                "max_contains_weight": "1000 kg",
+                "item_restriction": [
+                    "light_battery_cell",
+                    "light_plus_battery_cell",
+                    "light_minus_battery_cell",
+                    "light_atomic_battery_cell",
+                    "light_minus_atomic_battery_cell",
+                    "light_minus_disposable_cell",
+                    "light_disposable_cell"
+                ],
+                "max_item_length": "1 km"
+            }
+        ]
+    },
+    {
+        "type": "TOOL",
+        "id": "melting_point",
+        "copy-from": "melting_point",
+        "name": {
+            "str": "melting point apparatus",
+            "str_pl": "units of melting point apparatus"
+        },
+        "pocket_data": [
+            {
+                "pocket_type": "MAGAZINE_WELL",
+                "rigid": true,
+                "holster": true,
+                "max_contains_volume": "20 L",
+                "max_contains_weight": "1000 kg",
+                "item_restriction": [
+                    "light_battery_cell",
+                    "light_plus_battery_cell",
+                    "light_minus_battery_cell",
+                    "light_atomic_battery_cell",
+                    "light_minus_atomic_battery_cell",
+                    "light_minus_disposable_cell",
+                    "light_disposable_cell"
+                ],
+                "max_item_length": "1 km"
+            }
+        ]
+    },
+    {
+        "type": "TOOL",
+        "id": "microcentrifuge",
+        "copy-from": "microcentrifuge",
+        "name": {
+            "str": "microcentrifuge"
+        },
+        "pocket_data": [
+            {
+                "pocket_type": "MAGAZINE_WELL",
+                "rigid": true,
+                "holster": true,
+                "max_contains_volume": "20 L",
+                "max_contains_weight": "1000 kg",
+                "item_restriction": [
+                    "light_battery_cell",
+                    "light_plus_battery_cell",
+                    "light_minus_battery_cell",
+                    "light_atomic_battery_cell",
+                    "light_minus_atomic_battery_cell",
+                    "light_minus_disposable_cell",
+                    "light_disposable_cell"
+                ],
+                "max_item_length": "1 km"
+            }
+        ]
+    }
+]

--- a/Kenan-Modpack/easy_containers/items/tool/smoking.json
+++ b/Kenan-Modpack/easy_containers/items/tool/smoking.json
@@ -1,0 +1,29 @@
+[
+    {
+        "type": "TOOL",
+        "id": "advanced_ecig",
+        "copy-from": "advanced_ecig",
+        "name": {
+            "str": "advanced electronic cigarette"
+        },
+        "pocket_data": [
+            {
+                "pocket_type": "MAGAZINE_WELL",
+                "rigid": true,
+                "holster": true,
+                "max_contains_volume": "20 L",
+                "max_contains_weight": "1000 kg",
+                "item_restriction": [
+                    "light_battery_cell",
+                    "light_plus_battery_cell",
+                    "light_minus_battery_cell",
+                    "light_atomic_battery_cell",
+                    "light_disposable_cell",
+                    "light_minus_disposable_cell",
+                    "light_minus_atomic_battery_cell"
+                ],
+                "max_item_length": "1 km"
+            }
+        ]
+    }
+]

--- a/Kenan-Modpack/easy_containers/items/tool/stationary.json
+++ b/Kenan-Modpack/easy_containers/items/tool/stationary.json
@@ -1,0 +1,162 @@
+[
+    {
+        "type": "TOOL",
+        "id": "pen",
+        "copy-from": "pen",
+        "name": {
+            "str": "pen"
+        },
+        "pocket_data": [
+            {
+                "pocket_type": "MAGAZINE",
+                "ammo_restriction": {
+                    "black_pen_ink": 100
+                },
+                "watertight": true,
+                "rigid": true,
+                "max_contains_weight": "1000 kg",
+                "max_item_length": "1 km"
+            }
+        ]
+    },
+    {
+        "type": "TOOL",
+        "id": "pencil",
+        "copy-from": "pencil",
+        "name": {
+            "str": "pencil"
+        },
+        "pocket_data": [
+            {
+                "pocket_type": "MAGAZINE",
+                "ammo_restriction": {
+                    "graphite": 100
+                },
+                "rigid": true,
+                "max_contains_weight": "1000 kg",
+                "max_item_length": "1 km"
+            }
+        ]
+    },
+    {
+        "type": "TOOL",
+        "id": "black_pen",
+        "copy-from": "black_pen",
+        "name": {
+            "str": "black pen"
+        },
+        "pocket_data": [
+            {
+                "pocket_type": "MAGAZINE",
+                "ammo_restriction": {
+                    "black_pen_ink": 100
+                },
+                "watertight": true,
+                "rigid": true,
+                "max_contains_weight": "1000 kg",
+                "max_item_length": "1 km"
+            }
+        ]
+    },
+    {
+        "type": "TOOL",
+        "id": "blue_pen",
+        "copy-from": "blue_pen",
+        "name": {
+            "str": "blue pen"
+        },
+        "pocket_data": [
+            {
+                "pocket_type": "MAGAZINE",
+                "ammo_restriction": {
+                    "blue_pen_ink": 100
+                },
+                "watertight": true,
+                "rigid": true,
+                "max_contains_weight": "1000 kg",
+                "max_item_length": "1 km"
+            }
+        ]
+    },
+    {
+        "type": "TOOL",
+        "id": "red_pen",
+        "copy-from": "red_pen",
+        "name": {
+            "str": "red pen"
+        },
+        "pocket_data": [
+            {
+                "pocket_type": "MAGAZINE",
+                "ammo_restriction": {
+                    "red_pen_ink": 100
+                },
+                "watertight": true,
+                "rigid": true,
+                "max_contains_weight": "1000 kg",
+                "max_item_length": "1 km"
+            }
+        ]
+    },
+    {
+        "type": "TOOL",
+        "id": "green_pen",
+        "copy-from": "green_pen",
+        "name": {
+            "str": "green pen"
+        },
+        "pocket_data": [
+            {
+                "pocket_type": "MAGAZINE",
+                "ammo_restriction": {
+                    "green_pen_ink": 100
+                },
+                "watertight": true,
+                "rigid": true,
+                "max_contains_weight": "1000 kg",
+                "max_item_length": "1 km"
+            }
+        ]
+    },
+    {
+        "type": "TOOL",
+        "id": "leather_journal",
+        "copy-from": "leather_journal",
+        "name": {
+            "str": "leather journal"
+        },
+        "pocket_data": [
+            {
+                "//": "Binding",
+                "pocket_type": "CONTAINER",
+                "rigid": false,
+                "max_contains_weight": "1000 kg",
+                "max_contains_volume": "2500 ml",
+                "moves": 150,
+                "item_restriction": [
+                    "paper",
+                    "militarymap",
+                    "survivormap",
+                    "roadmap",
+                    "subwaymap",
+                    "trailmap",
+                    "touristmap",
+                    "restaurantmap",
+                    "flyer",
+                    "survnote",
+                    "character_sheet",
+                    "newest_newspaper",
+                    "many_years_old_newspaper",
+                    "years_old_newspaper",
+                    "one_year_old_newspaper",
+                    "months_old_newspaper",
+                    "weeks_old_newspaper",
+                    "necropolis_leaflet",
+                    "death_note",
+                    "evac_pamphlet"
+                ],
+                "max_item_length": "1 km"
+            }
+        ]
+    }
+]

--- a/Kenan-Modpack/easy_containers/items/tool/tailoring.json
+++ b/Kenan-Modpack/easy_containers/items/tool/tailoring.json
@@ -1,0 +1,92 @@
+[
+    {
+        "type": "TOOL",
+        "id": "needle_bone",
+        "copy-from": "needle_bone",
+        "name": {
+            "str": "bone needle"
+        },
+        "pocket_data": [
+            {
+                "pocket_type": "MAGAZINE",
+                "ammo_restriction": {
+                    "thread": 200
+                },
+                "max_contains_weight": "1000 kg",
+                "max_item_length": "1 km"
+            }
+        ]
+    },
+    {
+        "type": "TOOL",
+        "id": "needle_curved",
+        "copy-from": "needle_curved",
+        "name": {
+            "str": "curved needle"
+        },
+        "pocket_data": [
+            {
+                "pocket_type": "MAGAZINE",
+                "ammo_restriction": {
+                    "thread": 200
+                },
+                "max_contains_weight": "1000 kg",
+                "max_item_length": "1 km"
+            }
+        ]
+    },
+    {
+        "type": "TOOL",
+        "id": "needle_wood",
+        "copy-from": "needle_wood",
+        "name": {
+            "str": "wooden needle"
+        },
+        "pocket_data": [
+            {
+                "pocket_type": "MAGAZINE",
+                "ammo_restriction": {
+                    "thread": 200
+                },
+                "max_contains_weight": "1000 kg",
+                "max_item_length": "1 km"
+            }
+        ]
+    },
+    {
+        "type": "TOOL",
+        "id": "sewing_kit",
+        "copy-from": "sewing_kit",
+        "name": {
+            "str": "sewing kit"
+        },
+        "pocket_data": [
+            {
+                "pocket_type": "MAGAZINE",
+                "ammo_restriction": {
+                    "thread": 200
+                },
+                "max_contains_weight": "1000 kg",
+                "max_item_length": "1 km"
+            }
+        ]
+    },
+    {
+        "type": "TOOL",
+        "id": "tailors_kit",
+        "copy-from": "tailors_kit",
+        "name": {
+            "str": "tailor's kit"
+        },
+        "pocket_data": [
+            {
+                "pocket_type": "MAGAZINE",
+                "ammo_restriction": {
+                    "thread": 400
+                },
+                "max_contains_weight": "1000 kg",
+                "max_item_length": "1 km"
+            }
+        ]
+    }
+]

--- a/Kenan-Modpack/easy_containers/items/tool/toileteries.json
+++ b/Kenan-Modpack/easy_containers/items/tool/toileteries.json
@@ -1,0 +1,61 @@
+[
+    {
+        "type": "TOOL",
+        "id": "elec_hairtrimmer",
+        "copy-from": "elec_hairtrimmer",
+        "name": {
+            "str": "electric hair trimmer"
+        },
+        "pocket_data": [
+            {
+                "pocket_type": "MAGAZINE_WELL",
+                "rigid": true,
+                "holster": true,
+                "max_contains_volume": "20 L",
+                "max_contains_weight": "1000 kg",
+                "item_restriction": [
+                    "light_minus_battery_cell",
+                    "light_minus_atomic_battery_cell",
+                    "light_minus_disposable_cell"
+                ],
+                "max_item_length": "1 km"
+            }
+        ]
+    },
+    {
+        "type": "TOOL",
+        "id": "shavingkit",
+        "copy-from": "shavingkit",
+        "name": {
+            "str": "shaving kit"
+        },
+        "pocket_data": [
+            {
+                "pocket_type": "MAGAZINE",
+                "ammo_restriction": {
+                    "soap": 10
+                },
+                "max_contains_weight": "1000 kg",
+                "max_item_length": "1 km"
+            }
+        ]
+    },
+    {
+        "type": "TOOL",
+        "id": "survivor_shavingkit",
+        "copy-from": "survivor_shavingkit",
+        "name": {
+            "str": "makeshift shaving kit"
+        },
+        "pocket_data": [
+            {
+                "pocket_type": "MAGAZINE",
+                "ammo_restriction": {
+                    "soap": 10
+                },
+                "max_contains_weight": "1000 kg",
+                "max_item_length": "1 km"
+            }
+        ]
+    }
+]

--- a/Kenan-Modpack/easy_containers/items/tool/woodworking.json
+++ b/Kenan-Modpack/easy_containers/items/tool/woodworking.json
@@ -1,0 +1,73 @@
+[
+    {
+        "type": "TOOL",
+        "id": "chainsaw_off",
+        "copy-from": "chainsaw_off",
+        "name": {
+            "str": "chainsaw (off)",
+            "str_pl": "chainsaws (off)"
+        },
+        "pocket_data": [
+            {
+                "pocket_type": "MAGAZINE",
+                "ammo_restriction": {
+                    "gasoline": 450
+                },
+                "watertight": true,
+                "rigid": true,
+                "max_contains_weight": "1000 kg",
+                "max_item_length": "1 km"
+            }
+        ]
+    },
+    {
+        "type": "TOOL",
+        "id": "circsaw_off",
+        "copy-from": "circsaw_off",
+        "name": {
+            "str": "circular saw (off)",
+            "str_pl": "circular saws (off)"
+        },
+        "pocket_data": [
+            {
+                "pocket_type": "MAGAZINE_WELL",
+                "holster": true,
+                "magazine_well": "200 ml",
+                "max_contains_volume": "20 L",
+                "max_contains_weight": "1000 kg",
+                "item_restriction": [
+                    "medium_battery_cell",
+                    "medium_plus_battery_cell",
+                    "medium_atomic_battery_cell",
+                    "medium_disposable_cell"
+                ],
+                "max_item_length": "1 km"
+            }
+        ]
+    },
+    {
+        "type": "TOOL",
+        "id": "elec_chainsaw_off",
+        "copy-from": "elec_chainsaw_off",
+        "name": {
+            "str": "electric chainsaw (off)",
+            "str_pl": "electric chainsaws (off)"
+        },
+        "pocket_data": [
+            {
+                "pocket_type": "MAGAZINE_WELL",
+                "holster": true,
+                "magazine_well": "200 ml",
+                "max_contains_volume": "20 L",
+                "max_contains_weight": "1000 kg",
+                "item_restriction": [
+                    "medium_battery_cell",
+                    "medium_plus_battery_cell",
+                    "medium_atomic_battery_cell",
+                    "medium_disposable_cell"
+                ],
+                "max_item_length": "1 km"
+            }
+        ]
+    }
+]

--- a/Kenan-Modpack/easy_containers/items/tool/workshop.json
+++ b/Kenan-Modpack/easy_containers/items/tool/workshop.json
@@ -1,0 +1,377 @@
+[
+    {
+        "type": "TOOL",
+        "id": "angle_grinder",
+        "copy-from": "angle_grinder",
+        "name": {
+            "str": "angle grinder"
+        },
+        "pocket_data": [
+            {
+                "pocket_type": "MAGAZINE_WELL",
+                "holster": true,
+                "magazine_well": "200 ml",
+                "max_contains_volume": "20 L",
+                "max_contains_weight": "1000 kg",
+                "item_restriction": [
+                    "medium_battery_cell",
+                    "medium_plus_battery_cell",
+                    "medium_atomic_battery_cell",
+                    "medium_disposable_cell"
+                ],
+                "max_item_length": "1 km"
+            }
+        ]
+    },
+    {
+        "type": "TOOL",
+        "id": "brick_kiln",
+        "copy-from": "brick_kiln",
+        "name": {
+            "str": "brick kiln"
+        },
+        "pocket_data": [
+            {
+                "pocket_type": "MAGAZINE",
+                "rigid": true,
+                "ammo_restriction": {
+                    "charcoal": 1000
+                },
+                "max_contains_weight": "1000 kg",
+                "max_item_length": "1 km"
+            }
+        ]
+    },
+    {
+        "type": "TOOL",
+        "id": "kiln_pseudo",
+        "copy-from": "kiln_pseudo",
+        "name": {
+            "str": "clay kiln"
+        },
+        "pocket_data": [
+            {
+                "pocket_type": "MAGAZINE",
+                "ammo_restriction": {
+                    "charcoal": 40000
+                },
+                "max_contains_weight": "1000 kg",
+                "max_item_length": "1 km"
+            }
+        ]
+    },
+    {
+        "type": "TOOL",
+        "id": "con_mix",
+        "copy-from": "con_mix",
+        "name": {
+            "str": "concrete mixer"
+        },
+        "pocket_data": [
+            {
+                "pocket_type": "MAGAZINE_WELL",
+                "rigid": true,
+                "holster": true,
+                "max_contains_volume": "20 L",
+                "max_contains_weight": "1000 kg",
+                "item_restriction": [
+                    "medium_battery_cell",
+                    "medium_plus_battery_cell",
+                    "medium_atomic_battery_cell",
+                    "medium_disposable_cell"
+                ],
+                "max_item_length": "1 km"
+            }
+        ]
+    },
+    {
+        "type": "TOOL",
+        "id": "cordless_drill",
+        "copy-from": "cordless_drill",
+        "name": {
+            "str": "cordless drill"
+        },
+        "pocket_data": [
+            {
+                "pocket_type": "MAGAZINE_WELL",
+                "holster": true,
+                "magazine_well": "200 ml",
+                "max_contains_volume": "20 L",
+                "max_contains_weight": "1000 kg",
+                "item_restriction": [
+                    "medium_battery_cell",
+                    "medium_plus_battery_cell",
+                    "medium_atomic_battery_cell",
+                    "medium_disposable_cell"
+                ],
+                "max_item_length": "1 km"
+            }
+        ]
+    },
+    {
+        "type": "TOOL",
+        "id": "jackhammer",
+        "copy-from": "jackhammer",
+        "name": {
+            "str": "jackhammer"
+        },
+        "pocket_data": [
+            {
+                "pocket_type": "MAGAZINE",
+                "rigid": true,
+                "watertight": true,
+                "ammo_restriction": {
+                    "gasoline": 400
+                },
+                "max_contains_weight": "1000 kg",
+                "max_item_length": "1 km"
+            }
+        ]
+    },
+    {
+        "type": "TOOL",
+        "id": "kiln",
+        "copy-from": "kiln",
+        "name": {
+            "str": "electric kiln"
+        },
+        "pocket_data": [
+            {
+                "pocket_type": "MAGAZINE_WELL",
+                "rigid": true,
+                "holster": true,
+                "max_contains_volume": "20 L",
+                "max_contains_weight": "1000 kg",
+                "item_restriction": [
+                    "heavy_battery_cell",
+                    "heavy_plus_battery_cell",
+                    "heavy_atomic_battery_cell",
+                    "heavy_disposable_cell"
+                ],
+                "max_item_length": "1 km"
+            }
+        ]
+    },
+    {
+        "type": "TOOL",
+        "id": "large_repairkit",
+        "copy-from": "large_repairkit",
+        "name": {
+            "str": "gunsmith repair kit"
+        },
+        "pocket_data": [
+            {
+                "pocket_type": "MAGAZINE_WELL",
+                "rigid": true,
+                "holster": true,
+                "max_contains_volume": "20 L",
+                "max_contains_weight": "1000 kg",
+                "item_restriction": [
+                    "medium_battery_cell",
+                    "medium_plus_battery_cell",
+                    "medium_atomic_battery_cell",
+                    "medium_disposable_cell"
+                ],
+                "max_item_length": "1 km"
+            }
+        ]
+    },
+    {
+        "type": "TOOL",
+        "id": "misc_repairkit",
+        "copy-from": "misc_repairkit",
+        "name": {
+            "str": "misc repair kit"
+        },
+        "pocket_data": [
+            {
+                "pocket_type": "MAGAZINE",
+                "ammo_restriction": {
+                    "tape": 200
+                },
+                "max_contains_weight": "1000 kg",
+                "max_item_length": "1 km"
+            }
+        ]
+    },
+    {
+        "type": "TOOL",
+        "id": "oxy_torch",
+        "copy-from": "oxy_torch",
+        "name": {
+            "str": "acetylene torch",
+            "str_pl": "acetylene torches"
+        },
+        "pocket_data": [
+            {
+                "pocket_type": "MAGAZINE_WELL",
+                "holster": true,
+                "max_contains_volume": "20 L",
+                "max_contains_weight": "1000 kg",
+                "item_restriction": [
+                    "weldtank",
+                    "tinyweldtank"
+                ],
+                "max_item_length": "1 km"
+            }
+        ]
+    },
+    {
+        "type": "TOOL",
+        "id": "polisher",
+        "copy-from": "polisher",
+        "name": {
+            "str": "electric polisher"
+        },
+        "pocket_data": [
+            {
+                "pocket_type": "MAGAZINE_WELL",
+                "rigid": true,
+                "holster": true,
+                "max_contains_volume": "20 L",
+                "max_contains_weight": "1000 kg",
+                "item_restriction": [
+                    "light_battery_cell",
+                    "light_plus_battery_cell",
+                    "light_minus_battery_cell",
+                    "light_atomic_battery_cell",
+                    "light_minus_atomic_battery_cell",
+                    "light_minus_disposable_cell",
+                    "light_disposable_cell"
+                ],
+                "max_item_length": "1 km"
+            }
+        ]
+    },
+    {
+        "type": "TOOL",
+        "id": "small_repairkit",
+        "copy-from": "small_repairkit",
+        "name": {
+            "str": "firearm repair kit"
+        },
+        "pocket_data": [
+            {
+                "pocket_type": "MAGAZINE_WELL",
+                "rigid": true,
+                "holster": true,
+                "max_contains_volume": "20 L",
+                "max_contains_weight": "1000 kg",
+                "item_restriction": [
+                    "medium_battery_cell",
+                    "medium_plus_battery_cell",
+                    "medium_atomic_battery_cell",
+                    "medium_disposable_cell"
+                ],
+                "max_item_length": "1 km"
+            }
+        ]
+    },
+    {
+        "type": "TOOL",
+        "id": "soldering_iron",
+        "copy-from": "soldering_iron",
+        "name": {
+            "str": "soldering iron"
+        },
+        "pocket_data": [
+            {
+                "pocket_type": "MAGAZINE_WELL",
+                "rigid": true,
+                "holster": true,
+                "max_contains_volume": "20 L",
+                "max_contains_weight": "1000 kg",
+                "item_restriction": [
+                    "light_disposable_cell",
+                    "light_minus_battery_cell",
+                    "light_battery_cell",
+                    "light_plus_battery_cell",
+                    "light_atomic_battery_cell",
+                    "light_minus_atomic_battery_cell",
+                    "light_minus_disposable_cell"
+                ],
+                "max_item_length": "1 km"
+            }
+        ]
+    },
+    {
+        "type": "GENERIC",
+        "id": "toolbox_empty",
+        "copy-from": "toolbox_empty",
+        "name": {
+            "str": "toolbox",
+            "str_pl": "toolboxes"
+        },
+        "pocket_data": [
+            {
+                "max_contains_volume": "2400 ml",
+                "max_contains_weight": "1000 kg",
+                "max_item_length": "1 km"
+            }
+        ]
+    },
+    {
+        "type": "GENERIC",
+        "id": "toolbox_workshop_empty",
+        "copy-from": "toolbox_workshop_empty",
+        "name": {
+            "str": "workshop toolbox",
+            "str_pl": "workshop toolboxes"
+        },
+        "pocket_data": [
+            {
+                "max_contains_volume": "3000 ml",
+                "max_contains_weight": "1000 kg",
+                "max_item_length": "1 km"
+            }
+        ]
+    },
+    {
+        "type": "TOOL",
+        "id": "welder",
+        "copy-from": "welder",
+        "name": {
+            "str": "arc welder"
+        },
+        "pocket_data": [
+            {
+                "pocket_type": "MAGAZINE_WELL",
+                "rigid": true,
+                "holster": true,
+                "max_contains_volume": "20 L",
+                "max_contains_weight": "1000 kg",
+                "item_restriction": [
+                    "medium_battery_cell",
+                    "medium_plus_battery_cell",
+                    "medium_atomic_battery_cell",
+                    "medium_disposable_cell"
+                ],
+                "max_item_length": "1 km"
+            }
+        ]
+    },
+    {
+        "type": "TOOL",
+        "id": "welder_crude",
+        "copy-from": "welder_crude",
+        "name": {
+            "str": "makeshift arc welder"
+        },
+        "pocket_data": [
+            {
+                "pocket_type": "MAGAZINE_WELL",
+                "rigid": true,
+                "holster": true,
+                "max_contains_volume": "20 L",
+                "max_contains_weight": "1000 kg",
+                "item_restriction": [
+                    "medium_battery_cell",
+                    "medium_plus_battery_cell",
+                    "medium_atomic_battery_cell",
+                    "medium_disposable_cell"
+                ],
+                "max_item_length": "1 km"
+            }
+        ]
+    }
+]

--- a/Kenan-Modpack/easy_containers/items/tool_armor.json
+++ b/Kenan-Modpack/easy_containers/items/tool_armor.json
@@ -1,0 +1,933 @@
+[
+    {
+        "type": "TOOL_ARMOR",
+        "id": "miner_hat",
+        "copy-from": "miner_hat",
+        "name": {
+            "str": "mining helmet"
+        },
+        "pocket_data": [
+            {
+                "pocket_type": "MAGAZINE_WELL",
+                "holster": true,
+                "rigid": true,
+                "max_contains_volume": "20 L",
+                "max_contains_weight": "1000 kg",
+                "item_restriction": [
+                    "light_battery_cell",
+                    "light_plus_battery_cell",
+                    "light_minus_battery_cell",
+                    "light_atomic_battery_cell",
+                    "light_minus_atomic_battery_cell",
+                    "light_minus_disposable_cell",
+                    "light_disposable_cell"
+                ],
+                "max_item_length": "1 km"
+            }
+        ]
+    },
+    {
+        "type": "TOOL_ARMOR",
+        "id": "game_watch",
+        "copy-from": "game_watch",
+        "name": {
+            "str": "game watch",
+            "str_pl": "game watches"
+        },
+        "pocket_data": [
+            {
+                "pocket_type": "MAGAZINE_WELL",
+                "holster": true,
+                "rigid": true,
+                "max_contains_volume": "20 L",
+                "max_contains_weight": "1000 kg",
+                "item_restriction": [
+                    "light_minus_battery_cell",
+                    "light_minus_atomic_battery_cell",
+                    "light_minus_disposable_cell"
+                ],
+                "max_item_length": "1 km"
+            }
+        ]
+    },
+    {
+        "type": "TOOL_ARMOR",
+        "id": "holo_cloak",
+        "copy-from": "holo_cloak",
+        "name": {
+            "str": "hologram cloak"
+        },
+        "pocket_data": [
+            {
+                "pocket_type": "MAGAZINE_WELL",
+                "holster": true,
+                "rigid": true,
+                "max_contains_volume": "20 L",
+                "max_contains_weight": "1000 kg",
+                "item_restriction": [
+                    "light_atomic_battery_cell"
+                ],
+                "max_item_length": "1 km"
+            }
+        ]
+    },
+    {
+        "type": "TOOL_ARMOR",
+        "id": "thermal_socks",
+        "copy-from": "thermal_socks",
+        "name": {
+            "str": "pair of thermal electric socks",
+            "str_pl": "pairs of thermal electric socks"
+        },
+        "pocket_data": [
+            {
+                "pocket_type": "MAGAZINE_WELL",
+                "holster": true,
+                "rigid": true,
+                "max_contains_volume": "20 L",
+                "max_contains_weight": "1000 kg",
+                "item_restriction": [
+                    "light_battery_cell",
+                    "light_plus_battery_cell",
+                    "light_minus_battery_cell",
+                    "light_atomic_battery_cell",
+                    "light_minus_atomic_battery_cell",
+                    "light_minus_disposable_cell",
+                    "light_disposable_cell"
+                ],
+                "max_item_length": "1 km"
+            }
+        ]
+    },
+    {
+        "type": "TOOL_ARMOR",
+        "id": "thermal_suit",
+        "copy-from": "thermal_suit",
+        "name": {
+            "str": "thermal electric suit"
+        },
+        "pocket_data": [
+            {
+                "pocket_type": "MAGAZINE_WELL",
+                "holster": true,
+                "rigid": true,
+                "max_contains_volume": "20 L",
+                "max_contains_weight": "1000 kg",
+                "item_restriction": [
+                    "light_plus_battery_cell",
+                    "light_battery_cell",
+                    "light_minus_battery_cell",
+                    "light_atomic_battery_cell",
+                    "light_minus_atomic_battery_cell",
+                    "light_minus_disposable_cell",
+                    "light_disposable_cell"
+                ],
+                "max_item_length": "1 km"
+            }
+        ]
+    },
+    {
+        "type": "TOOL_ARMOR",
+        "id": "thermal_gloves",
+        "copy-from": "thermal_gloves",
+        "name": {
+            "str": "pair of thermal electric gloves",
+            "str_pl": "pairs of thermal electric gloves"
+        },
+        "pocket_data": [
+            {
+                "pocket_type": "MAGAZINE_WELL",
+                "holster": true,
+                "rigid": true,
+                "max_contains_volume": "20 L",
+                "max_contains_weight": "1000 kg",
+                "item_restriction": [
+                    "light_battery_cell",
+                    "light_plus_battery_cell",
+                    "light_minus_battery_cell",
+                    "light_atomic_battery_cell",
+                    "light_minus_atomic_battery_cell",
+                    "light_minus_disposable_cell",
+                    "light_disposable_cell"
+                ],
+                "max_item_length": "1 km"
+            }
+        ]
+    },
+    {
+        "type": "TOOL_ARMOR",
+        "id": "thermal_mask",
+        "copy-from": "thermal_mask",
+        "name": {
+            "str": "thermal electric balaclava"
+        },
+        "pocket_data": [
+            {
+                "pocket_type": "MAGAZINE_WELL",
+                "holster": true,
+                "rigid": true,
+                "max_contains_volume": "20 L",
+                "max_contains_weight": "1000 kg",
+                "item_restriction": [
+                    "light_battery_cell",
+                    "light_plus_battery_cell",
+                    "light_minus_battery_cell",
+                    "light_atomic_battery_cell",
+                    "light_minus_atomic_battery_cell",
+                    "light_minus_disposable_cell",
+                    "light_disposable_cell"
+                ],
+                "max_item_length": "1 km"
+            }
+        ]
+    },
+    {
+        "type": "TOOL_ARMOR",
+        "id": "wearable_light",
+        "copy-from": "wearable_light",
+        "name": {
+            "str": "headlamp"
+        },
+        "pocket_data": [
+            {
+                "pocket_type": "MAGAZINE_WELL",
+                "holster": true,
+                "rigid": true,
+                "max_contains_volume": "20 L",
+                "max_contains_weight": "1000 kg",
+                "item_restriction": [
+                    "light_battery_cell",
+                    "light_plus_battery_cell",
+                    "light_minus_battery_cell",
+                    "light_atomic_battery_cell",
+                    "light_minus_atomic_battery_cell",
+                    "light_minus_disposable_cell",
+                    "light_disposable_cell"
+                ],
+                "max_item_length": "1 km"
+            }
+        ]
+    },
+    {
+        "type": "TOOL_ARMOR",
+        "id": "survivor_light",
+        "copy-from": "survivor_light",
+        "name": {
+            "str": "survivor headlamp"
+        },
+        "pocket_data": [
+            {
+                "pocket_type": "MAGAZINE_WELL",
+                "holster": true,
+                "rigid": true,
+                "max_contains_volume": "20 L",
+                "max_contains_weight": "1000 kg",
+                "item_restriction": [
+                    "light_plus_battery_cell",
+                    "light_battery_cell",
+                    "light_minus_battery_cell",
+                    "light_atomic_battery_cell",
+                    "light_minus_atomic_battery_cell",
+                    "light_minus_disposable_cell",
+                    "light_disposable_cell"
+                ],
+                "max_item_length": "1 km"
+            }
+        ]
+    },
+    {
+        "type": "TOOL_ARMOR",
+        "id": "rm13_armor",
+        "copy-from": "rm13_armor",
+        "name": {
+            "str": "RM13 combat armor"
+        },
+        "pocket_data": [
+            {
+                "pocket_type": "MAGAZINE_WELL",
+                "holster": true,
+                "rigid": true,
+                "max_contains_volume": "20 L",
+                "max_contains_weight": "1000 kg",
+                "item_restriction": [
+                    "heavy_atomic_battery_cell"
+                ],
+                "max_item_length": "1 km"
+            }
+        ]
+    },
+    {
+        "type": "TOOL_ARMOR",
+        "id": "dimensional_anchor",
+        "copy-from": "dimensional_anchor",
+        "name": {
+            "str": "5-point anchor"
+        },
+        "pocket_data": [
+            {
+                "pocket_type": "MAGAZINE_WELL",
+                "holster": true,
+                "rigid": true,
+                "max_contains_volume": "20 L",
+                "max_contains_weight": "1000 kg",
+                "item_restriction": [
+                    "medium_atomic_battery_cell"
+                ],
+                "max_item_length": "1 km"
+            }
+        ]
+    },
+    {
+        "type": "TOOL_ARMOR",
+        "id": "phase_immersion_suit",
+        "copy-from": "phase_immersion_suit",
+        "name": {
+            "str": "phase immersion suit"
+        },
+        "pocket_data": [
+            {
+                "pocket_type": "MAGAZINE_WELL",
+                "holster": true,
+                "rigid": true,
+                "max_contains_volume": "20 L",
+                "max_contains_weight": "1000 kg",
+                "item_restriction": [
+                    "heavy_atomic_battery_cell"
+                ],
+                "max_item_length": "1 km"
+            }
+        ]
+    },
+    {
+        "type": "TOOL_ARMOR",
+        "id": "rebreather",
+        "copy-from": "rebreather",
+        "name": {
+            "str": "rebreather mask"
+        },
+        "pocket_data": [
+            {
+                "pocket_type": "MAGAZINE",
+                "rigid": true,
+                "ammo_restriction": {
+                    "rebreather_filter": 60
+                },
+                "max_contains_weight": "1000 kg",
+                "max_item_length": "1 km"
+            }
+        ]
+    },
+    {
+        "type": "TOOL_ARMOR",
+        "id": "rebreather_xl",
+        "copy-from": "rebreather_xl",
+        "name": {
+            "str": "XL rebreather mask"
+        },
+        "pocket_data": [
+            {
+                "pocket_type": "MAGAZINE",
+                "rigid": true,
+                "ammo_restriction": {
+                    "rebreather_filter": 60
+                },
+                "max_contains_weight": "1000 kg",
+                "max_item_length": "1 km"
+            }
+        ]
+    },
+    {
+        "type": "TOOL_ARMOR",
+        "id": "mask_filter",
+        "copy-from": "mask_filter",
+        "name": {
+            "str": "filter mask"
+        },
+        "pocket_data": [
+            {
+                "pocket_type": "MAGAZINE",
+                "rigid": true,
+                "ammo_restriction": {
+                    "gasfilter_s": 100
+                },
+                "max_contains_weight": "1000 kg",
+                "max_item_length": "1 km"
+            }
+        ]
+    },
+    {
+        "type": "TOOL_ARMOR",
+        "id": "mask_gas",
+        "copy-from": "mask_gas",
+        "name": {
+            "str": "gas mask"
+        },
+        "pocket_data": [
+            {
+                "pocket_type": "MAGAZINE",
+                "rigid": true,
+                "ammo_restriction": {
+                    "gasfilter_m": 100
+                },
+                "max_contains_weight": "1000 kg",
+                "max_item_length": "1 km"
+            }
+        ]
+    },
+    {
+        "type": "TOOL_ARMOR",
+        "id": "mask_gas_xl",
+        "copy-from": "mask_gas_xl",
+        "name": {
+            "str": "XL gas mask"
+        },
+        "pocket_data": [
+            {
+                "pocket_type": "MAGAZINE",
+                "rigid": true,
+                "ammo_restriction": {
+                    "gasfilter_m": 100
+                },
+                "max_contains_weight": "1000 kg",
+                "max_item_length": "1 km"
+            }
+        ]
+    },
+    {
+        "type": "TOOL_ARMOR",
+        "id": "mask_fsurvivor",
+        "copy-from": "mask_fsurvivor",
+        "name": {
+            "str": "survivor firemask"
+        },
+        "pocket_data": [
+            {
+                "pocket_type": "MAGAZINE",
+                "rigid": true,
+                "ammo_restriction": {
+                    "gasfilter_m": 100
+                },
+                "max_contains_weight": "1000 kg",
+                "max_item_length": "1 km"
+            }
+        ]
+    },
+    {
+        "type": "TOOL_ARMOR",
+        "id": "mask_fsurvivorxl",
+        "copy-from": "mask_fsurvivorxl",
+        "name": {
+            "str": "XL survivor firemask"
+        },
+        "pocket_data": [
+            {
+                "pocket_type": "MAGAZINE",
+                "rigid": true,
+                "ammo_restriction": {
+                    "gasfilter_m": 100
+                },
+                "max_contains_weight": "1000 kg",
+                "max_item_length": "1 km"
+            }
+        ]
+    },
+    {
+        "type": "TOOL_ARMOR",
+        "id": "mask_bunker",
+        "copy-from": "mask_bunker",
+        "name": {
+            "str": "firefighter PBA mask"
+        },
+        "pocket_data": [
+            {
+                "pocket_type": "MAGAZINE",
+                "rigid": true,
+                "ammo_restriction": {
+                    "gasfilter_m": 100
+                },
+                "max_contains_weight": "1000 kg",
+                "max_item_length": "1 km"
+            }
+        ]
+    },
+    {
+        "type": "TOOL_ARMOR",
+        "id": "mask_hsurvivor",
+        "copy-from": "mask_hsurvivor",
+        "name": {
+            "str": "heavy survivor mask"
+        },
+        "pocket_data": [
+            {
+                "pocket_type": "MAGAZINE",
+                "rigid": true,
+                "ammo_restriction": {
+                    "gasfilter_m": 100
+                },
+                "max_contains_weight": "1000 kg",
+                "max_item_length": "1 km"
+            }
+        ]
+    },
+    {
+        "type": "TOOL_ARMOR",
+        "id": "mask_lsurvivor",
+        "copy-from": "mask_lsurvivor",
+        "name": {
+            "str": "light survivor mask"
+        },
+        "pocket_data": [
+            {
+                "pocket_type": "MAGAZINE",
+                "rigid": true,
+                "ammo_restriction": {
+                    "gasfilter_m": 100
+                },
+                "max_contains_weight": "1000 kg",
+                "max_item_length": "1 km"
+            }
+        ]
+    },
+    {
+        "type": "TOOL_ARMOR",
+        "id": "mask_survivor",
+        "copy-from": "mask_survivor",
+        "name": {
+            "str": "survivor mask"
+        },
+        "pocket_data": [
+            {
+                "pocket_type": "MAGAZINE",
+                "rigid": true,
+                "ammo_restriction": {
+                    "gasfilter_m": 100
+                },
+                "max_contains_weight": "1000 kg",
+                "max_item_length": "1 km"
+            }
+        ]
+    },
+    {
+        "type": "TOOL_ARMOR",
+        "id": "mask_survivorxl",
+        "copy-from": "mask_survivorxl",
+        "name": {
+            "str": "XL survivor mask"
+        },
+        "pocket_data": [
+            {
+                "pocket_type": "MAGAZINE",
+                "rigid": true,
+                "ammo_restriction": {
+                    "gasfilter_m": 100
+                },
+                "max_contains_weight": "1000 kg",
+                "max_item_length": "1 km"
+            }
+        ]
+    },
+    {
+        "type": "TOOL_ARMOR",
+        "id": "mask_wsurvivor",
+        "copy-from": "mask_wsurvivor",
+        "name": {
+            "str": "winter survivor mask"
+        },
+        "pocket_data": [
+            {
+                "pocket_type": "MAGAZINE",
+                "rigid": true,
+                "ammo_restriction": {
+                    "gasfilter_m": 100
+                },
+                "max_contains_weight": "1000 kg",
+                "max_item_length": "1 km"
+            }
+        ]
+    },
+    {
+        "type": "TOOL_ARMOR",
+        "id": "mask_wsurvivorxl",
+        "copy-from": "mask_wsurvivorxl",
+        "name": {
+            "str": "XL winter survivor mask"
+        },
+        "pocket_data": [
+            {
+                "pocket_type": "MAGAZINE",
+                "rigid": true,
+                "ammo_restriction": {
+                    "gasfilter_m": 100
+                },
+                "max_contains_weight": "1000 kg",
+                "max_item_length": "1 km"
+            }
+        ]
+    },
+    {
+        "type": "TOOL_ARMOR",
+        "id": "goggles_nv",
+        "copy-from": "goggles_nv",
+        "name": {
+            "str": "pair of light amp goggles",
+            "str_pl": "pairs of light amp goggles"
+        },
+        "pocket_data": [
+            {
+                "pocket_type": "MAGAZINE_WELL",
+                "holster": true,
+                "rigid": true,
+                "max_contains_volume": "20 L",
+                "max_contains_weight": "1000 kg",
+                "item_restriction": [
+                    "light_plus_battery_cell",
+                    "light_battery_cell",
+                    "light_minus_battery_cell",
+                    "light_atomic_battery_cell",
+                    "light_minus_atomic_battery_cell",
+                    "light_minus_disposable_cell",
+                    "light_disposable_cell"
+                ],
+                "max_item_length": "1 km"
+            }
+        ]
+    },
+    {
+        "type": "TOOL_ARMOR",
+        "id": "goggles_ir",
+        "copy-from": "goggles_ir",
+        "name": {
+            "str": "pair of infrared goggles",
+            "str_pl": "pairs of infrared goggles"
+        },
+        "pocket_data": [
+            {
+                "pocket_type": "MAGAZINE_WELL",
+                "holster": true,
+                "rigid": true,
+                "max_contains_volume": "20 L",
+                "max_contains_weight": "1000 kg",
+                "item_restriction": [
+                    "light_plus_battery_cell",
+                    "light_battery_cell",
+                    "light_minus_battery_cell",
+                    "light_atomic_battery_cell",
+                    "light_minus_atomic_battery_cell",
+                    "light_minus_disposable_cell",
+                    "light_disposable_cell"
+                ],
+                "max_item_length": "1 km"
+            }
+        ]
+    },
+    {
+        "type": "TOOL_ARMOR",
+        "id": "wearable_rx12",
+        "copy-from": "wearable_rx12",
+        "name": {
+            "str": "wearable RX12 jet injector"
+        },
+        "pocket_data": [
+            {
+                "pocket_type": "MAGAZINE",
+                "rigid": true,
+                "ammo_restriction": {
+                    "ampoule": 2
+                },
+                "max_contains_weight": "1000 kg",
+                "max_item_length": "1 km"
+            }
+        ]
+    },
+    {
+        "type": "TOOL_ARMOR",
+        "id": "rx11_stimpack",
+        "copy-from": "rx11_stimpack",
+        "name": {
+            "str_sp": "RX11 stimulant delivery system"
+        },
+        "pocket_data": [
+            {
+                "pocket_type": "MAGAZINE",
+                "rigid": true,
+                "ammo_restriction": {
+                    "stimpack_ammo": 5
+                },
+                "max_contains_weight": "1000 kg",
+                "max_item_length": "1 km"
+            }
+        ]
+    },
+    {
+        "type": "TOOL_ARMOR",
+        "id": "mask_h20survivor",
+        "copy-from": "mask_h20survivor",
+        "name": {
+            "str": "survivor divemask"
+        },
+        "pocket_data": [
+            {
+                "pocket_type": "MAGAZINE",
+                "rigid": true,
+                "ammo_restriction": {
+                    "rebreather_filter": 120
+                },
+                "max_contains_weight": "1000 kg",
+                "max_item_length": "1 km"
+            }
+        ]
+    },
+    {
+        "type": "TOOL_ARMOR",
+        "id": "mask_h20survivorxl",
+        "copy-from": "mask_h20survivorxl",
+        "name": {
+            "str": "XL survivor divemask"
+        },
+        "pocket_data": [
+            {
+                "pocket_type": "MAGAZINE",
+                "rigid": true,
+                "ammo_restriction": {
+                    "rebreather_filter": 120
+                },
+                "max_contains_weight": "1000 kg",
+                "max_item_length": "1 km"
+            }
+        ]
+    },
+    {
+        "type": "TOOL_ARMOR",
+        "id": "rad_monitor",
+        "copy-from": "rad_monitor",
+        "name": {
+            "str": "radiation biomonitor"
+        },
+        "pocket_data": [
+            {
+                "pocket_type": "MAGAZINE_WELL",
+                "holster": true,
+                "rigid": true,
+                "max_contains_volume": "20 L",
+                "max_contains_weight": "1000 kg",
+                "item_restriction": [
+                    "light_minus_battery_cell",
+                    "light_minus_atomic_battery_cell"
+                ],
+                "max_item_length": "1 km"
+            }
+        ]
+    },
+    {
+        "type": "TOOL_ARMOR",
+        "id": "thermal_outfit",
+        "copy-from": "thermal_outfit",
+        "name": {
+            "str": "thermal electric outfit"
+        },
+        "pocket_data": [
+            {
+                "pocket_type": "MAGAZINE_WELL",
+                "holster": true,
+                "rigid": true,
+                "max_contains_volume": "20 L",
+                "max_contains_weight": "1000 kg",
+                "item_restriction": [
+                    "medium_battery_cell",
+                    "medium_plus_battery_cell",
+                    "medium_atomic_battery_cell",
+                    "medium_disposable_cell"
+                ],
+                "max_item_length": "1 km"
+            }
+        ]
+    },
+    {
+        "type": "TOOL_ARMOR",
+        "id": "powered_earmuffs",
+        "copy-from": "powered_earmuffs",
+        "name": {
+            "str_sp": "shooter's earmuffs"
+        },
+        "pocket_data": [
+            {
+                "pocket_type": "MAGAZINE_WELL",
+                "holster": true,
+                "rigid": true,
+                "max_contains_volume": "20 L",
+                "max_contains_weight": "1000 kg",
+                "item_restriction": [
+                    "light_plus_battery_cell",
+                    "light_battery_cell",
+                    "light_minus_battery_cell",
+                    "light_atomic_battery_cell",
+                    "light_minus_atomic_battery_cell",
+                    "light_minus_disposable_cell",
+                    "light_disposable_cell"
+                ],
+                "max_item_length": "1 km"
+            }
+        ]
+    },
+    {
+        "type": "TOOL_ARMOR",
+        "id": "powered_earmuffs_on",
+        "copy-from": "powered_earmuffs_on",
+        "name": {
+            "str_sp": "shooter's earmuffs"
+        },
+        "pocket_data": [
+            {
+                "pocket_type": "MAGAZINE_WELL",
+                "holster": true,
+                "rigid": true,
+                "max_contains_volume": "20 L",
+                "max_contains_weight": "1000 kg",
+                "item_restriction": [
+                    "light_plus_battery_cell",
+                    "light_battery_cell",
+                    "light_minus_battery_cell",
+                    "light_atomic_battery_cell",
+                    "light_minus_atomic_battery_cell",
+                    "light_minus_disposable_cell",
+                    "light_disposable_cell"
+                ],
+                "max_item_length": "1 km"
+            }
+        ]
+    },
+    {
+        "type": "TOOL_ARMOR",
+        "id": "scuba_tank",
+        "copy-from": "scuba_tank",
+        "name": {
+            "str": "scuba tank"
+        },
+        "pocket_data": [
+            {
+                "pocket_type": "MAGAZINE",
+                "airtight": true,
+                "rigid": true,
+                "watertight": true,
+                "ammo_restriction": {
+                    "nitrox": 60
+                },
+                "max_contains_weight": "1000 kg",
+                "max_item_length": "1 km"
+            }
+        ]
+    },
+    {
+        "type": "TOOL_ARMOR",
+        "id": "scuba_tank_on",
+        "copy-from": "scuba_tank_on",
+        "name": {
+            "str": "scuba tank (on)",
+            "str_pl": "scuba tanks (on)"
+        },
+        "pocket_data": [
+            {
+                "pocket_type": "MAGAZINE",
+                "airtight": true,
+                "rigid": true,
+                "watertight": true,
+                "ammo_restriction": {
+                    "nitrox": 60
+                },
+                "max_contains_weight": "1000 kg",
+                "max_item_length": "1 km"
+            }
+        ]
+    },
+    {
+        "type": "TOOL_ARMOR",
+        "id": "small_scuba_tank",
+        "copy-from": "small_scuba_tank",
+        "name": {
+            "str": "small scuba tank"
+        },
+        "pocket_data": [
+            {
+                "pocket_type": "MAGAZINE",
+                "airtight": true,
+                "rigid": true,
+                "watertight": true,
+                "ammo_restriction": {
+                    "nitrox": 20
+                },
+                "max_contains_weight": "1000 kg",
+                "max_item_length": "1 km"
+            }
+        ]
+    },
+    {
+        "type": "TOOL_ARMOR",
+        "id": "small_scuba_tank_on",
+        "copy-from": "small_scuba_tank_on",
+        "name": {
+            "str": "small scuba tank (on)",
+            "str_pl": "small scuba tanks (on)"
+        },
+        "pocket_data": [
+            {
+                "pocket_type": "MAGAZINE",
+                "airtight": true,
+                "rigid": true,
+                "watertight": true,
+                "ammo_restriction": {
+                    "nitrox": 20
+                },
+                "max_contains_weight": "1000 kg",
+                "max_item_length": "1 km"
+            }
+        ]
+    },
+    {
+        "type": "TOOL_ARMOR",
+        "id": "electric_blanket",
+        "copy-from": "electric_blanket",
+        "name": {
+            "str": "electric blanket"
+        },
+        "pocket_data": [
+            {
+                "pocket_type": "MAGAZINE_WELL",
+                "holster": true,
+                "rigid": true,
+                "max_contains_volume": "20 L",
+                "max_contains_weight": "1000 kg",
+                "item_restriction": [
+                    "medium_battery_cell",
+                    "medium_plus_battery_cell",
+                    "medium_atomic_battery_cell",
+                    "medium_disposable_cell"
+                ],
+                "max_item_length": "1 km"
+            }
+        ]
+    },
+    {
+        "type": "TOOL_ARMOR",
+        "id": "foodperson_mask",
+        "copy-from": "foodperson_mask",
+        "name": {
+            "str": "Foodperson mask"
+        },
+        "pocket_data": [
+            {
+                "pocket_type": "MAGAZINE_WELL",
+                "holster": true,
+                "rigid": true,
+                "max_contains_volume": "20 L",
+                "max_contains_weight": "1000 kg",
+                "item_restriction": [
+                    "medium_battery_cell",
+                    "medium_plus_battery_cell",
+                    "medium_atomic_battery_cell",
+                    "medium_disposable_cell"
+                ],
+                "max_item_length": "1 km"
+            }
+        ]
+    }
+]

--- a/Kenan-Modpack/easy_containers/items/vehicle/battery.json
+++ b/Kenan-Modpack/easy_containers/items/vehicle/battery.json
@@ -1,0 +1,142 @@
+[
+    {
+        "type": "MAGAZINE",
+        "id": "battery_car",
+        "copy-from": "battery_car",
+        "name": {
+            "str": "car battery",
+            "str_pl": "car batteries"
+        },
+        "pocket_data": [
+            {
+                "pocket_type": "MAGAZINE",
+                "rigid": true,
+                "ammo_restriction": {
+                    "battery": 2500
+                },
+                "max_contains_weight": "1000 kg",
+                "max_item_length": "1 km"
+            }
+        ]
+    },
+    {
+        "type": "MAGAZINE",
+        "id": "battery_motorbike",
+        "copy-from": "battery_motorbike",
+        "name": {
+            "str": "motorbike battery",
+            "str_pl": "motorbike batteries"
+        },
+        "pocket_data": [
+            {
+                "pocket_type": "MAGAZINE",
+                "rigid": true,
+                "ammo_restriction": {
+                    "battery": 500
+                },
+                "max_contains_weight": "1000 kg",
+                "max_item_length": "1 km"
+            }
+        ]
+    },
+    {
+        "type": "MAGAZINE",
+        "id": "battery_motorbike_small",
+        "copy-from": "battery_motorbike_small",
+        "name": {
+            "str": "small motorbike battery",
+            "str_pl": "small motorbike batteries"
+        },
+        "pocket_data": [
+            {
+                "pocket_type": "MAGAZINE",
+                "rigid": true,
+                "ammo_restriction": {
+                    "battery": 150
+                },
+                "max_contains_weight": "1000 kg",
+                "max_item_length": "1 km"
+            }
+        ]
+    },
+    {
+        "type": "MAGAZINE",
+        "id": "large_storage_battery",
+        "copy-from": "large_storage_battery",
+        "name": {
+            "str": "large storage battery",
+            "str_pl": "large storage batteries"
+        },
+        "pocket_data": [
+            {
+                "pocket_type": "MAGAZINE",
+                "rigid": true,
+                "ammo_restriction": {
+                    "battery": 80000
+                },
+                "max_contains_weight": "1000 kg",
+                "max_item_length": "1 km"
+            }
+        ]
+    },
+    {
+        "type": "MAGAZINE",
+        "id": "medium_storage_battery",
+        "copy-from": "medium_storage_battery",
+        "name": {
+            "str": "medium storage battery",
+            "str_pl": "medium storage batteries"
+        },
+        "pocket_data": [
+            {
+                "pocket_type": "MAGAZINE",
+                "rigid": true,
+                "ammo_restriction": {
+                    "battery": 7000
+                },
+                "max_contains_weight": "1000 kg",
+                "max_item_length": "1 km"
+            }
+        ]
+    },
+    {
+        "type": "MAGAZINE",
+        "id": "small_storage_battery",
+        "copy-from": "small_storage_battery",
+        "name": {
+            "str": "small storage battery",
+            "str_pl": "small storage batteries"
+        },
+        "pocket_data": [
+            {
+                "pocket_type": "MAGAZINE",
+                "rigid": true,
+                "ammo_restriction": {
+                    "battery": 500
+                },
+                "max_contains_weight": "1000 kg",
+                "max_item_length": "1 km"
+            }
+        ]
+    },
+    {
+        "type": "MAGAZINE",
+        "id": "storage_battery",
+        "copy-from": "storage_battery",
+        "name": {
+            "str": "storage battery",
+            "str_pl": "storage batteries"
+        },
+        "pocket_data": [
+            {
+                "pocket_type": "MAGAZINE",
+                "rigid": true,
+                "ammo_restriction": {
+                    "battery": 40000
+                },
+                "max_contains_weight": "1000 kg",
+                "max_item_length": "1 km"
+            }
+        ]
+    }
+]

--- a/Kenan-Modpack/easy_containers/items/vehicle/fuel_storage.json
+++ b/Kenan-Modpack/easy_containers/items/vehicle/fuel_storage.json
@@ -1,0 +1,20 @@
+[
+    {
+        "type": "MAGAZINE",
+        "id": "fuel_bunker",
+        "copy-from": "fuel_bunker",
+        "name": {
+            "str": "fuel bunker"
+        },
+        "pocket_data": [
+            {
+                "pocket_type": "MAGAZINE",
+                "ammo_restriction": {
+                    "charcoal": 2000
+                },
+                "max_contains_weight": "1000 kg",
+                "max_item_length": "1 km"
+            }
+        ]
+    }
+]

--- a/Kenan-Modpack/easy_containers/items/vehicle/utilities.json
+++ b/Kenan-Modpack/easy_containers/items/vehicle/utilities.json
@@ -1,0 +1,39 @@
+[
+    {
+        "type": "TOOL",
+        "id": "minireactor",
+        "copy-from": "minireactor",
+        "name": {
+            "str": "minireactor"
+        },
+        "pocket_data": [
+            {
+                "pocket_type": "MAGAZINE",
+                "ammo_restriction": {
+                    "plutonium": 10000
+                },
+                "rigid": true,
+                "max_contains_weight": "1000 kg",
+                "max_item_length": "1 km"
+            }
+        ]
+    },
+    {
+        "type": "GENERIC",
+        "id": "fridgetank",
+        "copy-from": "fridgetank",
+        "name": {
+            "str": "refrigerated tank"
+        },
+        "pocket_data": [
+            {
+                "pocket_type": "CONTAINER",
+                "rigid": true,
+                "watertight": true,
+                "max_contains_volume": "60 L",
+                "max_contains_weight": "1000 kg",
+                "max_item_length": "1 km"
+            }
+        ]
+    }
+]

--- a/Kenan-Modpack/easy_containers/modinfo.json
+++ b/Kenan-Modpack/easy_containers/modinfo.json
@@ -1,0 +1,11 @@
+[
+  {
+    "type": "MOD_INFO",
+    "id": "sch_easy_containers",
+    "name": "Easy Containers",
+    "authors": [ "Saicchi" ],
+    "description": "Makes containers behave more like 0.E containers.  Single pocket with infinite item length and infinite weight limit.",
+    "category": "rebalance",
+    "dependencies": [ "dda" ]
+  }
+]


### PR DESCRIPTION
#### Purpose of change
I often hear players complain about the pocket system, hopefully they won't anymore with this mod.

#### Describe the solution
Merge all pockets inside a container, increase their item length to 1 km and their weight capacity to 1000 kg. That way they behave more like 0.E containers, which don't have the weight capacity nor item length.

#### Describe alternatives you've considered
Double or triple item length instead of setting it to 1 km.

#### Testing
Tested with several items and didn't find any problems. Please warn me if you find any.

#### Additional context
I automated the process with a script, I don't think there are any items which need to be edited manually but it could happen.

Container type pockets which did not have any special features, like item restrictions, multipliers, watertight or airtight and rigid were deemed as unique, and were not merged, their item length and weight limit were still raised.

The number of additions is very high, sorry! But they are only a copy of the item with the pocket changes. If its preferred, I could split it into more PRs.

