### PR TITLE
Add missing flags to vehicle mods

### DIFF
--- a/Kenan-Modpack/AdvancedGear_CDDA_Mod/items/vehicle/vehicle_parts.json
+++ b/Kenan-Modpack/AdvancedGear_CDDA_Mod/items/vehicle/vehicle_parts.json
@@ -1,5 +1,20 @@
 [
   {
+    "id": "TRACKED",
+    "type": "json_flag",
+    "context": [ "vehicle_part" ]
+  },
+  {
+    "id": "TOOL_NONE",
+    "type": "json_flag",
+    "context": [ "vehicle_part" ]
+  },
+  {
+    "id": "NO_JACK",
+    "type": "json_flag",
+    "context": [ "vehicle_part" ]
+  },
+  {
     "id": "nanovp",
     "type": "vehicle_part",
     "name": { "str": "nanotech vehicle part" },

--- a/Kenan-Modpack/Arcana/vehicleparts.json
+++ b/Kenan-Modpack/Arcana/vehicleparts.json
@@ -1,5 +1,10 @@
 [
   {
+    "id": "EMITTER",
+    "type": "json_flag",
+    "context": [ "vehicle_part" ]
+  },
+  {
     "id": "electrothermal_arc_cannon_part",
     "copy-from": "turret",
     "type": "vehicle_part",

--- a/Kenan-Modpack/Fallout_CDDA/vehicle_parts.json
+++ b/Kenan-Modpack/Fallout_CDDA/vehicle_parts.json
@@ -1,5 +1,15 @@
 [
   {
+    "id": "TOOL_SCREWDRIVER",
+    "type": "json_flag",
+    "context": [ "vehicle_part" ]
+  },
+  {
+    "id": "TOOL_WRENCH",
+    "type": "json_flag",
+    "context": [ "vehicle_part" ]
+  },
+  {
     "type": "vehicle_part",
     "id": "minifridge_atomic",
     "name": { "str": "atomic minifridge" },

--- a/Kenan-Modpack/HeavyMining/parts.json
+++ b/Kenan-Modpack/HeavyMining/parts.json
@@ -1,5 +1,15 @@
 [
   {
+    "id": "ROADHEAD",
+    "type": "json_flag",
+    "context": [ "vehicle_part" ]
+  },
+  {
+    "id": "CRASH_TERRAIN_AROUND",
+    "type": "json_flag",
+    "context": [ "vehicle_part" ]
+  },
+  {
     "type": "GENERIC",
     "id": "v_roadheader_item",
     "symbol": "&",

--- a/Kenan-Modpack/PKs_Rebalancing/items/vehicle_parts.json
+++ b/Kenan-Modpack/PKs_Rebalancing/items/vehicle_parts.json
@@ -1,5 +1,30 @@
 [
   {
+    "id": "REVERSIBLE",
+    "type": "json_flag",
+    "context": [ "vehicle_part" ]
+  },
+  {
+    "id": "TOOL_NONE",
+    "type": "json_flag",
+    "context": [ "vehicle_part" ]
+  },
+  {
+    "id": "TOOL_SCREWDRIVER",
+    "type": "json_flag",
+    "context": [ "vehicle_part" ]
+  },
+  {
+    "id": "TOOL_WRENCH",
+    "type": "json_flag",
+    "context": [ "vehicle_part" ]
+  },
+  {
+    "id": "NAILABLE",
+    "type": "json_flag",
+    "context": [ "vehicle_part" ]
+  },
+  {
     "id": "storage_battery_removable",
     "copy-from": "storage_battery",
     "type": "vehicle_part",

--- a/Kenan-Modpack/Tankmod_Revived/treads.json
+++ b/Kenan-Modpack/Tankmod_Revived/treads.json
@@ -1,5 +1,10 @@
 [
   {
+    "id": "TRACKED",
+    "type": "json_flag",
+    "context": [ "vehicle_part" ]
+  },
+  {
     "id": "tread1",
     "type": "vehicle_part",
     "name": { "str": "rubber treads" },

--- a/Kenan-Modpack/blazemod/vehicleparts/flags.json
+++ b/Kenan-Modpack/blazemod/vehicleparts/flags.json
@@ -1,0 +1,12 @@
+[
+  {
+    "id": "TRACKED",
+    "type": "json_flag",
+    "context": [ "vehicle_part" ]
+  },
+  {
+    "id": "FUEL_TANK",
+    "type": "json_flag",
+    "context": [ "vehicle_part" ]
+  }
+]

--- a/Kenan-Modpack/cdda_variety_pack/vehicleparts/tanks.json
+++ b/Kenan-Modpack/cdda_variety_pack/vehicleparts/tanks.json
@@ -1,5 +1,10 @@
 [
   {
+    "id": "TOOL_WRENCH",
+    "type": "json_flag",
+    "context": [ "vehicle_part" ]
+  },
+  {
     "id": "tank_small_insulated",
     "type": "vehicle_part",
     "name": { "str": "insulated potable water tank" },

--- a/Kenan-Modpack/secronom_lore_expansion/Modification Files/Others/secro_vehicleparts.json
+++ b/Kenan-Modpack/secronom_lore_expansion/Modification Files/Others/secro_vehicleparts.json
@@ -1,5 +1,10 @@
 [
   {
+    "id": "TRACKED",
+    "type": "json_flag",
+    "context": [ "vehicle_part" ]
+  },
+  {
     "id": "SECRO_FLESH",
     "type": "json_flag",
     "context": [ "vehicle_part" ]


### PR DESCRIPTION
Fixes the new warnings when loading certain vehicle mods, in the simplest way possible. I think I got them all.

Background: CleverRaven/Cataclysm-DDA#49193 added a check for vehicle part flags without definitions, but only flags used by the base game and in-repository mods were added to DDA. Some obsoleted, legacy, or mod-only flags weren't included. TRACKED was a big one, since lots of mods add tanks but there are none in the core game. I went here first because it's the biggest repository of mods I'm aware of at the moment; let me know if you know of any other big packs or any mod authors who'll need to update their own repositories.

Doesn't actually fix mods using broken flags, just clears the warnings. For example, I think the TOOL_X flags don't have an implementation in C++ anymore.