### PR TITLE
[Psychiclysm]Missing "skill_display_type"

### DIFF
--- a/Kenan-Modpack/Psychiclysm/skills.json
+++ b/Kenan-Modpack/Psychiclysm/skills.json
@@ -10,5 +10,7 @@
     "type": "skill_display_type",
     "id": "display_social",
     "display_string": "Psychology"
+  
+  
   }
 ]

--- a/Kenan-Modpack/Psychiclysm/skills.json
+++ b/Kenan-Modpack/Psychiclysm/skills.json
@@ -5,5 +5,10 @@
     "name": { "str": "psychology" },
     "description": "Your skill in understanding other people.  Covers speaking ability, such as boasting, flattery, threats, persuasion, lies, and other facets of interpersonal communication.  Works best in conjunction with a high level of intelligence.",
     "display_category": "display_social"
+  },
+  {
+    "type": "skill_display_type",
+    "id": "display_social",
+    "display_string": "Psychology"
   }
 ]


### PR DESCRIPTION
But I don't know what's the proper name of this category, or just put it into Interaction skills.
Without screenshot because of the item group bug of Arcana.

EDIT:
This pr is to fix:
![Screenshot_20210913_144808](https://user-images.githubusercontent.com/22638873/133036641-14b46ee3-809a-4631-9b61-425c55367daf.jpg)
