### PR TITLE
[PK] Minor Tweak to Fungal Boomer

### DIFF
--- a/Kenan-Modpack/PKs_Rebalancing/monsters/fungus.json
+++ b/Kenan-Modpack/PKs_Rebalancing/monsters/fungus.json
@@ -109,9 +109,9 @@
     "vision_night": 3,
     "special_attacks": [ [ "wound_minor", 30 ], [ "FUNGUS", 100 ], [ "BOOMER", 20 ], [ "scratch", 25 ] ],
     "death_function": {
-      "effect": { "id": "death_blobsplit", "hit_self": true },
+      "effect": { "id": "death_fungalburst", "hit_self": true },
       "corpse_type": "NO_CORPSE",
-      "message": "The %s splits in two!"
+      "message": "The %s explodes into a cloud of fungal spores!"
     },
     "flags": [
       "SEES",


### PR DESCRIPTION
Changes Fungal Boomer's death to fungalburst, as boomers splitting into two on death seems like an odd choice, unless that is intended by @meelock, in which case I will close this.