### PR TITLE
Make DracoDogMod and Dinomod play nice. Category merger pr

### DIFF
--- a/Kenan-Modpack/DracoDogMod/recipes/dog_recipes.json
+++ b/Kenan-Modpack/DracoDogMod/recipes/dog_recipes.json
@@ -2,6 +2,15 @@
   {
     "type": "recipe_category",
     "id": "CC_ANIMALS",
-    "recipe_subcategories": [ "CSC_ALL", "CSC_ANIMALS_CANINE ARMOR", "CSC_ANIMALS_CANINE TRAINING", "CSC_ANIMALS_EQUINE ARMOR", "CSC_ANIMALS_EQUINE STORAGE" ]
+    "recipe_subcategories": [ 
+      "CSC_ALL",
+      "CSC_ANIMALS_CANINE ARMOR",
+      "CSC_ANIMALS_CANINE TRAINING",
+      "CSC_ANIMALS_ELEPHANT ARMOR",
+      "CSC_ANIMALS_OSTRICH ARMOR",
+      "CSC_ANIMALS_EQUINE ARMOR",
+      "CSC_ANIMALS_EQUINE STORAGE" ]
   }
 ]
+
+


### PR DESCRIPTION
Recipe categories aren't extensible like monster groups, they still act in the old manner and overwrite what came before. Both mods make a Animals crafting category, whixh leads to whichever loads last into breaking things for the former. Making this change to Draco makes things work, with the caveat that it must be loaded AFTER dinomod or it will be overwritten. I think I'll submit a change to the description in modinfo, too. 
I checked if this will break other stuff by just loading a mod that was just the above recipe category definition. Loaded alone, before or after dinomod it causes no issues. The game doesn't care about subcategories that don't get used. This is the best solution I can come up with that doesn't involve a compatibility mod.