### PR TITLE
 Add Easy Proficiencies: Removing proficiencies learn time

### DIFF
--- a/Kenan-Modpack/easy_proficiency/modinfo.json
+++ b/Kenan-Modpack/easy_proficiency/modinfo.json
@@ -1,0 +1,11 @@
+[
+  {
+    "type": "MOD_INFO",
+    "id": "sch_easy_proficiency",
+    "name": "Easy Proficiency",
+    "authors": [ "Saicchi" ],
+    "description": "Makes proficiencies in the base game instantaneous to learn.  Proficiency requirements still apply.",
+    "category": "rebalance",
+    "dependencies": [ "dda" ]
+  }
+]

--- a/Kenan-Modpack/easy_proficiency/proficiencies/chemistry.json
+++ b/Kenan-Modpack/easy_proficiency/proficiencies/chemistry.json
@@ -1,0 +1,8 @@
+[
+    {
+        "type": "proficiency",
+        "id": "prof_metallurgy",
+        "copy-from": "prof_metallurgy",
+        "time_to_learn": "1 s"
+    }
+]

--- a/Kenan-Modpack/easy_proficiency/proficiencies/electronics.json
+++ b/Kenan-Modpack/easy_proficiency/proficiencies/electronics.json
@@ -1,0 +1,20 @@
+[
+    {
+        "type": "proficiency",
+        "id": "prof_elec_soldering",
+        "copy-from": "prof_elec_soldering",
+        "time_to_learn": "1 s"
+    },
+    {
+        "type": "proficiency",
+        "id": "prof_electromagnetics",
+        "copy-from": "prof_electromagnetics",
+        "time_to_learn": "1 s"
+    },
+    {
+        "type": "proficiency",
+        "id": "prof_shock_weapons",
+        "copy-from": "prof_shock_weapons",
+        "time_to_learn": "1 s"
+    }
+]

--- a/Kenan-Modpack/easy_proficiency/proficiencies/gunsmithing.json
+++ b/Kenan-Modpack/easy_proficiency/proficiencies/gunsmithing.json
@@ -1,0 +1,32 @@
+[
+    {
+        "type": "proficiency",
+        "id": "prof_gunsmithing_basic",
+        "copy-from": "prof_gunsmithing_basic",
+        "time_to_learn": "1 s"
+    },
+    {
+        "type": "proficiency",
+        "id": "prof_gunsmithing_improv",
+        "copy-from": "prof_gunsmithing_improv",
+        "time_to_learn": "1 s"
+    },
+    {
+        "type": "proficiency",
+        "id": "prof_gunsmithing_antique",
+        "copy-from": "prof_gunsmithing_antique",
+        "time_to_learn": "1 s"
+    },
+    {
+        "type": "proficiency",
+        "id": "prof_gunsmithing_spring",
+        "copy-from": "prof_gunsmithing_spring",
+        "time_to_learn": "1 s"
+    },
+    {
+        "type": "proficiency",
+        "id": "prof_gunsmithing_revolver",
+        "copy-from": "prof_gunsmithing_revolver",
+        "time_to_learn": "1 s"
+    }
+]

--- a/Kenan-Modpack/easy_proficiency/proficiencies/metalwork.json
+++ b/Kenan-Modpack/easy_proficiency/proficiencies/metalwork.json
@@ -1,0 +1,56 @@
+[
+    {
+        "type": "proficiency",
+        "id": "prof_metalworking",
+        "copy-from": "prof_metalworking",
+        "time_to_learn": "1 s"
+    },
+    {
+        "type": "proficiency",
+        "id": "prof_welding_basic",
+        "copy-from": "prof_welding_basic",
+        "time_to_learn": "1 s"
+    },
+    {
+        "type": "proficiency",
+        "id": "prof_welding",
+        "copy-from": "prof_welding",
+        "time_to_learn": "1 s"
+    },
+    {
+        "type": "proficiency",
+        "id": "prof_blacksmithing",
+        "copy-from": "prof_blacksmithing",
+        "time_to_learn": "1 s"
+    },
+    {
+        "type": "proficiency",
+        "id": "prof_redsmithing",
+        "copy-from": "prof_redsmithing",
+        "time_to_learn": "1 s"
+    },
+    {
+        "type": "proficiency",
+        "id": "prof_fine_metalsmithing",
+        "copy-from": "prof_fine_metalsmithing",
+        "time_to_learn": "1 s"
+    },
+    {
+        "type": "proficiency",
+        "id": "prof_armorsmithing",
+        "copy-from": "prof_armorsmithing",
+        "time_to_learn": "1 s"
+    },
+    {
+        "type": "proficiency",
+        "id": "prof_bladesmith",
+        "copy-from": "prof_bladesmith",
+        "time_to_learn": "1 s"
+    },
+    {
+        "type": "proficiency",
+        "id": "prof_toolsmithing",
+        "copy-from": "prof_toolsmithing",
+        "time_to_learn": "1 s"
+    }
+]

--- a/Kenan-Modpack/easy_proficiency/proficiencies/misc.json
+++ b/Kenan-Modpack/easy_proficiency/proficiencies/misc.json
@@ -1,0 +1,74 @@
+[
+    {
+        "type": "proficiency",
+        "id": "prof_knapping",
+        "copy-from": "prof_knapping",
+        "time_to_learn": "1 s"
+    },
+    {
+        "type": "proficiency",
+        "id": "prof_knapping_speed",
+        "copy-from": "prof_knapping_speed",
+        "time_to_learn": "1 s"
+    },
+    {
+        "type": "proficiency",
+        "id": "prof_glassblowing",
+        "copy-from": "prof_glassblowing",
+        "time_to_learn": "1 s"
+    },
+    {
+        "type": "proficiency",
+        "id": "prof_plumbing",
+        "copy-from": "prof_plumbing",
+        "time_to_learn": "1 s"
+    },
+    {
+        "type": "proficiency",
+        "id": "prof_pottery",
+        "copy-from": "prof_pottery",
+        "time_to_learn": "1 s"
+    },
+    {
+        "type": "proficiency",
+        "id": "prof_bowyery",
+        "copy-from": "prof_bowyery",
+        "time_to_learn": "1 s"
+    },
+    {
+        "type": "proficiency",
+        "id": "prof_fletching",
+        "copy-from": "prof_fletching",
+        "time_to_learn": "1 s"
+    },
+    {
+        "type": "proficiency",
+        "id": "prof_basketweaving",
+        "copy-from": "prof_basketweaving",
+        "time_to_learn": "1 s"
+    },
+    {
+        "type": "proficiency",
+        "id": "prof_pottery_glazing",
+        "copy-from": "prof_pottery_glazing",
+        "time_to_learn": "1 s"
+    },
+    {
+        "type": "proficiency",
+        "id": "prof_plasticworking",
+        "copy-from": "prof_plasticworking",
+        "time_to_learn": "1 s"
+    },
+    {
+        "type": "proficiency",
+        "id": "prof_carving",
+        "copy-from": "prof_carving",
+        "time_to_learn": "1 s"
+    },
+    {
+        "type": "proficiency",
+        "id": "prof_gem_setting",
+        "copy-from": "prof_gem_setting",
+        "time_to_learn": "1 s"
+    }
+]

--- a/Kenan-Modpack/easy_proficiency/proficiencies/tailoring.json
+++ b/Kenan-Modpack/easy_proficiency/proficiencies/tailoring.json
@@ -1,0 +1,98 @@
+[
+    {
+        "type": "proficiency",
+        "id": "prof_articulation",
+        "copy-from": "prof_articulation",
+        "time_to_learn": "1 s"
+    },
+    {
+        "type": "proficiency",
+        "id": "prof_closures",
+        "copy-from": "prof_closures",
+        "time_to_learn": "1 s"
+    },
+    {
+        "type": "proficiency",
+        "id": "prof_closures_waterproofing",
+        "copy-from": "prof_closures_waterproofing",
+        "time_to_learn": "1 s"
+    },
+    {
+        "type": "proficiency",
+        "id": "prof_elastics",
+        "copy-from": "prof_elastics",
+        "time_to_learn": "1 s"
+    },
+    {
+        "type": "proficiency",
+        "id": "prof_cobbling",
+        "copy-from": "prof_cobbling",
+        "time_to_learn": "1 s"
+    },
+    {
+        "type": "proficiency",
+        "id": "prof_spinning",
+        "copy-from": "prof_spinning",
+        "time_to_learn": "1 s"
+    },
+    {
+        "type": "proficiency",
+        "id": "prof_weaving",
+        "copy-from": "prof_weaving",
+        "time_to_learn": "1 s"
+    },
+    {
+        "type": "proficiency",
+        "id": "prof_millinery",
+        "copy-from": "prof_millinery",
+        "time_to_learn": "1 s"
+    },
+    {
+        "type": "proficiency",
+        "id": "prof_knitting",
+        "copy-from": "prof_knitting",
+        "time_to_learn": "1 s"
+    },
+    {
+        "type": "proficiency",
+        "id": "prof_knitting_speed",
+        "copy-from": "prof_knitting_speed",
+        "time_to_learn": "1 s"
+    },
+    {
+        "type": "proficiency",
+        "id": "prof_leatherworking_basic",
+        "copy-from": "prof_leatherworking_basic",
+        "time_to_learn": "1 s"
+    },
+    {
+        "type": "proficiency",
+        "id": "prof_leatherworking",
+        "copy-from": "prof_leatherworking",
+        "time_to_learn": "1 s"
+    },
+    {
+        "type": "proficiency",
+        "id": "prof_furriery",
+        "copy-from": "prof_furriery",
+        "time_to_learn": "1 s"
+    },
+    {
+        "type": "proficiency",
+        "id": "prof_chitinworking",
+        "copy-from": "prof_chitinworking",
+        "time_to_learn": "1 s"
+    },
+    {
+        "type": "proficiency",
+        "id": "prof_chain_armour",
+        "copy-from": "prof_chain_armour",
+        "time_to_learn": "1 s"
+    },
+    {
+        "type": "proficiency",
+        "id": "prof_polymerworking",
+        "copy-from": "prof_polymerworking",
+        "time_to_learn": "1 s"
+    }
+]

--- a/Kenan-Modpack/easy_proficiency/proficiencies/traps.json
+++ b/Kenan-Modpack/easy_proficiency/proficiencies/traps.json
@@ -1,0 +1,44 @@
+[
+    {
+        "type": "proficiency",
+        "id": "prof_lockpicking",
+        "copy-from": "prof_lockpicking",
+        "time_to_learn": "1 s"
+    },
+    {
+        "type": "proficiency",
+        "id": "prof_lockpicking_expert",
+        "copy-from": "prof_lockpicking_expert",
+        "time_to_learn": "1 s"
+    },
+    {
+        "type": "proficiency",
+        "id": "prof_safecracking",
+        "copy-from": "prof_safecracking",
+        "time_to_learn": "1 s"
+    },
+    {
+        "type": "proficiency",
+        "id": "prof_traps",
+        "copy-from": "prof_traps",
+        "time_to_learn": "1 s"
+    },
+    {
+        "type": "proficiency",
+        "id": "prof_trapsetting",
+        "copy-from": "prof_trapsetting",
+        "time_to_learn": "1 s"
+    },
+    {
+        "type": "proficiency",
+        "id": "prof_disarming",
+        "copy-from": "prof_disarming",
+        "time_to_learn": "1 s"
+    },
+    {
+        "type": "proficiency",
+        "id": "prof_spotting",
+        "copy-from": "prof_spotting",
+        "time_to_learn": "1 s"
+    }
+]

--- a/Kenan-Modpack/easy_proficiency/proficiencies/wilderness.json
+++ b/Kenan-Modpack/easy_proficiency/proficiencies/wilderness.json
@@ -1,0 +1,26 @@
+[
+    {
+        "type": "proficiency",
+        "id": "prof_fibers",
+        "copy-from": "prof_fibers",
+        "time_to_learn": "1 s"
+    },
+    {
+        "type": "proficiency",
+        "id": "prof_fibers_rope",
+        "copy-from": "prof_fibers_rope",
+        "time_to_learn": "1 s"
+    },
+    {
+        "type": "proficiency",
+        "id": "prof_tanning_basic",
+        "copy-from": "prof_tanning_basic",
+        "time_to_learn": "1 s"
+    },
+    {
+        "type": "proficiency",
+        "id": "prof_tanning",
+        "copy-from": "prof_tanning",
+        "time_to_learn": "1 s"
+    }
+]

--- a/Kenan-Modpack/easy_proficiency/proficiencies/woodworking.json
+++ b/Kenan-Modpack/easy_proficiency/proficiencies/woodworking.json
@@ -1,0 +1,8 @@
+[
+    {
+        "type": "proficiency",
+        "id": "prof_carpentry_basic",
+        "copy-from": "prof_carpentry_basic",
+        "time_to_learn": "1 s"
+    }
+]


### PR DESCRIPTION
#### Purpose of change
There seems to be a lot of players who hate the proficiency system that was added.

#### Describe the solution
Reduce all the proficiencies that can be learned learn time to 1 second. The player will get them instantly as long as they have the requirements.

#### Describe alternatives you've considered
None

#### Testing
Tested crafting several items and doing activities that give proficiency.

#### Additional context
I automated the process with a script, I don't think there are any proficiencies which need to be edited manually but it could happen.
