### PR TITLE
fix: vehicle part distorion_amp_motor_part has unknown flag EMITTER

### DIFF
--- a/Kenan-Modpack/Arcana/vehicleparts.json
+++ b/Kenan-Modpack/Arcana/vehicleparts.json
@@ -89,7 +89,7 @@
       }
     },
     "damage_reduction": { "all": 15 },
-    "flags": [ "ENGINE", "E_COMBUSTION", "EMITTER" ],
+    "flags": [ "ENGINE", "E_COMBUSTION" ],
     "emissions": [ "emit_electroanomaly_vehicle" ],
     "description": "A powerful electric motor relying on a spatial distortion.  Outputs more energy than it consumes, but unusable as a source of free energy.  Multiple can be installed without penalty, but operation can lead to unsafe electrical discharge."
   },


### PR DESCRIPTION
porting https://github.com/chaosvolt/cdda-arcana-mod/pull/184

vehicle_part not supporting EMITTER anymore? I tried after this fix it stop the warning.