### PR TITLE
[PK] Give Homunculus description

### DIFF
--- a/Kenan-Modpack/PKs_Rebalancing/monsters/cult.json
+++ b/Kenan-Modpack/PKs_Rebalancing/monsters/cult.json
@@ -98,6 +98,7 @@
     "id": "mon_homunculus",
     "type": "MONSTER",
     "name": { "str": "homunculus", "str_pl": "homunculi" },
+    "description": "A pale hairless man with an impressive athletic physique.  Its lidless eyes are totally black, and seeping with blood.",
     "default_faction": "cult",
     "diff": 13,
     "bodytype": "human",


### PR DESCRIPTION
Gives Homunculus description from Arcana, for compatibility and also because PK Homunculus needed description.