### PR TITLE
Finish what was started...

### DIFF
--- a/Kenan-Modpack/Jury_Rigged_Robots/jrr_recipes.json
+++ b/Kenan-Modpack/Jury_Rigged_Robots/jrr_recipes.json
@@ -133,7 +133,7 @@
   {
     "type": "recipe",
     "activity_level": "LIGHT_EXERCISE",
-    "result": "bot_skaterbot",
+    "result": "bot_skaterbotmisc",
     "id_suffix": "from_skitter_bot",
     "category": "CC_ELECTRONIC",
     "subcategory": "CSC_ELECTRONIC_OTHER",
@@ -172,7 +172,7 @@
   {
     "type": "recipe",
     "activity_level": "LIGHT_EXERCISE",
-    "result": "bot_skaterbot",
+    "result": "bot_skaterbotmisc",
     "id_suffix": "from_skater_bot",
     "category": "CC_ELECTRONIC",
     "subcategory": "CSC_ELECTRONIC_OTHER",


### PR DESCRIPTION
The fix for the crash bug earlier in the week spawns two errors since the recipes no longer point to a valid item. I can confirm that this fix didn't bring back the crash bug on my existing save.