### PR TITLE
Kill the wind resist error due to being made of nothing.

### DIFF
--- a/Kenan-Modpack/secronom_lore_expansion/Modification Files/Items/Armors/secro_power_armor_armaments.json
+++ b/Kenan-Modpack/secronom_lore_expansion/Modification Files/Items/Armors/secro_power_armor_armaments.json
@@ -223,6 +223,7 @@
     "description": "Protruding from your shoulders are small, oddly-shaped and short-lived frond emitting strong light. Can be detached.",
     "weight": "20 g",
     "volume": "100 ml",
+    "material": [ "secro_flesh_reinforced" ],
     "symbol": "i",
     "color": "white",
     "flags": [ "PERSONAL", "OVERSIZE", "TRADER_AVOID", "LIGHT_50", "SEMITANGIBLE" ],


### PR DESCRIPTION
When you make one of these and walk a step, the game complains about the lack of a material. This minor change silences that. Incidentally, did you know the game was calculating wind resistance for worn items based on their materials? Pretty cool.