### PR TITLE
[Fallout] Move Ghouls to the sewers

### DIFF
--- a/Kenan-Modpack/Fallout_CDDA/monsters/monstergroups.json
+++ b/Kenan-Modpack/Fallout_CDDA/monsters/monstergroups.json
@@ -211,7 +211,7 @@
   },
   {
     "type": "monstergroup",
-    "name": "GROUP_CITY",
+    "name": "GROUP_SEWER",
     "default": "mon_fallout_ghoul",
     "monsters": [
       { "monster": "mon_fallout_ghoul", "freq": 30, "cost_multiplier": 1 },


### PR DESCRIPTION
Moves ghouls to the sewer group, as it is more fitting with fallout lore and this way I know for certain that they are spawning.