### PR TITLE
Altered a couple of mod's recipes to require GLARE 1 instead of 2.

### DIFF
--- a/Kenan-Modpack/Pneumatic_fun/Recipes/Recipes_weapons.json
+++ b/Kenan-Modpack/Pneumatic_fun/Recipes/Recipes_weapons.json
@@ -114,7 +114,7 @@
       { "id": "SAW_M_FINE", "level": 1 },
       { "id": "SCREW_FINE", "level": 1 },
       { "id": "WRENCH_FINE", "level": 1 },
-      { "id": "GLARE", "level": 2 }
+      { "id": "GLARE", "level": 1 }
     ],
     "tools": [ [ [ "oxy_torch", 60 ], [ "welder", 300 ], [ "welder_crude", 450 ], [ "toolset", 450 ] ] ],
     "components": [

--- a/Kenan-Modpack/SD_Magcrafting/recipes/12ga_shotgun.json
+++ b/Kenan-Modpack/SD_Magcrafting/recipes/12ga_shotgun.json
@@ -18,7 +18,7 @@
       { "id": "SAW_M_FINE", "level": 1 },
       { "id": "SCREW_FINE", "level": 1 },
       { "id": "WRENCH_FINE", "level": 1 },
-      { "id": "GLARE", "level": 2 },
+      { "id": "GLARE", "level": 1 },
       { "id": "CUT_FINE", "level": 2 }
     ],
     "tools": [
@@ -52,7 +52,7 @@
       { "id": "SAW_M_FINE", "level": 1 },
       { "id": "SCREW_FINE", "level": 1 },
       { "id": "WRENCH_FINE", "level": 1 },
-      { "id": "GLARE", "level": 2 },
+      { "id": "GLARE", "level": 1 },
       { "id": "CUT_FINE", "level": 2 }
     ],
     "tools": [

--- a/Kenan-Modpack/SD_Magcrafting/recipes/22_long_rifle.json
+++ b/Kenan-Modpack/SD_Magcrafting/recipes/22_long_rifle.json
@@ -18,7 +18,7 @@
       { "id": "SAW_M_FINE", "level": 1 },
       { "id": "SCREW_FINE", "level": 1 },
       { "id": "WRENCH_FINE", "level": 1 },
-      { "id": "GLARE", "level": 2 },
+      { "id": "GLARE", "level": 1 },
       { "id": "HAMMER", "level": 3 }
     ],
     "tools": [
@@ -54,7 +54,7 @@
       { "id": "SAW_M_FINE", "level": 1 },
       { "id": "SCREW_FINE", "level": 1 },
       { "id": "WRENCH_FINE", "level": 1 },
-      { "id": "GLARE", "level": 2 },
+      { "id": "GLARE", "level": 1 },
       { "id": "HAMMER", "level": 3 }
     ],
     "tools": [
@@ -90,7 +90,7 @@
       { "id": "SAW_M_FINE", "level": 1 },
       { "id": "SCREW_FINE", "level": 1 },
       { "id": "WRENCH_FINE", "level": 1 },
-      { "id": "GLARE", "level": 2 },
+      { "id": "GLARE", "level": 1 },
       { "id": "HAMMER", "level": 3 }
     ],
     "tools": [
@@ -126,7 +126,7 @@
       { "id": "SAW_M_FINE", "level": 1 },
       { "id": "SCREW_FINE", "level": 1 },
       { "id": "WRENCH_FINE", "level": 1 },
-      { "id": "GLARE", "level": 2 },
+      { "id": "GLARE", "level": 1 },
       { "id": "HAMMER", "level": 3 }
     ],
     "tools": [
@@ -162,7 +162,7 @@
       { "id": "SAW_M_FINE", "level": 1 },
       { "id": "SCREW_FINE", "level": 1 },
       { "id": "WRENCH_FINE", "level": 1 },
-      { "id": "GLARE", "level": 2 },
+      { "id": "GLARE", "level": 1 },
       { "id": "HAMMER", "level": 3 }
     ],
     "tools": [

--- a/Kenan-Modpack/SD_Magcrafting/recipes/300_Winchester_Magnum.json
+++ b/Kenan-Modpack/SD_Magcrafting/recipes/300_Winchester_Magnum.json
@@ -18,7 +18,7 @@
       { "id": "SAW_M_FINE", "level": 1 },
       { "id": "SCREW_FINE", "level": 1 },
       { "id": "WRENCH_FINE", "level": 1 },
-      { "id": "GLARE", "level": 2 },
+      { "id": "GLARE", "level": 1 },
       { "id": "HAMMER", "level": 3 }
     ],
     "tools": [

--- a/Kenan-Modpack/SD_Magcrafting/recipes/308_Winchester.json
+++ b/Kenan-Modpack/SD_Magcrafting/recipes/308_Winchester.json
@@ -18,7 +18,7 @@
       { "id": "SAW_M_FINE", "level": 1 },
       { "id": "SCREW_FINE", "level": 1 },
       { "id": "WRENCH_FINE", "level": 1 },
-      { "id": "GLARE", "level": 2 },
+      { "id": "GLARE", "level": 1 },
       { "id": "HAMMER", "level": 3 }
     ],
     "tools": [
@@ -54,7 +54,7 @@
       { "id": "SAW_M_FINE", "level": 1 },
       { "id": "SCREW_FINE", "level": 1 },
       { "id": "WRENCH_FINE", "level": 1 },
-      { "id": "GLARE", "level": 2 },
+      { "id": "GLARE", "level": 1 },
       { "id": "HAMMER", "level": 3 }
     ],
     "tools": [
@@ -90,7 +90,7 @@
       { "id": "SAW_M_FINE", "level": 1 },
       { "id": "SCREW_FINE", "level": 1 },
       { "id": "WRENCH_FINE", "level": 1 },
-      { "id": "GLARE", "level": 2 },
+      { "id": "GLARE", "level": 1 },
       { "id": "HAMMER", "level": 3 }
     ],
     "tools": [
@@ -127,7 +127,7 @@
       { "id": "SAW_M_FINE", "level": 1 },
       { "id": "SCREW_FINE", "level": 1 },
       { "id": "WRENCH_FINE", "level": 1 },
-      { "id": "GLARE", "level": 2 },
+      { "id": "GLARE", "level": 1 },
       { "id": "HAMMER", "level": 3 }
     ],
     "tools": [
@@ -163,7 +163,7 @@
       { "id": "SAW_M_FINE", "level": 1 },
       { "id": "SCREW_FINE", "level": 1 },
       { "id": "WRENCH_FINE", "level": 1 },
-      { "id": "GLARE", "level": 2 },
+      { "id": "GLARE", "level": 1 },
       { "id": "HAMMER", "level": 3 }
     ],
     "tools": [
@@ -199,7 +199,7 @@
       { "id": "SAW_M_FINE", "level": 1 },
       { "id": "SCREW_FINE", "level": 1 },
       { "id": "WRENCH_FINE", "level": 1 },
-      { "id": "GLARE", "level": 2 },
+      { "id": "GLARE", "level": 1 },
       { "id": "HAMMER", "level": 3 }
     ],
     "tools": [
@@ -235,7 +235,7 @@
       { "id": "SAW_M_FINE", "level": 1 },
       { "id": "SCREW_FINE", "level": 1 },
       { "id": "WRENCH_FINE", "level": 1 },
-      { "id": "GLARE", "level": 2 },
+      { "id": "GLARE", "level": 1 },
       { "id": "HAMMER", "level": 3 }
     ],
     "tools": [
@@ -271,7 +271,7 @@
       { "id": "SAW_M_FINE", "level": 1 },
       { "id": "SCREW_FINE", "level": 1 },
       { "id": "WRENCH_FINE", "level": 1 },
-      { "id": "GLARE", "level": 2 },
+      { "id": "GLARE", "level": 1 },
       { "id": "HAMMER", "level": 3 }
     ],
     "tools": [

--- a/Kenan-Modpack/SD_Magcrafting/recipes/30_06.json
+++ b/Kenan-Modpack/SD_Magcrafting/recipes/30_06.json
@@ -18,7 +18,7 @@
       { "id": "SAW_M_FINE", "level": 1 },
       { "id": "SCREW_FINE", "level": 1 },
       { "id": "WRENCH_FINE", "level": 1 },
-      { "id": "GLARE", "level": 2 },
+      { "id": "GLARE", "level": 1 },
       { "id": "HAMMER", "level": 3 }
     ],
     "tools": [
@@ -54,7 +54,7 @@
       { "id": "SAW_M_FINE", "level": 1 },
       { "id": "SCREW_FINE", "level": 1 },
       { "id": "WRENCH_FINE", "level": 1 },
-      { "id": "GLARE", "level": 2 },
+      { "id": "GLARE", "level": 1 },
       { "id": "HAMMER", "level": 3 }
     ],
     "tools": [
@@ -90,7 +90,7 @@
       { "id": "SAW_M_FINE", "level": 1 },
       { "id": "SCREW_FINE", "level": 1 },
       { "id": "WRENCH_FINE", "level": 1 },
-      { "id": "GLARE", "level": 2 },
+      { "id": "GLARE", "level": 1 },
       { "id": "HAMMER", "level": 3 }
     ],
     "tools": [

--- a/Kenan-Modpack/SD_Magcrafting/recipes/32_acp.json
+++ b/Kenan-Modpack/SD_Magcrafting/recipes/32_acp.json
@@ -18,7 +18,7 @@
       { "id": "SAW_M_FINE", "level": 1 },
       { "id": "SCREW_FINE", "level": 1 },
       { "id": "WRENCH_FINE", "level": 1 },
-      { "id": "GLARE", "level": 2 },
+      { "id": "GLARE", "level": 1 },
       { "id": "HAMMER", "level": 3 }
     ],
     "tools": [
@@ -54,7 +54,7 @@
       { "id": "SAW_M_FINE", "level": 1 },
       { "id": "SCREW_FINE", "level": 1 },
       { "id": "WRENCH_FINE", "level": 1 },
-      { "id": "GLARE", "level": 2 },
+      { "id": "GLARE", "level": 1 },
       { "id": "HAMMER", "level": 3 }
     ],
     "tools": [
@@ -90,7 +90,7 @@
       { "id": "SAW_M_FINE", "level": 1 },
       { "id": "SCREW_FINE", "level": 1 },
       { "id": "WRENCH_FINE", "level": 1 },
-      { "id": "GLARE", "level": 2 },
+      { "id": "GLARE", "level": 1 },
       { "id": "HAMMER", "level": 3 }
     ],
     "tools": [

--- a/Kenan-Modpack/SD_Magcrafting/recipes/38_special.json
+++ b/Kenan-Modpack/SD_Magcrafting/recipes/38_special.json
@@ -18,7 +18,7 @@
       { "id": "SAW_M_FINE", "level": 1 },
       { "id": "SCREW_FINE", "level": 1 },
       { "id": "WRENCH_FINE", "level": 1 },
-      { "id": "GLARE", "level": 2 },
+      { "id": "GLARE", "level": 1 },
       { "id": "HAMMER", "level": 3 }
     ],
     "tools": [

--- a/Kenan-Modpack/SD_Magcrafting/recipes/4.6x30mm.json
+++ b/Kenan-Modpack/SD_Magcrafting/recipes/4.6x30mm.json
@@ -18,7 +18,7 @@
       { "id": "SAW_M_FINE", "level": 1 },
       { "id": "SCREW_FINE", "level": 1 },
       { "id": "WRENCH_FINE", "level": 1 },
-      { "id": "GLARE", "level": 2 },
+      { "id": "GLARE", "level": 1 },
       { "id": "HAMMER", "level": 3 }
     ],
     "tools": [
@@ -54,7 +54,7 @@
       { "id": "SAW_M_FINE", "level": 1 },
       { "id": "SCREW_FINE", "level": 1 },
       { "id": "WRENCH_FINE", "level": 1 },
-      { "id": "GLARE", "level": 2 },
+      { "id": "GLARE", "level": 1 },
       { "id": "HAMMER", "level": 3 }
     ],
     "tools": [

--- a/Kenan-Modpack/SD_Magcrafting/recipes/40_Smith_and_Wesson.json
+++ b/Kenan-Modpack/SD_Magcrafting/recipes/40_Smith_and_Wesson.json
@@ -18,7 +18,7 @@
       { "id": "SAW_M_FINE", "level": 1 },
       { "id": "SCREW_FINE", "level": 1 },
       { "id": "WRENCH_FINE", "level": 1 },
-      { "id": "GLARE", "level": 2 },
+      { "id": "GLARE", "level": 1 },
       { "id": "CUT_FINE", "level": 2 }
     ],
     "tools": [
@@ -52,7 +52,7 @@
       { "id": "SAW_M_FINE", "level": 1 },
       { "id": "SCREW_FINE", "level": 1 },
       { "id": "WRENCH_FINE", "level": 1 },
-      { "id": "GLARE", "level": 2 },
+      { "id": "GLARE", "level": 1 },
       { "id": "CUT_FINE", "level": 2 }
     ],
     "tools": [
@@ -86,7 +86,7 @@
       { "id": "SAW_M_FINE", "level": 1 },
       { "id": "SCREW_FINE", "level": 1 },
       { "id": "WRENCH_FINE", "level": 1 },
-      { "id": "GLARE", "level": 2 },
+      { "id": "GLARE", "level": 1 },
       { "id": "CUT_FINE", "level": 2 }
     ],
     "tools": [

--- a/Kenan-Modpack/SD_Magcrafting/recipes/44_magnum.json
+++ b/Kenan-Modpack/SD_Magcrafting/recipes/44_magnum.json
@@ -18,7 +18,7 @@
       { "id": "SAW_M_FINE", "level": 1 },
       { "id": "SCREW_FINE", "level": 1 },
       { "id": "WRENCH_FINE", "level": 1 },
-      { "id": "GLARE", "level": 2 },
+      { "id": "GLARE", "level": 1 },
       { "id": "HAMMER", "level": 3 }
     ],
     "tools": [

--- a/Kenan-Modpack/SD_Magcrafting/recipes/45_ACP.json
+++ b/Kenan-Modpack/SD_Magcrafting/recipes/45_ACP.json
@@ -18,7 +18,7 @@
       { "id": "SAW_M_FINE", "level": 1 },
       { "id": "SCREW_FINE", "level": 1 },
       { "id": "WRENCH_FINE", "level": 1 },
-      { "id": "GLARE", "level": 2 },
+      { "id": "GLARE", "level": 1 },
       { "id": "CUT_FINE", "level": 2 }
     ],
     "tools": [
@@ -52,7 +52,7 @@
       { "id": "SAW_M_FINE", "level": 1 },
       { "id": "SCREW_FINE", "level": 1 },
       { "id": "WRENCH_FINE", "level": 1 },
-      { "id": "GLARE", "level": 2 },
+      { "id": "GLARE", "level": 1 },
       { "id": "HAMMER", "level": 3 }
     ],
     "tools": [
@@ -88,7 +88,7 @@
       { "id": "SAW_M_FINE", "level": 1 },
       { "id": "SCREW_FINE", "level": 1 },
       { "id": "WRENCH_FINE", "level": 1 },
-      { "id": "GLARE", "level": 2 },
+      { "id": "GLARE", "level": 1 },
       { "id": "HAMMER", "level": 3 }
     ],
     "tools": [
@@ -124,7 +124,7 @@
       { "id": "SAW_M_FINE", "level": 1 },
       { "id": "SCREW_FINE", "level": 1 },
       { "id": "WRENCH_FINE", "level": 1 },
-      { "id": "GLARE", "level": 2 },
+      { "id": "GLARE", "level": 1 },
       { "id": "HAMMER", "level": 3 }
     ],
     "tools": [
@@ -160,7 +160,7 @@
       { "id": "SAW_M_FINE", "level": 1 },
       { "id": "SCREW_FINE", "level": 1 },
       { "id": "WRENCH_FINE", "level": 1 },
-      { "id": "GLARE", "level": 2 },
+      { "id": "GLARE", "level": 1 },
       { "id": "HAMMER", "level": 3 }
     ],
     "tools": [
@@ -196,7 +196,7 @@
       { "id": "SAW_M_FINE", "level": 1 },
       { "id": "SCREW_FINE", "level": 1 },
       { "id": "WRENCH_FINE", "level": 1 },
-      { "id": "GLARE", "level": 2 },
+      { "id": "GLARE", "level": 1 },
       { "id": "HAMMER", "level": 3 }
     ],
     "tools": [
@@ -232,7 +232,7 @@
       { "id": "SAW_M_FINE", "level": 1 },
       { "id": "SCREW_FINE", "level": 1 },
       { "id": "WRENCH_FINE", "level": 1 },
-      { "id": "GLARE", "level": 2 },
+      { "id": "GLARE", "level": 1 },
       { "id": "HAMMER", "level": 3 }
     ],
     "tools": [
@@ -268,7 +268,7 @@
       { "id": "SAW_M_FINE", "level": 1 },
       { "id": "SCREW_FINE", "level": 1 },
       { "id": "WRENCH_FINE", "level": 1 },
-      { "id": "GLARE", "level": 2 },
+      { "id": "GLARE", "level": 1 },
       { "id": "HAMMER", "level": 3 }
     ],
     "tools": [
@@ -304,7 +304,7 @@
       { "id": "SAW_M_FINE", "level": 1 },
       { "id": "SCREW_FINE", "level": 1 },
       { "id": "WRENCH_FINE", "level": 1 },
-      { "id": "GLARE", "level": 2 },
+      { "id": "GLARE", "level": 1 },
       { "id": "HAMMER", "level": 3 }
     ],
     "tools": [
@@ -340,7 +340,7 @@
       { "id": "SAW_M_FINE", "level": 1 },
       { "id": "SCREW_FINE", "level": 1 },
       { "id": "WRENCH_FINE", "level": 1 },
-      { "id": "GLARE", "level": 2 },
+      { "id": "GLARE", "level": 1 },
       { "id": "HAMMER", "level": 3 },
       { "id": "CUT_FINE", "level": 2 }
     ],

--- a/Kenan-Modpack/SD_Magcrafting/recipes/5.45x39mm.json
+++ b/Kenan-Modpack/SD_Magcrafting/recipes/5.45x39mm.json
@@ -18,7 +18,7 @@
       { "id": "SAW_M_FINE", "level": 1 },
       { "id": "SCREW_FINE", "level": 1 },
       { "id": "WRENCH_FINE", "level": 1 },
-      { "id": "GLARE", "level": 2 },
+      { "id": "GLARE", "level": 1 },
       { "id": "HAMMER", "level": 3 },
       { "id": "CUT_FINE", "level": 2 }
     ],
@@ -56,7 +56,7 @@
       { "id": "SAW_M_FINE", "level": 1 },
       { "id": "SCREW_FINE", "level": 1 },
       { "id": "WRENCH_FINE", "level": 1 },
-      { "id": "GLARE", "level": 2 },
+      { "id": "GLARE", "level": 1 },
       { "id": "CUT_FINE", "level": 2 }
     ],
     "tools": [

--- a/Kenan-Modpack/SD_Magcrafting/recipes/5.56_NATO.json
+++ b/Kenan-Modpack/SD_Magcrafting/recipes/5.56_NATO.json
@@ -18,7 +18,7 @@
       { "id": "SAW_M_FINE", "level": 1 },
       { "id": "SCREW_FINE", "level": 1 },
       { "id": "WRENCH_FINE", "level": 1 },
-      { "id": "GLARE", "level": 2 },
+      { "id": "GLARE", "level": 1 },
       { "id": "CUT_FINE", "level": 2 }
     ],
     "tools": [
@@ -52,7 +52,7 @@
       { "id": "SAW_M_FINE", "level": 1 },
       { "id": "SCREW_FINE", "level": 1 },
       { "id": "WRENCH_FINE", "level": 1 },
-      { "id": "GLARE", "level": 2 },
+      { "id": "GLARE", "level": 1 },
       { "id": "CUT_FINE", "level": 2 }
     ],
     "tools": [
@@ -86,7 +86,7 @@
       { "id": "SAW_M_FINE", "level": 1 },
       { "id": "SCREW_FINE", "level": 1 },
       { "id": "WRENCH_FINE", "level": 1 },
-      { "id": "GLARE", "level": 2 },
+      { "id": "GLARE", "level": 1 },
       { "id": "HAMMER", "level": 3 }
     ],
     "tools": [
@@ -122,7 +122,7 @@
       { "id": "SAW_M_FINE", "level": 1 },
       { "id": "SCREW_FINE", "level": 1 },
       { "id": "WRENCH_FINE", "level": 1 },
-      { "id": "GLARE", "level": 2 },
+      { "id": "GLARE", "level": 1 },
       { "id": "HAMMER", "level": 3 }
     ],
     "tools": [
@@ -158,7 +158,7 @@
       { "id": "SAW_M_FINE", "level": 1 },
       { "id": "SCREW_FINE", "level": 1 },
       { "id": "WRENCH_FINE", "level": 1 },
-      { "id": "GLARE", "level": 2 },
+      { "id": "GLARE", "level": 1 },
       { "id": "HAMMER", "level": 3 },
       { "id": "CUT_FINE", "level": 2 }
     ],

--- a/Kenan-Modpack/SD_Magcrafting/recipes/5.7x28mm.json
+++ b/Kenan-Modpack/SD_Magcrafting/recipes/5.7x28mm.json
@@ -18,7 +18,7 @@
       { "id": "SAW_M_FINE", "level": 1 },
       { "id": "SCREW_FINE", "level": 1 },
       { "id": "WRENCH_FINE", "level": 1 },
-      { "id": "GLARE", "level": 2 },
+      { "id": "GLARE", "level": 1 },
       { "id": "HAMMER", "level": 3 }
     ],
     "tools": [
@@ -54,7 +54,7 @@
       { "id": "SAW_M_FINE", "level": 1 },
       { "id": "SCREW_FINE", "level": 1 },
       { "id": "WRENCH_FINE", "level": 1 },
-      { "id": "GLARE", "level": 2 },
+      { "id": "GLARE", "level": 1 },
       { "id": "HAMMER", "level": 3 },
       { "id": "CUT_FINE", "level": 2 }
     ],

--- a/Kenan-Modpack/SD_Magcrafting/recipes/50_BMG.json
+++ b/Kenan-Modpack/SD_Magcrafting/recipes/50_BMG.json
@@ -18,7 +18,7 @@
       { "id": "SAW_M_FINE", "level": 1 },
       { "id": "SCREW_FINE", "level": 1 },
       { "id": "WRENCH_FINE", "level": 1 },
-      { "id": "GLARE", "level": 2 },
+      { "id": "GLARE", "level": 1 },
       { "id": "HAMMER", "level": 3 }
     ],
     "tools": [

--- a/Kenan-Modpack/SD_Magcrafting/recipes/7.62_SOVIET.json
+++ b/Kenan-Modpack/SD_Magcrafting/recipes/7.62_SOVIET.json
@@ -18,7 +18,7 @@
       { "id": "SAW_M_FINE", "level": 1 },
       { "id": "SCREW_FINE", "level": 1 },
       { "id": "WRENCH_FINE", "level": 1 },
-      { "id": "GLARE", "level": 2 },
+      { "id": "GLARE", "level": 1 },
       { "id": "HAMMER", "level": 3 }
     ],
     "tools": [
@@ -54,7 +54,7 @@
       { "id": "SAW_M_FINE", "level": 1 },
       { "id": "SCREW_FINE", "level": 1 },
       { "id": "WRENCH_FINE", "level": 1 },
-      { "id": "GLARE", "level": 2 },
+      { "id": "GLARE", "level": 1 },
       { "id": "HAMMER", "level": 3 }
     ],
     "tools": [

--- a/Kenan-Modpack/SD_Magcrafting/recipes/7.62x25mm.json
+++ b/Kenan-Modpack/SD_Magcrafting/recipes/7.62x25mm.json
@@ -18,7 +18,7 @@
       { "id": "SAW_M_FINE", "level": 1 },
       { "id": "SCREW_FINE", "level": 1 },
       { "id": "WRENCH_FINE", "level": 1 },
-      { "id": "GLARE", "level": 2 },
+      { "id": "GLARE", "level": 1 },
       { "id": "HAMMER", "level": 3 }
     ],
     "tools": [
@@ -54,7 +54,7 @@
       { "id": "SAW_M_FINE", "level": 1 },
       { "id": "SCREW_FINE", "level": 1 },
       { "id": "WRENCH_FINE", "level": 1 },
-      { "id": "GLARE", "level": 2 },
+      { "id": "GLARE", "level": 1 },
       { "id": "HAMMER", "level": 3 }
     ],
     "tools": [
@@ -90,7 +90,7 @@
       { "id": "SAW_M_FINE", "level": 1 },
       { "id": "SCREW_FINE", "level": 1 },
       { "id": "WRENCH_FINE", "level": 1 },
-      { "id": "GLARE", "level": 2 },
+      { "id": "GLARE", "level": 1 },
       { "id": "HAMMER", "level": 3 }
     ],
     "tools": [

--- a/Kenan-Modpack/SD_Magcrafting/recipes/9x18mm_Makarov.json
+++ b/Kenan-Modpack/SD_Magcrafting/recipes/9x18mm_Makarov.json
@@ -18,7 +18,7 @@
       { "id": "SAW_M_FINE", "level": 1 },
       { "id": "SCREW_FINE", "level": 1 },
       { "id": "WRENCH_FINE", "level": 1 },
-      { "id": "GLARE", "level": 2 },
+      { "id": "GLARE", "level": 1 },
       { "id": "HAMMER", "level": 3 }
     ],
     "tools": [
@@ -54,7 +54,7 @@
       { "id": "SAW_M_FINE", "level": 1 },
       { "id": "SCREW_FINE", "level": 1 },
       { "id": "WRENCH_FINE", "level": 1 },
-      { "id": "GLARE", "level": 2 },
+      { "id": "GLARE", "level": 1 },
       { "id": "HAMMER", "level": 3 }
     ],
     "tools": [

--- a/Kenan-Modpack/SD_Magcrafting/recipes/9x19mm_Parabellum.json
+++ b/Kenan-Modpack/SD_Magcrafting/recipes/9x19mm_Parabellum.json
@@ -18,7 +18,7 @@
       { "id": "SAW_M_FINE", "level": 1 },
       { "id": "SCREW_FINE", "level": 1 },
       { "id": "WRENCH_FINE", "level": 1 },
-      { "id": "GLARE", "level": 2 },
+      { "id": "GLARE", "level": 1 },
       { "id": "HAMMER", "level": 3 }
     ],
     "tools": [
@@ -54,7 +54,7 @@
       { "id": "SAW_M_FINE", "level": 1 },
       { "id": "SCREW_FINE", "level": 1 },
       { "id": "WRENCH_FINE", "level": 1 },
-      { "id": "GLARE", "level": 2 },
+      { "id": "GLARE", "level": 1 },
       { "id": "CUT_FINE", "level": 2 }
     ],
     "tools": [
@@ -88,7 +88,7 @@
       { "id": "SAW_M_FINE", "level": 1 },
       { "id": "SCREW_FINE", "level": 1 },
       { "id": "WRENCH_FINE", "level": 1 },
-      { "id": "GLARE", "level": 2 },
+      { "id": "GLARE", "level": 1 },
       { "id": "CUT_FINE", "level": 2 }
     ],
     "tools": [
@@ -122,7 +122,7 @@
       { "id": "SAW_M_FINE", "level": 1 },
       { "id": "SCREW_FINE", "level": 1 },
       { "id": "WRENCH_FINE", "level": 1 },
-      { "id": "GLARE", "level": 2 },
+      { "id": "GLARE", "level": 1 },
       { "id": "CUT_FINE", "level": 2 }
     ],
     "tools": [
@@ -156,7 +156,7 @@
       { "id": "SAW_M_FINE", "level": 1 },
       { "id": "SCREW_FINE", "level": 1 },
       { "id": "WRENCH_FINE", "level": 1 },
-      { "id": "GLARE", "level": 2 },
+      { "id": "GLARE", "level": 1 },
       { "id": "HAMMER", "level": 3 }
     ],
     "tools": [
@@ -192,7 +192,7 @@
       { "id": "SAW_M_FINE", "level": 1 },
       { "id": "SCREW_FINE", "level": 1 },
       { "id": "WRENCH_FINE", "level": 1 },
-      { "id": "GLARE", "level": 2 },
+      { "id": "GLARE", "level": 1 },
       { "id": "HAMMER", "level": 3 }
     ],
     "tools": [
@@ -228,7 +228,7 @@
       { "id": "SAW_M_FINE", "level": 1 },
       { "id": "SCREW_FINE", "level": 1 },
       { "id": "WRENCH_FINE", "level": 1 },
-      { "id": "GLARE", "level": 2 },
+      { "id": "GLARE", "level": 1 },
       { "id": "HAMMER", "level": 3 }
     ],
     "tools": [
@@ -264,7 +264,7 @@
       { "id": "SAW_M_FINE", "level": 1 },
       { "id": "SCREW_FINE", "level": 1 },
       { "id": "WRENCH_FINE", "level": 1 },
-      { "id": "GLARE", "level": 2 },
+      { "id": "GLARE", "level": 1 },
       { "id": "HAMMER", "level": 3 }
     ],
     "tools": [
@@ -300,7 +300,7 @@
       { "id": "SAW_M_FINE", "level": 1 },
       { "id": "SCREW_FINE", "level": 1 },
       { "id": "WRENCH_FINE", "level": 1 },
-      { "id": "GLARE", "level": 2 },
+      { "id": "GLARE", "level": 1 },
       { "id": "HAMMER", "level": 3 }
     ],
     "tools": [
@@ -336,7 +336,7 @@
       { "id": "SAW_M_FINE", "level": 1 },
       { "id": "SCREW_FINE", "level": 1 },
       { "id": "WRENCH_FINE", "level": 1 },
-      { "id": "GLARE", "level": 2 },
+      { "id": "GLARE", "level": 1 },
       { "id": "HAMMER", "level": 3 }
     ],
     "tools": [


### PR DESCRIPTION
Noticed in a couple of mods from this pack that I use, there are some recipes which have glare protection 2 requirement.  According to http://cdda-trunk.chezzo.com/qualities/GLARE there are no items in base game nor core mods that provide such a quality level.  There are some mods in this pack which provide such a quality level but the mods I'm using don't rely on those mods.  The obvious solution is to change the recipe requirements, at least for the mods I'm familiar with.

This was basically a find and replace in all json files:
find: "id": "GLARE", "level": 2
replace: "id": "GLARE", "level": 1

My guess is that at some point GLARE 2 was removed in favor of just GLARE 1.  I didn't try to scrub through the commit log since this change is likely before I started playing the experimental previously 0.E stable.