### PR TITLE
Add new flags and extra effects

### DIFF
--- a/Kenan-Structured-Modpack/High-Maintenance-Huge-Mods/MagicRevampAdditions/Spells_Override/animist.json
+++ b/Kenan-Structured-Modpack/High-Maintenance-Huge-Mods/MagicRevampAdditions/Spells_Override/animist.json
@@ -2,12 +2,16 @@
   {
     "id": "smite",
     "type": "SPELL",
-    "name": { "str": "Smite" },
+    "name": {
+      "str": "Smite"
+    },
     "description": "Evil has become pervasive throughout the world.  Let your power be the light that shines in the darkness!",
-    "valid_targets": [ "hostile" ],
+    "valid_targets": [
+      "hostile"
+    ],
     "min_damage": 10,
     "max_damage": 300,
-    "damage_increment": 15.0,
+    "damage_increment": 15,
     "min_range": 1,
     "max_range": 1,
     "effect": "attack",
@@ -21,18 +25,33 @@
     "spell_class": "ANIMIST",
     "difficulty": 8,
     "max_level": 22,
-    "damage_type": "pure",
-    "flags": [ "VERBAL", "SOMATIC", "LOUD" ],
+    "damage_type": "light",
+    "flags": [
+      "EVOCATION_SPELL",
+      "VERBAL",
+      "LOUD",
+      "NO_HANDS"
+    ],
+    "extra_effects": [
+      {
+        "id": "eoc_evocation_setup",
+        "hit_self": true
+      }
+    ],
     "energy_source": "MANA"
   },
   {
     "id": "recover_mana",
     "type": "SPELL",
-    "name": { "str": "Life Conversion" },
+    "name": {
+      "str": "Life Conversion"
+    },
     "description": "You channel your life force itself into your spiritual energy.  You spend hp to regain mana.",
-    "valid_targets": [ "self" ],
+    "valid_targets": [
+      "self"
+    ],
     "min_damage": 90,
-    "damage_increment": 15.0,
+    "damage_increment": 15,
     "max_damage": 1000,
     "max_level": 50,
     "effect": "recover_energy",
@@ -42,18 +61,35 @@
     "energy_source": "MANA",
     "components": "spell_components_rune_animist",
     "base_casting_time": 500,
-    "flags": [ "SOMATIC", "VERBAL", "SILENT", "NO_LEGS", "CONSUMES_RUNES" ],
+    "flags": [
+      "CHANNELING_SPELL",
+      "SOMATIC",
+      "VERBAL",
+      "SILENT",
+      "NO_LEGS",
+      "CONSUMES_RUNES"
+    ],
+    "extra_effects": [
+      {
+        "id": "eoc_channeling_setup",
+        "hit_self": true
+      }
+    ],
     "difficulty": 3
   },
   {
     "id": "recover_pain",
     "type": "SPELL",
-    "name": { "str": "Mind over Pain" },
+    "name": {
+      "str": "Mind over Pain"
+    },
     "description": "With an intense ritual that resembles crossfit, you manage to put some of your pain at bay.",
-    "valid_targets": [ "self" ],
+    "valid_targets": [
+      "self"
+    ],
     "min_damage": 10,
     "max_damage": 150,
-    "damage_increment": 2.0,
+    "damage_increment": 2,
     "max_level": 67,
     "spell_class": "ANIMIST",
     "effect": "recover_energy",
@@ -62,25 +98,48 @@
     "energy_source": "STAMINA",
     "base_casting_time": 50000,
     "base_energy_cost": 5000,
-    "energy_increment": 500.0,
-    "flags": [ "SOMATIC", "VERBAL", "PAIN_NORESIST" ],
+    "energy_increment": 500,
+    "flags": [
+      "RESTORATION_SPELL",
+      "SOMATIC",
+      "VERBAL",
+      "PAIN_NORESIST"
+    ],
+    "extra_effects": [
+      {
+        "id": "eoc_restoration_setup",
+        "hit_self": true
+      }
+    ],
     "final_energy_cost": 10000
   },
   {
     "id": "necrotic_gaze",
     "type": "SPELL",
-    "name": { "str": "Necrotic Gaze" },
+    "name": {
+      "str": "Necrotic Gaze"
+    },
     "description": "You use the power of your own blood to imbue necrotic energy into your gaze, damaging the target you look at.",
-    "valid_targets": [ "hostile" ],
+    "valid_targets": [
+      "hostile"
+    ],
     "effect": "attack",
     "shape": "line",
     "spell_class": "ANIMIST",
     "energy_source": "MANA",
-    "flags": [ "NO_LEGS", "CONCENTRATE", "SOMATIC", "NO_HANDS", "CONSUMES_RUNES" ],
+    "flags": [
+      "EVOCATION_SPELL",
+      "NO_LEGS",
+      "CONCENTRATE",
+      "SOMATIC",
+      "NO_PROJECTILE",
+      "NO_HANDS",
+      "CONSUMES_RUNES"
+    ],
     "components": "spell_components_rune_animist",
     "min_damage": 10,
     "max_damage": 300,
-    "damage_increment": 6.0,
+    "damage_increment": 6,
     "min_range": 3,
     "max_range": 8,
     "range_increment": 0.1,
@@ -90,14 +149,24 @@
     "min_aoe": 1,
     "max_aoe": 3,
     "aoe_increment": 0.1,
+    "extra_effects": [
+      {
+        "id": "eoc_evocation_setup",
+        "hit_self": true
+      }
+    ],
     "damage_type": "biological"
   },
   {
     "id": "create_rune_animist",
     "type": "SPELL",
-    "name": { "str": "Animist Rune" },
+    "name": {
+      "str": "Animist Rune"
+    },
     "description": "This ritual creates a small pebble attuned to Animists.  You can use the rune as a catalyst for recipes.",
-    "valid_targets": [ "self" ],
+    "valid_targets": [
+      "self"
+    ],
     "min_damage": 1,
     "max_damage": 1,
     "effect": "spawn_item",
@@ -112,15 +181,40 @@
     "max_level": 0,
     "spell_class": "ANIMIST",
     "energy_source": "MANA",
-    "flags": [ "PERMANENT", "NO_LEGS", "CONCENTRATE" ]
+    "//": "I'm not sure if this should train anything, since it's an innate ability.",
+    "extra_effects": [
+      {
+        "id": "eoc_channeling_setup",
+        "hit_self": true
+      }
+    ],
+    "flags": [
+      "CHANNELING_SPELL",
+      "PERMANENT",
+      "NO_LEGS",
+      "CONCENTRATE"
+    ]
   },
   {
     "id": "soulrend",
     "type": "SPELL",
-    "name": { "str": "Soulrend" },
+    "name": {
+      "str": "Soulrend"
+    },
     "description": "Violently tears the spirit from the body, and bounds the resulting shade to your will.",
-    "valid_targets": [ "hostile", "ally" ],
-    "flags": [ "NO_LEGS", "LOUD", "SOMATIC", "POLYMORPH_GROUP", "FRIENDLY_POLY", "NO_HANDS" ],
+    "valid_targets": [
+      "hostile",
+      "ally"
+    ],
+    "flags": [
+      "CONJURATION_SPELL",
+      "NO_LEGS",
+      "LOUD",
+      "SOMATIC",
+      "POLYMORPH_GROUP",
+      "FRIENDLY_POLY",
+      "NO_HANDS"
+    ],
     "effect": "targeted_polymorph",
     "effect_str": "GROUP_POLYMORPH_SHADOW",
     "shape": "blast",
@@ -132,20 +226,38 @@
     "damage_increment": 2.5,
     "max_level": 60,
     "base_casting_time": 200,
-    "casting_time_increment": -2.0,
+    "casting_time_increment": -2,
     "final_casting_time": 80,
     "base_energy_cost": 200,
     "min_range": 3,
     "max_range": 9,
+    "extra_effects": [
+      {
+        "id": "eoc_summon_setup",
+        "hit_self": true
+      }
+    ],
     "range_increment": 0.2
   },
   {
     "id": "disruption_bolt",
     "type": "SPELL",
-    "name": { "str": "Disruption Bolt" },
+    "name": {
+      "str": "Disruption Bolt"
+    },
     "description": "Release a resonant bolt of spiritual energy at a nearby target.  It will disrupt the natural link between matter and animus, causing heavy but never lethal damage.",
-    "valid_targets": [ "hostile" ],
-    "flags": [ "VERBAL", "SOMATIC", "NO_LEGS", "PERCENTAGE_DAMAGE", "SILENT", "NO_PROJECTILE" ],
+    "valid_targets": [
+      "hostile"
+    ],
+    "flags": [
+      "EVOCATION_SPELL",
+      "VERBAL",
+      "SOMATIC",
+      "NO_LEGS",
+      "PERCENTAGE_DAMAGE",
+      "SILENT",
+      "NO_PROJECTILE"
+    ],
     "min_damage": 35,
     "damage_type": "pure",
     "damage_increment": 1,
@@ -154,7 +266,7 @@
     "range_increment": 0.5,
     "max_range": 66,
     "base_energy_cost": 150,
-    "energy_increment": -5.0,
+    "energy_increment": -5,
     "final_energy_cost": 50,
     "spell_class": "ANIMIST",
     "difficulty": 3,
@@ -163,15 +275,32 @@
     "energy_source": "MANA",
     "shape": "blast",
     "effect": "attack",
-    "learn_spells": { "soulrend": 20 }
+    "learn_spells": {
+      "soulrend": 20
+    },
+    "extra_effects": [
+      {
+        "id": "eoc_evocation_setup",
+        "hit_self": true
+      }
+    ]
   },
   {
     "id": "banishment_lesser",
     "type": "SPELL",
-    "name": { "str": "Lesser Banishment" },
+    "name": {
+      "str": "Lesser Banishment"
+    },
     "description": "Banish a monster to the lesser-known nether dimension.  If a monster is more powerful than you can handle, the spell drains your life force to make up the difference.",
-    "valid_targets": [ "hostile" ],
-    "flags": [ "SOMATIC", "VERBAL", "NO_HANDS" ],
+    "valid_targets": [
+      "hostile"
+    ],
+    "flags": [
+      "CONVEYANCE_SPELL",
+      "SOMATIC",
+      "VERBAL",
+      "NO_HANDS"
+    ],
     "effect": "banishment",
     "shape": "blast",
     "min_damage": 40,
@@ -184,18 +313,32 @@
     "difficulty": 9,
     "max_level": 37,
     "base_casting_time": 100,
-    "energy_source": "MANA"
+    "energy_source": "MANA",
+    "extra_effects": [
+      {
+        "id": "eoc_conveyance_setup",
+        "hit_self": true
+      }
+    ]
   },
   {
     "id": "summon_wisps",
     "type": "SPELL",
-    "name": { "str": "Ignus Fatuus" },
+    "name": {
+      "str": "Ignus Fatuus"
+    },
     "description": "Summons ghostly foxfire worked from living marsh vapor, to lead your enemies astray.  With more experience, this spell can conjure multiple ghost lights.",
-    "valid_targets": [ "ground" ],
+    "valid_targets": [
+      "ground"
+    ],
     "effect": "summon",
     "effect_str": "mon_wisp",
     "shape": "blast",
-    "flags": [ "LOUD", "SOMATIC" ],
+    "flags": [
+      "CONJURATION_SPELL",
+      "LOUD",
+      "SOMATIC"
+    ],
     "energy_source": "MANA",
     "spell_class": "ANIMIST",
     "difficulty": 2,
@@ -212,17 +355,34 @@
     "range_increment": 0.16,
     "min_duration": 6000,
     "max_duration": 90000,
-    "duration_increment": 2160
+    "duration_increment": 2160,
+    "extra_effects": [
+      {
+        "id": "eoc_summon_setup",
+        "hit_self": true
+      }
+    ]
   },
   {
     "id": "bleed",
     "type": "SPELL",
-    "name": { "str": "Bleed" },
+    "name": {
+      "str": "Bleed"
+    },
     "description": "With a shout and a gesture, the target starts bleeding from old wounds.",
-    "valid_targets": [ "hostile" ],
+    "valid_targets": [
+      "hostile"
+    ],
     "effect": "attack",
     "shape": "blast",
-    "flags": [ "VERBAL", "SOMATIC", "NO_LEGS", "NO_PROJECTILE", "NO_HANDS" ],
+    "flags": [
+      "EVOCATION_SPELL",
+      "VERBAL",
+      "SOMATIC",
+      "NO_LEGS",
+      "NO_PROJECTILE",
+      "NO_HANDS"
+    ],
     "energy_source": "MANA",
     "spell_class": "ANIMIST",
     "difficulty": 2,
@@ -241,19 +401,35 @@
     "duration_increment": 20,
     "min_dot": 2,
     "max_dot": 76,
-    "dot_increment": 2
+    "dot_increment": 2,
+    "extra_effects": [
+      {
+        "id": "eoc_evocation_setup",
+        "hit_self": true
+      }
+    ]
   },
   {
     "id": "animist_summon_watcher",
     "type": "SPELL",
-    "name": { "str": "Summon Watcher Spirit" },
+    "name": {
+      "str": "Summon Watcher Spirit"
+    },
     "description": "Summon a watcher spirit, whose senses overlap with your own and through whose eyes you can see.  Although they are spirits, they are fragile and dissipate easily in the face of any assault.",
-    "flags": [ "SOMATIC", "CONCENTRATE", "VERBAL", "NO_PROJECTILE" ],
+    "flags": [
+      "CONJURATION_SPELL",
+      "SOMATIC",
+      "CONCENTRATE",
+      "VERBAL",
+      "NO_PROJECTILE"
+    ],
     "spell_class": "ANIMIST",
     "effect": "summon",
     "effect_str": "mon_watcher_spirit",
     "shape": "blast",
-    "valid_targets": [ "ground" ],
+    "valid_targets": [
+      "ground"
+    ],
     "difficulty": 3,
     "max_level": 22,
     "min_damage": 1,
@@ -266,6 +442,12 @@
     "duration_increment": 24000,
     "energy_source": "MANA",
     "base_casting_time": 500,
-    "base_energy_cost": 150
+    "base_energy_cost": 150,
+    "extra_effects": [
+      {
+        "id": "eoc_summon_setup",
+        "hit_self": true
+      }
+    ]
   }
 ]

--- a/Kenan-Structured-Modpack/High-Maintenance-Huge-Mods/MagicRevampAdditions/Spells_Override/biomancer.json
+++ b/Kenan-Structured-Modpack/High-Maintenance-Huge-Mods/MagicRevampAdditions/Spells_Override/biomancer.json
@@ -2,12 +2,17 @@
   {
     "id": "light_healing",
     "type": "SPELL",
-    "name": { "str": "Cure Light Wounds" },
+    "name": {
+      "str": "Cure Light Wounds"
+    },
     "description": "Heals a little bit of damage on the target.",
-    "valid_targets": [ "self", "ally" ],
+    "valid_targets": [
+      "self",
+      "ally"
+    ],
     "min_damage": -5,
     "max_damage": -30,
-    "damage_increment": -1.0,
+    "damage_increment": -1,
     "max_level": 22,
     "min_range": 0,
     "max_range": 6,
@@ -16,33 +21,63 @@
     "shape": "blast",
     "base_casting_time": 300,
     "base_energy_cost": 800,
-    "flags": [ "SOMATIC", "VERBAL", "NO_PROJECTILE" ],
+    "flags": [
+      "RESTORATION_SPELL",
+      "SOMATIC",
+      "VERBAL",
+      "NO_PROJECTILE"
+    ],
     "spell_class": "BIOMANCER",
     "difficulty": 2,
-    "energy_source": "MANA"
+    "energy_source": "MANA",
+    "extra_effects": [
+      {
+        "id": "eoc_restoration_setup",
+        "hit_self": true
+      }
+    ]
   },
   {
     "id": "pain_split",
     "type": "SPELL",
-    "name": { "str": "Pain Split" },
+    "name": {
+      "str": "Pain Split"
+    },
     "description": "Evens out damage among your limbs.",
-    "valid_targets": [ "self" ],
+    "valid_targets": [
+      "self"
+    ],
     "effect": "pain_split",
     "shape": "blast",
     "base_casting_time": 100,
     "base_energy_cost": 800,
     "energy_source": "MANA",
-    "flags": [ "SOMATIC", "NO_LEGS", "CONCENTRATE" ],
+    "flags": [
+      "TRANSFORMATION_SPELL",
+      "SOMATIC",
+      "NO_LEGS",
+      "CONCENTRATE"
+    ],
     "spell_class": "BIOMANCER",
     "difficulty": 4,
-    "max_level": 1
+    "max_level": 1,
+    "extra_effects": [
+      {
+        "id": "eoc_transformation_setup",
+        "hit_self": true
+      }
+    ]
   },
   {
     "id": "vicious_tentacle",
     "type": "SPELL",
-    "name": { "str": "Vicious Tentacle" },
+    "name": {
+      "str": "Vicious Tentacle"
+    },
     "description": "This spell extrudes a long nasty whiplike tentacle of sharp bones and oozing acid from your body, it has a long reach attack and vicious damage.",
-    "valid_targets": [ "self" ],
+    "valid_targets": [
+      "self"
+    ],
     "min_damage": 1,
     "max_damage": 1,
     "effect": "spawn_item",
@@ -55,17 +90,33 @@
     "duration_increment": 24000,
     "difficulty": 6,
     "max_level": 22,
-    "flags": [ "SOMATIC", "LOUD" ],
+    "flags": [
+      "TRANSFORMATION_SPELL",
+      "SOMATIC",
+      "LOUD"
+    ],
     "spell_class": "BIOMANCER",
-    "learn_spells": { "vicious_tentacle_plus": 15 },
-    "energy_source": "MANA"
+    "learn_spells": {
+      "vicious_tentacle_plus": 15
+    },
+    "energy_source": "MANA",
+    "extra_effects": [
+      {
+        "id": "eoc_transformation_setup",
+        "hit_self": true
+      }
+    ]
   },
   {
     "id": "vicious_tentacle_plus",
     "type": "SPELL",
-    "name": { "str": "Evolved Vicious Tentacle" },
+    "name": {
+      "str": "Evolved Vicious Tentacle"
+    },
     "description": "This spell extrudes a long nasty whiplike tentacle of sharp bones and oozing acid from your body, it has a long reach attack and vicious damage.  Now you know this spell like the back of your hand, and start to design your own version.",
-    "valid_targets": [ "self" ],
+    "valid_targets": [
+      "self"
+    ],
     "min_damage": 1,
     "max_damage": 1,
     "effect": "spawn_item",
@@ -82,16 +133,30 @@
     "duration_increment": 72000,
     "difficulty": 7,
     "max_level": 37,
-    "flags": [ "LOUD" ],
+    "flags": [
+      "TRANSFORMATION_SPELL",
+      "LOUD",
+      "NO_FAIL"
+    ],
     "spell_class": "BIOMANCER",
-    "energy_source": "MANA"
+    "energy_source": "MANA",
+    "extra_effects": [
+      {
+        "id": "eoc_transformation_setup",
+        "hit_self": true
+      }
+    ]
   },
   {
     "id": "bio_grotesque",
     "type": "SPELL",
-    "name": { "str": "Grotesque Enhancement" },
+    "name": {
+      "str": "Grotesque Enhancement"
+    },
     "description": "A spell that warps your body in alien ways to increase your physical abilities and strength.",
-    "valid_targets": [ "self" ],
+    "valid_targets": [
+      "self"
+    ],
     "effect": "attack",
     "effect_str": "bio_boost",
     "shape": "blast",
@@ -99,24 +164,40 @@
     "casting_time_increment": -2.5,
     "final_casting_time": 50,
     "base_energy_cost": 250,
-    "energy_increment": -5.0,
+    "energy_increment": -5,
     "final_energy_cost": 100,
     "energy_source": "MANA",
     "spell_class": "BIOMANCER",
     "difficulty": 6,
     "max_level": 30,
-    "flags": [ "SOMATIC", "LOUD" ],
+    "flags": [
+      "TRANSFORMATION_SPELL",
+      "SOMATIC",
+      "LOUD"
+    ],
     "//": "duration is in moves",
     "min_duration": 6000,
     "max_duration": 90000,
-    "duration_increment": 3000
+    "duration_increment": 3000,
+    "extra_effects": [
+      {
+        "id": "eoc_transformation_setup",
+        "hit_self": true
+      }
+    ]
   },
   {
     "id": "bio_acidicspray",
     "type": "SPELL",
-    "name": { "str": "Acidic Spray" },
+    "name": {
+      "str": "Acidic Spray"
+    },
     "description": "When cast, the mage opens his mouth and sprays acid in a wide cone to dissolve his foes into goo.  Just imagine what he'll do with the goo.",
-    "valid_targets": [ "ally", "hostile", "ground" ],
+    "valid_targets": [
+      "ally",
+      "hostile",
+      "ground"
+    ],
     "effect": "attack",
     "effect_str": "bio_acidburn",
     "shape": "cone",
@@ -128,22 +209,36 @@
     "max_level": 30,
     "min_damage": 8,
     "max_damage": 97,
-    "damage_increment": 4.0,
+    "damage_increment": 4,
     "damage_type": "acid",
     "min_range": 3,
     "max_range": 8,
-    "flags": [ "VERBAL", "NO_HANDS" ],
+    "flags": [
+      "EVOCATION_SPELL",
+      "VERBAL",
+      "NO_HANDS"
+    ],
     "range_increment": 0.25,
     "min_aoe": 25,
     "max_aoe": 90,
-    "aoe_increment": 5.0
+    "aoe_increment": 5,
+    "extra_effects": [
+      {
+        "id": "eoc_evocation_setup",
+        "hit_self": true
+      }
+    ]
   },
   {
     "id": "bio_fleshpouch",
     "type": "SPELL",
-    "name": { "str": "Flesh Pouch" },
+    "name": {
+      "str": "Flesh Pouch"
+    },
     "description": "This spell grows a large pouch out of your skin on your back, allowing you to store your gear in it.",
-    "valid_targets": [ "none" ],
+    "valid_targets": [
+      "none"
+    ],
     "min_damage": 1,
     "max_damage": 1,
     "effect": "spawn_item",
@@ -156,16 +251,31 @@
     "duration_increment": 520000,
     "difficulty": 4,
     "max_level": 30,
-    "flags": [ "NO_HANDS", "NO_LEGS", "SOMATIC" ],
+    "flags": [
+      "TRANSFORMATION_SPELL",
+      "NO_HANDS",
+      "NO_LEGS",
+      "SOMATIC"
+    ],
     "spell_class": "BIOMANCER",
-    "energy_source": "MANA"
+    "energy_source": "MANA",
+    "extra_effects": [
+      {
+        "id": "eoc_transformation_setup",
+        "hit_self": true
+      }
+    ]
   },
   {
     "id": "bio_bonespear",
     "type": "SPELL",
-    "name": { "str": "Conjure Bonespear" },
+    "name": {
+      "str": "Conjure Bonespear"
+    },
     "description": "This spell creates a long shaft of bone with a wicked point and blades along its length.",
-    "valid_targets": [ "self" ],
+    "valid_targets": [
+      "self"
+    ],
     "min_damage": 1,
     "max_damage": 1,
     "effect": "spawn_item",
@@ -178,17 +288,33 @@
     "duration_increment": 24000,
     "difficulty": 8,
     "max_level": 22,
-    "flags": [ "LOUD", "SOMATIC" ],
+    "flags": [
+      "CONJURATION_SPELL",
+      "LOUD",
+      "SOMATIC"
+    ],
     "spell_class": "BIOMANCER",
-    "learn_spells": { "bio_bonespear_plus": 15 },
-    "energy_source": "MANA"
+    "learn_spells": {
+      "bio_bonespear_plus": 15
+    },
+    "energy_source": "MANA",
+    "extra_effects": [
+      {
+        "id": "eoc_summon_setup",
+        "hit_self": true
+      }
+    ]
   },
   {
     "id": "bio_bonespear_plus",
     "type": "SPELL",
-    "name": { "str": "Evolved Conjure Bonespear" },
+    "name": {
+      "str": "Evolved Conjure Bonespear"
+    },
     "description": "This spell creates a long shaft of bone with a wicked point and blades along its length.  Now you know this spell like the back of your hand, and start to design your own version.",
-    "valid_targets": [ "self" ],
+    "valid_targets": [
+      "self"
+    ],
     "min_damage": 1,
     "max_damage": 1,
     "effect": "spawn_item",
@@ -205,16 +331,30 @@
     "duration_increment": 72000,
     "difficulty": 9,
     "max_level": 37,
-    "flags": [ "LOUD" ],
+    "flags": [
+      "CONJURATION_SPELL",
+      "LOUD",
+      "NO_FAIL"
+    ],
     "spell_class": "BIOMANCER",
-    "energy_source": "MANA"
+    "energy_source": "MANA",
+    "extra_effects": [
+      {
+        "id": "eoc_summon_setup",
+        "hit_self": true
+      }
+    ]
   },
   {
     "id": "create_rune_biomancer",
     "type": "SPELL",
-    "name": { "str": "Biomancer Rune" },
+    "name": {
+      "str": "Biomancer Rune"
+    },
     "description": "This ritual creates a small pebble attuned to Biomancers.  You can use the rune as a catalyst for recipes.",
-    "valid_targets": [ "self" ],
+    "valid_targets": [
+      "self"
+    ],
     "min_damage": 1,
     "max_damage": 1,
     "effect": "spawn_item",
@@ -229,18 +369,38 @@
     "max_level": 0,
     "spell_class": "BIOMANCER",
     "energy_source": "MANA",
-    "flags": [ "PERMANENT", "NO_LEGS", "CONCENTRATE" ]
+    "flags": [
+      "CHANNELING_SPELL",
+      "PERMANENT",
+      "NO_LEGS",
+      "CONCENTRATE"
+    ],
+    "extra_effects": [
+      {
+        "id": "eoc_channeling_setup",
+        "hit_self": true
+      }
+    ]
   },
   {
     "id": "biomancer_paralytic_dart",
     "type": "SPELL",
-    "name": { "str": "Paralytic Dart" },
+    "name": {
+      "str": "Paralytic Dart"
+    },
     "description": "Spits a warped needle of sinew and bone, carrying with it a sting that slows your victim.",
-    "valid_targets": [ "ally", "hostile" ],
+    "valid_targets": [
+      "ally",
+      "hostile"
+    ],
     "effect": "attack",
     "effect_str": "biomancer_dart_venom",
     "shape": "blast",
-    "flags": [ "VERBAL", "NO_HANDS" ],
+    "flags": [
+      "EVOCATION_SPELL",
+      "VERBAL",
+      "NO_HANDS"
+    ],
     "spell_class": "BIOMANCER",
     "energy_source": "MANA",
     "difficulty": 3,
@@ -256,19 +416,47 @@
     "range_increment": 0.4,
     "min_duration": 1200,
     "max_duration": 18000,
-    "duration_increment": 720
+    "duration_increment": 720,
+    "extra_effects": [
+      {
+        "id": "eoc_evocation_setup",
+        "hit_self": true
+      }
+    ]
   },
   {
     "id": "biomancer_visceral_projection",
     "type": "SPELL",
-    "name": { "str": "Visceral Projection" },
+    "name": {
+      "str": "Visceral Projection"
+    },
     "description": "Projects a spray of acrid blood and gore all around you, growing to ensnare your prey in in a field of twitching poisonous tendrils.",
-    "valid_targets": [ "ally", "hostile", "ground" ],
+    "valid_targets": [
+      "ally",
+      "hostile",
+      "ground"
+    ],
     "effect": "attack",
     "effect_str": "badpoison",
     "shape": "blast",
-    "extra_effects": [ { "id": "biomancer_visceral_paralyze" }, { "id": "biomancer_visceral_backlash", "hit_self": true } ],
-    "flags": [ "VERBAL", "NO_HANDS" ],
+    "extra_effects": [
+      {
+        "id": "biomancer_visceral_paralyze"
+      },
+      {
+        "id": "biomancer_visceral_backlash",
+        "hit_self": true
+      },
+      {
+        "id": "eoc_evocation_setup",
+        "hit_self": true
+      }
+    ],
+    "flags": [
+      "EVOCATION_SPELL",
+      "VERBAL",
+      "NO_HANDS"
+    ],
     "spell_class": "BIOMANCER",
     "energy_source": "MANA",
     "difficulty": 4,
@@ -291,13 +479,21 @@
   {
     "id": "biomancer_visceral_paralyze",
     "type": "SPELL",
-    "name": { "str": "Visceral Paralysis" },
+    "name": {
+      "str": "Visceral Paralysis"
+    },
     "description": "Paralytic side effect of Projection.",
-    "valid_targets": [ "ally", "hostile" ],
+    "valid_targets": [
+      "ally",
+      "hostile"
+    ],
     "effect": "attack",
     "effect_str": "biomancer_dart_venom",
     "shape": "blast",
-    "flags": [ "SILENT" ],
+    "flags": [
+      "EVOCATION_SPELL",
+      "SILENT"
+    ],
     "max_level": 30,
     "min_aoe": 2,
     "max_aoe": 9,
@@ -309,31 +505,51 @@
     "field_chance": 1,
     "min_field_intensity": 1,
     "max_field_intensity": 3,
-    "field_intensity_increment": 0.1
+    "field_intensity_increment": 0.1,
+    "extra_effects": [
+      {
+        "id": "eoc_evocation_setup",
+        "hit_self": true
+      }
+    ]
   },
   {
     "id": "biomancer_visceral_backlash",
     "type": "SPELL",
-    "name": { "str": "Visceral Backlash" },
+    "name": {
+      "str": "Visceral Backlash"
+    },
     "description": "Hits the user with side effects too.",
-    "valid_targets": [ "self" ],
+    "valid_targets": [
+      "self"
+    ],
     "effect": "attack",
     "effect_str": "biomancer_visceral_side_effects",
     "shape": "blast",
-    "flags": [ "VERBAL" ],
+    "flags": [
+      "VERBAL"
+    ],
     "min_duration": 600,
     "max_duration": 600
   },
   {
     "id": "biomancer_coagulant_weave",
     "type": "SPELL",
-    "name": { "str": "Coagulant Weave" },
+    "name": {
+      "str": "Coagulant Weave"
+    },
     "description": "Turns your biological mastery inwards, medically enhancing your flesh.  Rather than strength of healing, it staves off blood loss and purges wounds before they can turn septic, at the cost of increased hunger and thirst.",
-    "valid_targets": [ "self" ],
+    "valid_targets": [
+      "self"
+    ],
     "effect": "attack",
     "effect_str": "bio_weave",
     "shape": "blast",
-    "flags": [ "SOMATIC", "VERBAL" ],
+    "flags": [
+      "ENHANCEMENT_SPELL",
+      "SOMATIC",
+      "VERBAL"
+    ],
     "energy_source": "MANA",
     "spell_class": "BIOMANCER",
     "difficulty": 5,
@@ -342,20 +558,33 @@
     "max_level": 30,
     "min_duration": 6000,
     "max_duration": 135000,
-    "duration_increment": 4200
+    "duration_increment": 4200,
+    "extra_effects": [
+      {
+        "id": "eoc_enhancement_setup",
+        "hit_self": true
+      }
+    ]
   },
   {
     "id": "corrosive_aura_spell",
     "type": "SPELL",
-    "name": { "str": "Caustic Feedback" },
+    "name": {
+      "str": "Caustic Feedback"
+    },
     "description": "This is a sub-spell of the Caustic Aura spell.",
-    "valid_targets": [ "hostile" ],
+    "valid_targets": [
+      "hostile"
+    ],
     "effect": "attack",
     "shape": "blast",
     "damage_type": "acid",
     "min_damage": 3,
     "max_damage": 3,
-    "flags": [ "SILENT", "NO_PROJECTILE" ],
+    "flags": [
+      "SILENT",
+      "NO_PROJECTILE"
+    ],
     "sound_type": "combat",
     "sound_description": "acidic sizzle!",
     "min_range": 2,
@@ -368,13 +597,21 @@
   {
     "id": "biomancer_caustic_aura",
     "type": "SPELL",
-    "name": { "str": "Caustic Aura" },
+    "name": {
+      "str": "Caustic Aura"
+    },
     "description": "This spell suspends acid in a layer around you, corroding melee attackers when struck and enhancing your melee damage.",
-    "valid_targets": [ "self" ],
+    "valid_targets": [
+      "self"
+    ],
     "effect": "spawn_item",
     "effect_str": "aura_caustic",
     "shape": "blast",
-    "flags": [ "SOMATIC", "CONCENTRATE" ],
+    "flags": [
+      "ENHANCEMENT_SPELL",
+      "SOMATIC",
+      "CONCENTRATE"
+    ],
     "components": "spell_components_causticaura",
     "energy_source": "MANA",
     "spell_class": "BIOMANCER",
@@ -389,18 +626,34 @@
     "min_duration": 24000,
     "max_duration": 52000,
     "duration_increment": 24000,
-    "learn_spells": { "biomancer_caustic_aura_plus": 15 }
+    "learn_spells": {
+      "biomancer_caustic_aura_plus": 15
+    },
+    "extra_effects": [
+      {
+        "id": "eoc_enhancement_setup",
+        "hit_self": true
+      }
+    ]
   },
   {
     "id": "biomancer_caustic_aura_plus",
     "type": "SPELL",
-    "name": { "str": "Improved Caustic Aura" },
+    "name": {
+      "str": "Improved Caustic Aura"
+    },
     "description": "This spell suspends acid in a layer around you, corroding melee attackers when struck and enhancing your melee damage.  Now you know this spell like the back of your hand, and start to design your own version.",
-    "valid_targets": [ "self" ],
+    "valid_targets": [
+      "self"
+    ],
     "effect": "spawn_item",
     "effect_str": "aura_caustic",
     "shape": "blast",
-    "flags": [ "SOMATIC" ],
+    "flags": [
+      "ENHANCEMENT_SPELL",
+      "SOMATIC",
+      "NO_FAIL"
+    ],
     "components": "spell_components_causticaura",
     "energy_source": "MANA",
     "spell_class": "BIOMANCER",
@@ -418,16 +671,31 @@
     "max_range": 1,
     "min_duration": 360000,
     "max_duration": 3220000,
-    "duration_increment": 72000
+    "duration_increment": 72000,
+    "extra_effects": [
+      {
+        "id": "eoc_summon_setup",
+        "hit_self": true
+      }
+    ]
   },
   {
     "id": "biomancer_swim_frog",
     "type": "SPELL",
-    "name": { "str": "Limbs of the Frog" },
+    "name": {
+      "str": "Limbs of the Frog"
+    },
     "description": "Grow webbing on your hands and feet, making quick swimming a breeze.",
-    "valid_targets": [ "self" ],
+    "valid_targets": [
+      "self"
+    ],
     "spell_class": "BIOMANCER",
-    "flags": [ "CONCENTRATE", "VERBAL", "SOMATIC" ],
+    "flags": [
+      "TRANSFORMATION_SPELL",
+      "CONCENTRATE",
+      "VERBAL",
+      "SOMATIC"
+    ],
     "effect": "attack",
     "effect_str": "effect_biomancer_swim_speed",
     "shape": "blast",
@@ -438,16 +706,32 @@
     "duration_increment": 24000,
     "energy_source": "MANA",
     "base_energy_cost": 300,
-    "base_casting_time": 1000
+    "base_casting_time": 1000,
+    "extra_effects": [
+      {
+        "id": "eoc_transformation_setup",
+        "hit_self": true
+      }
+    ]
   },
   {
     "id": "biomancer_cure_disease_minor",
     "type": "SPELL",
-    "name": { "str": "Cure Disease, Minor" },
+    "name": {
+      "str": "Cure Disease, Minor"
+    },
     "description": "Cure any flu or common cold you might be suffering from.  This is one of the few biomantic cure spells that is castable on other people.",
-    "valid_targets": [ "self", "ally" ],
+    "valid_targets": [
+      "self",
+      "ally"
+    ],
     "spell_class": "BIOMANCER",
-    "flags": [ "CONCENTRATE", "VERBAL", "SOMATIC" ],
+    "flags": [
+      "RESTORATION_SPELL",
+      "CONCENTRATE",
+      "VERBAL",
+      "SOMATIC"
+    ],
     "effect": "attack",
     "effect_str": "effect_biomancer_cure_disease_minor",
     "shape": "blast",
@@ -461,6 +745,12 @@
     "base_energy_cost": 350,
     "base_casting_time": 90000,
     "final_casting_time": 16000,
-    "casting_time_increment": -6000
+    "casting_time_increment": -6000,
+    "extra_effects": [
+      {
+        "id": "eoc_restoration_setup",
+        "hit_self": true
+      }
+    ]
   }
 ]

--- a/Kenan-Structured-Modpack/High-Maintenance-Huge-Mods/MagicRevampAdditions/Spells_Override/black_dragon.json
+++ b/Kenan-Structured-Modpack/High-Maintenance-Huge-Mods/MagicRevampAdditions/Spells_Override/black_dragon.json
@@ -2,20 +2,32 @@
   {
     "type": "SPELL",
     "id": "acid_claw",
-    "name": { "str": "Acid Claw" },
+    "name": {
+      "str": "Acid Claw"
+    },
     "description": "Your claws glow with yellow acid energy, and as you swipe your claw a wave of acid sweeps forth from it.",
-    "valid_targets": [ "hostile", "ground" ],
-    "flags": [ "SOMATIC", "VERBAL", "LOUD" ],
+    "valid_targets": [
+      "hostile",
+      "ground"
+    ],
+    "flags": [
+      "EVOCATION_SPELL",
+      "SOMATIC",
+      "VERBAL",
+      "LOUD"
+    ],
     "spell_class": "NONE",
     "effect": "attack",
     "effect_str": "dragon_acidburn",
     "shape": "cone",
-    "affected_body_parts": [ "torso" ],
+    "affected_body_parts": [
+      "torso"
+    ],
     "damage_type": "acid",
     "max_level": 7,
     "min_damage": 5,
     "max_damage": 97,
-    "damage_increment": 15.0,
+    "damage_increment": 15,
     "min_range": 3,
     "max_range": 7,
     "range_increment": 0.5,
@@ -31,25 +43,42 @@
     "final_casting_time": 140,
     "casting_time_increment": -10,
     "energy_source": "MANA",
-    "base_energy_cost": 350
+    "base_energy_cost": 350,
+    "extra_effects": [
+      {
+        "id": "eoc_evocation_setup",
+        "hit_self": true
+      }
+    ]
   },
   {
     "type": "SPELL",
     "id": "acid_bite",
-    "name": { "str": "Acid Bite" },
+    "name": {
+      "str": "Acid Bite"
+    },
     "description": "Your maw drips with acid as you make a bite attack.",
-    "valid_targets": [ "hostile" ],
-    "flags": [ "VERBAL", "NO_HANDS", "LOUD" ],
+    "valid_targets": [
+      "hostile"
+    ],
+    "flags": [
+      "EVOCATION_SPELL",
+      "VERBAL",
+      "NO_HANDS",
+      "LOUD"
+    ],
     "spell_class": "NONE",
     "effect": "attack",
     "effect_str": "dragon_acidburn",
     "shape": "blast",
-    "affected_body_parts": [ "torso" ],
+    "affected_body_parts": [
+      "torso"
+    ],
     "damage_type": "acid",
     "max_level": 7,
     "min_damage": 15,
     "max_damage": 100,
-    "damage_increment": 15.0,
+    "damage_increment": 15,
     "min_range": 1,
     "max_range": 1,
     "difficulty": 0,
@@ -58,26 +87,45 @@
     "casting_time_increment": -9,
     "energy_source": "MANA",
     "base_energy_cost": 350,
-    "extra_effects": [ { "id": "dragon_bite" } ]
+    "extra_effects": [
+      {
+        "id": "dragon_bite"
+      },
+      {
+        "id": "eoc_evocation_setup",
+        "hit_self": true
+      }
+    ]
   },
   {
     "type": "SPELL",
     "id": "dragon_bite",
-    "name": { "str": "Dragon's Bite" },
+    "name": {
+      "str": "Dragon's Bite"
+    },
     "description": "The bite damage in Acid Bite.",
-    "valid_targets": [ "hostile" ],
+    "valid_targets": [
+      "hostile"
+    ],
     "effect": "attack",
     "shape": "blast",
     "damage_type": "stab",
     "min_damage": 20,
-    "max_damage": 20
+    "max_damage": 20,
+    "flags": [
+      "EVOCATION_SPELL"
+    ]
   },
   {
     "id": "dragon_shell_black",
     "type": "SPELL",
-    "name": { "str": "Black Dragon Shell" },
+    "name": {
+      "str": "Black Dragon Shell"
+    },
     "description": "You channel your inner draconic magic to protect yourself from damage and reflect some back as acid damage.",
-    "valid_targets": [ "none" ],
+    "valid_targets": [
+      "none"
+    ],
     "min_range": 0,
     "max_range": 0,
     "min_damage": 1,
@@ -87,32 +135,50 @@
     "shape": "blast",
     "energy_source": "MANA",
     "spell_class": "NONE",
-    "flags": [ "CONCENTRATE" ],
+    "flags": [
+      "CONJURATION_SPELL",
+      "CONCENTRATE"
+    ],
     "difficulty": 1,
     "max_level": 22,
     "base_casting_time": 200,
     "base_energy_cost": 250,
     "min_duration": 1000,
     "max_duration": 7500,
-    "duration_increment": 1000
+    "duration_increment": 1000,
+    "extra_effects": [
+      {
+        "id": "eoc_summon_setup",
+        "hit_self": true
+      }
+    ]
   },
   {
     "id": "dragon_shell_retaliation_black",
     "type": "SPELL",
-    "name": { "str": "Black Dragon Shell Retaliation" },
+    "name": {
+      "str": "Black Dragon Shell Retaliation"
+    },
     "description": "Acid burst that punishes attackers.",
     "effect": "attack",
     "effect_str": "dragon_acidburn",
     "shape": "blast",
-    "affected_body_parts": [ "torso" ],
-    "valid_targets": [ "hostile" ],
+    "affected_body_parts": [
+      "torso"
+    ],
+    "valid_targets": [
+      "hostile"
+    ],
     "min_damage": 0,
     "max_damage": 10,
-    "damage_increment": 1.0,
-    "flags": [ "RANDOM_DAMAGE", "RANDOM_AOE" ],
+    "damage_increment": 1,
+    "flags": [
+      "RANDOM_DAMAGE",
+      "RANDOM_AOE"
+    ],
     "min_aoe": 0,
     "max_aoe": 3,
-    "aoe_increment": 1.0,
+    "aoe_increment": 1,
     "min_range": 1,
     "max_range": 1,
     "spell_class": "NONE",
@@ -121,13 +187,20 @@
   {
     "id": "dragon_terror",
     "type": "SPELL",
-    "name": { "str": "Dragon Terror" },
+    "name": {
+      "str": "Dragon Terror"
+    },
     "description": "With an ear piercing roar, you channel the inner power of dragons and strike fear into those who stand before you, slowing their escape from your terror.",
-    "valid_targets": [ "hostile", "ground" ],
+    "valid_targets": [
+      "hostile",
+      "ground"
+    ],
     "effect": "attack",
     "effect_str": "dragon_terror_debuff",
     "shape": "blast",
-    "affected_body_parts": [ "torso" ],
+    "affected_body_parts": [
+      "torso"
+    ],
     "max_level": 7,
     "min_damage": 0,
     "max_damage": 0,
@@ -143,18 +216,46 @@
     "base_energy_cost": 400,
     "energy_source": "MANA",
     "difficulty": 0,
-    "flags": [ "LOUD", "NO_HANDS", "NO_LEGS" ]
+    "flags": [
+      "ENERVATION_SPELL",
+      "LOUD",
+      "NO_HANDS",
+      "NO_LEGS"
+    ],
+    "extra_effects": [
+      {
+        "id": "eoc_enervation_setup",
+        "hit_self": true
+      }
+    ]
   },
   {
     "id": "dragon_boost",
     "type": "SPELL",
-    "name": { "str": "Dragon Boost" },
+    "name": {
+      "str": "Dragon Boost"
+    },
     "description": "You let out a mighty roar as you infuse yourself with the power of Dragons.",
-    "valid_targets": [ "self" ],
+    "valid_targets": [
+      "self"
+    ],
     "effect": "attack",
     "effect_str": "dragon_boost",
     "shape": "blast",
-    "extra_effects": [ { "id": "health_recovery", "hit_self": true }, { "id": "stamina_recovery", "hit_self": true } ],
+    "extra_effects": [
+      {
+        "id": "health_recovery",
+        "hit_self": true
+      },
+      {
+        "id": "stamina_recovery",
+        "hit_self": true
+      },
+      {
+        "id": "eoc_enhancement_setup",
+        "hit_self": true
+      }
+    ],
     "max_level": 7,
     "min_range": 1,
     "max_range": 1,
@@ -165,48 +266,81 @@
     "base_energy_cost": 150,
     "energy_source": "MANA",
     "difficulty": 0,
-    "flags": [ "LOUD", "NO_HANDS", "NO_LEGS" ]
+    "flags": [
+      "ENHANCEMENT_SPELL",
+      "LOUD",
+      "NO_HANDS",
+      "NO_LEGS"
+    ]
   },
   {
     "type": "SPELL",
     "id": "health_recovery",
-    "name": { "str": "Health recovery" },
+    "name": {
+      "str": "Health recovery"
+    },
     "description": "minor health recovery spell associated with Dragon Boost.",
-    "valid_targets": [ "self" ],
+    "valid_targets": [
+      "self"
+    ],
     "effect": "attack",
     "shape": "blast",
     "min_damage": 0,
     "max_damage": -10,
-    "flags": [ "SILENT", "RANDOM_DAMAGE" ]
+    "flags": [
+      "ENHANCEMENT_SPELL",
+      "SILENT",
+      "RANDOM_DAMAGE"
+    ]
   },
   {
     "type": "SPELL",
     "id": "stamina_recovery",
-    "name": { "str": "Stamina recovery" },
+    "name": {
+      "str": "Stamina recovery"
+    },
     "description": "minor stamina recovery spell associated with Dragon Boost.",
-    "valid_targets": [ "self" ],
+    "valid_targets": [
+      "self"
+    ],
     "effect": "recover_energy",
     "effect_str": "STAMINA",
     "shape": "blast",
     "min_damage": 0,
     "max_damage": 500,
-    "flags": [ "SILENT", "RANDOM_DAMAGE" ]
+    "flags": [
+      "ENHANCEMENT_SPELL",
+      "SILENT",
+      "RANDOM_DAMAGE"
+    ]
   },
   {
     "id": "dragon_spit_acid",
     "type": "SPELL",
-    "name": { "str": "Dragon Acid Spit" },
+    "name": {
+      "str": "Dragon Acid Spit"
+    },
     "description": "You conjur up acidic spittle that you can shoot long distances as you close on your terrified prey.",
-    "valid_targets": [ "hostile" ],
-    "flags": [ "LOUD", "VERBAL", "NO_HANDS", "NO_LEGS" ],
+    "valid_targets": [
+      "hostile"
+    ],
+    "flags": [
+      "EVOCATION_SPELL",
+      "LOUD",
+      "VERBAL",
+      "NO_HANDS",
+      "NO_LEGS"
+    ],
     "effect": "attack",
     "shape": "blast",
     "damage_type": "acid",
     "effect_str": "lesser_dragon_acidburn",
-    "affected_body_parts": [ "torso" ],
+    "affected_body_parts": [
+      "torso"
+    ],
     "min_damage": 10,
     "max_damage": 70,
-    "damage_increment": 10.0,
+    "damage_increment": 10,
     "min_range": 5,
     "max_range": 15,
     "range_increment": 2,
@@ -216,19 +350,31 @@
     "final_casting_time": 140,
     "casting_time_increment": -10,
     "energy_source": "MANA",
-    "base_energy_cost": 100
+    "base_energy_cost": 100,
+    "extra_effects": [
+      {
+        "id": "eoc_evocation_setup",
+        "hit_self": true
+      }
+    ]
   },
   {
     "type": "SPELL",
     "id": "dragon_breath_acid",
-    "name": { "str": "Black Dragon Breath" },
+    "name": {
+      "str": "Black Dragon Breath"
+    },
     "description": "Spews a line of acid from your mouth.",
-    "valid_targets": [ "hostile", "ally", "ground" ],
+    "valid_targets": [
+      "hostile",
+      "ally",
+      "ground"
+    ],
     "damage_type": "acid",
     "max_level": 7,
     "min_damage": 5,
     "max_damage": 65,
-    "damage_increment": 10.0,
+    "damage_increment": 10,
     "min_range": 8,
     "max_range": 14,
     "range_increment": 1,
@@ -242,6 +388,18 @@
     "base_casting_time": 200,
     "energy_source": "MANA",
     "base_energy_cost": 200,
-    "flags": [ "VERBAL", "NO_HANDS", "NO_LEGS", "LOUD" ]
+    "flags": [
+      "EVOCATION_SPELL",
+      "VERBAL",
+      "NO_HANDS",
+      "NO_LEGS",
+      "LOUD"
+    ],
+    "extra_effects": [
+      {
+        "id": "eoc_evocation_setup",
+        "hit_self": true
+      }
+    ]
   }
 ]

--- a/Kenan-Structured-Modpack/High-Maintenance-Huge-Mods/MagicRevampAdditions/Spells_Override/classless.json
+++ b/Kenan-Structured-Modpack/High-Maintenance-Huge-Mods/MagicRevampAdditions/Spells_Override/classless.json
@@ -2,10 +2,14 @@
   {
     "id": "dark_sight",
     "type": "SPELL",
-    "name": { "str": "Dark Sight" },
+    "name": {
+      "str": "Dark Sight"
+    },
     "description": "Gives you the power to see in the dark",
     "message": "Your eyes glow green for a moment.  Now your sight can pierce the darkest shadows.",
-    "valid_targets": [ "self" ],
+    "valid_targets": [
+      "self"
+    ],
     "effect": "attack",
     "effect_str": "dark_sight",
     "shape": "blast",
@@ -18,14 +22,32 @@
     "max_level": 30,
     "min_duration": 100000,
     "max_duration": 1500000,
-    "duration_increment": 45000
+    "duration_increment": 45000,
+    "flags": [
+      "ENHANCEMENT_SPELL",
+      "VERBAL",
+      "NO_LEGS",
+      "CONCENTRATE"
+    ],
+    "extra_effects": [
+      {
+        "id": "eoc_enhancement_setup",
+        "hit_self": true
+      }
+    ]
   },
   {
     "id": "megablast",
     "type": "SPELL",
-    "name": { "str": "Megablast" },
+    "name": {
+      "str": "Megablast"
+    },
     "description": "You always wanted to fire energy beams like in the animes you watched as a kid.  Now you can!",
-    "valid_targets": [ "ally", "hostile", "ground" ],
+    "valid_targets": [
+      "ally",
+      "hostile",
+      "ground"
+    ],
     "effect": "attack",
     "shape": "line",
     "damage_type": "heat",
@@ -33,7 +55,12 @@
     "base_energy_cost": 8000,
     "energy_source": "STAMINA",
     "spell_class": "NONE",
-    "flags": [ "LOUD", "SOMATIC", "VERBAL" ],
+    "flags": [
+      "EVOCATION_SPELL",
+      "LOUD",
+      "SOMATIC",
+      "VERBAL"
+    ],
     "difficulty": 10,
     "max_level": 30,
     "min_damage": 30,
@@ -44,14 +71,24 @@
     "range_increment": 0.45,
     "min_aoe": 1,
     "max_aoe": 8,
-    "aoe_increment": 0.2
+    "aoe_increment": 0.2,
+    "extra_effects": [
+      {
+        "id": "eoc_evocation_setup",
+        "hit_self": true
+      }
+    ]
   },
   {
     "id": "create_atomic_light",
     "type": "SPELL",
-    "name": { "str": "Magical Light" },
+    "name": {
+      "str": "Magical Light"
+    },
     "description": "Creates a magical light.",
-    "valid_targets": [ "none" ],
+    "valid_targets": [
+      "none"
+    ],
     "min_range": 0,
     "max_range": 0,
     "min_damage": 1,
@@ -60,25 +97,41 @@
     "effect_str": "magic_light",
     "shape": "blast",
     "energy_source": "MANA",
-    "flags": [ "VERBAL", "NO_LEGS" ],
+    "flags": [
+      "CONJURATION_SPELL",
+      "VERBAL",
+      "NO_LEGS"
+    ],
     "difficulty": 1,
     "max_level": 30,
     "base_casting_time": 1000,
     "base_energy_cost": 200,
     "min_duration": 100000,
     "max_duration": 1500000,
-    "duration_increment": 45000
+    "duration_increment": 45000,
+    "extra_effects": [
+      {
+        "id": "eoc_summon_setup",
+        "hit_self": true
+      }
+    ]
   },
   {
     "id": "blinding_flash",
     "type": "SPELL",
-    "name": { "str": "Blinding Flash" },
+    "name": {
+      "str": "Blinding Flash"
+    },
     "description": "Blind enemies for a short time with a sudden, dazzling light.  Higher levels deal slightly higher damage.",
     "effect": "attack",
     "effect_str": "blind",
     "shape": "blast",
-    "affected_body_parts": [ "eyes" ],
-    "valid_targets": [ "hostile" ],
+    "affected_body_parts": [
+      "eyes"
+    ],
+    "valid_targets": [
+      "hostile"
+    ],
     "max_level": 30,
     "min_damage": 1,
     "max_damage": 15,
@@ -93,56 +146,92 @@
     "max_duration": 4500,
     "duration_increment": 100,
     "spell_class": "NONE",
-    "flags": [ "SOMATIC", "NO_LEGS", "NO_PROJECTILE" ],
+    "flags": [
+      "EVOCATION_SPELL",
+      "SOMATIC",
+      "NO_LEGS",
+      "NO_PROJECTILE"
+    ],
     "base_casting_time": 200,
     "base_energy_cost": 150,
     "energy_source": "MANA",
     "difficulty": 3,
-    "damage_type": "pure"
+    "damage_type": "pure",
+    "extra_effects": [
+      {
+        "id": "eoc_evocation_setup",
+        "hit_self": true
+      }
+    ]
   },
   {
     "id": "ethereal_grasp",
     "type": "SPELL",
-    "name": { "str": "Ethereal Grasp" },
+    "name": {
+      "str": "Ethereal Grasp"
+    },
     "description": "A mass of spectral hands emerge from the ground, slowing everything in range.  Higher levels allow a bigger AoE, and longer effect.",
     "effect": "attack",
     "effect_str": "effect_ethereal_grasp",
     "shape": "blast",
-    "affected_body_parts": [ "foot_l", "foot_r" ],
-    "valid_targets": [ "hostile" ],
+    "affected_body_parts": [
+      "foot_l",
+      "foot_r"
+    ],
+    "valid_targets": [
+      "hostile"
+    ],
     "max_level": 30,
     "min_damage": 10,
     "max_damage": 45,
-    "damage_increment": 1.0,
+    "damage_increment": 1,
     "min_aoe": 2,
     "max_aoe": 30,
     "aoe_increment": 0.5,
     "min_range": 5,
     "max_range": 30,
-    "range_increment": 2.0,
+    "range_increment": 2,
     "min_duration": 1000,
     "max_duration": 7500,
     "duration_increment": 200,
     "spell_class": "NONE",
-    "flags": [ "SOMATIC", "NO_PROJECTILE" ],
+    "flags": [
+      "EVOCATION_SPELL",
+      "SOMATIC",
+      "NO_PROJECTILE"
+    ],
     "base_casting_time": 200,
     "base_energy_cost": 400,
     "energy_source": "MANA",
     "difficulty": 3,
-    "damage_type": "bash"
+    "damage_type": "bash",
+    "extra_effects": [
+      {
+        "id": "eoc_evocation_setup",
+        "hit_self": true
+      }
+    ]
   },
   {
     "id": "obfuscated_body",
     "type": "SPELL",
-    "name": { "str": "Obfuscated Body" },
+    "name": {
+      "str": "Obfuscated Body"
+    },
     "description": "A magical aura distorts light around your body, increasing the amount of attacks you might dodge in a given turn.",
-    "valid_targets": [ "self" ],
+    "valid_targets": [
+      "self"
+    ],
     "effect": "spawn_item",
     "effect_str": "obfuscating_aura",
     "shape": "blast",
     "energy_source": "MANA",
     "spell_class": "NONE",
-    "flags": [ "CONCENTRATE", "NO_LEGS" ],
+    "flags": [
+      "ENHANCEMENT_SPELL",
+      "CONCENTRATE",
+      "NO_LEGS"
+    ],
     "difficulty": 5,
     "max_level": 22,
     "base_casting_time": 200,
@@ -150,19 +239,35 @@
     "min_duration": 24000,
     "max_duration": 520000,
     "duration_increment": 24000,
-	"learn_spells": { "obfuscated_body_plus": 15 }
+    "learn_spells": {
+      "obfuscated_body_plus": 15
+    },
+    "extra_effects": [
+      {
+        "id": "eoc_enhancement_setup",
+        "hit_self": true
+      }
+    ]
   },
   {
     "id": "obfuscated_body_plus",
     "type": "SPELL",
-    "name": { "str": "Improved Obfuscated Body" },
+    "name": {
+      "str": "Improved Obfuscated Body"
+    },
     "description": "A magical aura distorts light around your body, increasing the amount of attacks you might dodge in a given turn.",
-    "valid_targets": [ "self" ],
+    "valid_targets": [
+      "self"
+    ],
     "effect": "attack",
     "effect_str": "effect_obfuscating_aura",
     "shape": "blast",
     "energy_source": "MANA",
-    "flags": [ "NO_LEGS" ],
+    "flags": [
+      "ENHANCEMENT_SPELL",
+      "NO_LEGS",
+      "NO_FAIL"
+    ],
     "difficulty": 7,
     "max_level": 37,
     "base_casting_time": 500,
@@ -173,14 +278,24 @@
     "energy_increment": -16,
     "min_duration": 360000,
     "max_duration": 3220000,
-    "duration_increment": 72000
+    "duration_increment": 72000,
+    "extra_effects": [
+      {
+        "id": "eoc_enhancement_setup",
+        "hit_self": true
+      }
+    ]
   },
   {
     "id": "protection_aura",
     "type": "SPELL",
-    "name": { "str": "Aura of Protection" },
+    "name": {
+      "str": "Aura of Protection"
+    },
     "description": "Encases your whole body in a magical aura that protects you from the environment.",
-    "valid_targets": [ "self" ],
+    "valid_targets": [
+      "self"
+    ],
     "min_damage": 1,
     "max_damage": 1,
     "effect": "spawn_item",
@@ -189,20 +304,37 @@
     "energy_source": "MANA",
     "difficulty": 2,
     "max_level": 22,
-    "flags": [ "CONCENTRATE", "VERBAL", "NO_LEGS" ],
+    "flags": [
+      "ENHANCEMENT_SPELL",
+      "CONCENTRATE",
+      "VERBAL",
+      "NO_LEGS"
+    ],
     "base_casting_time": 350,
     "base_energy_cost": 375,
     "min_duration": 24000,
     "max_duration": 520000,
     "duration_increment": 24000,
-    "learn_spells": { "protection_aura_plus": 15 }
+    "learn_spells": {
+      "protection_aura_plus": 15
+    },
+    "extra_effects": [
+      {
+        "id": "eoc_summon_setup",
+        "hit_self": true
+      }
+    ]
   },
   {
     "id": "protection_aura_plus",
     "type": "SPELL",
-    "name": { "str": "Improved Aura of Protection" },
+    "name": {
+      "str": "Improved Aura of Protection"
+    },
     "description": "Encases your whole body in a magical aura that protects you from the environment.  Now you know this spell like the back of your hand, and start to design your own version.",
-    "valid_targets": [ "self" ],
+    "valid_targets": [
+      "self"
+    ],
     "min_damage": 1,
     "max_damage": 1,
     "effect": "spawn_item",
@@ -211,7 +343,12 @@
     "energy_source": "MANA",
     "difficulty": 5,
     "max_level": 37,
-    "flags": [ "VERBAL", "NO_LEGS" ],
+    "flags": [
+      "ENHANCEMENT_SPELL",
+      "VERBAL",
+      "NO_LEGS",
+      "NO_FAIL"
+    ],
     "base_casting_time": 350,
     "final_casting_time": 100,
     "casting_time_increment": -10,
@@ -220,14 +357,24 @@
     "energy_increment": -9,
     "min_duration": 360000,
     "max_duration": 3220000,
-    "duration_increment": 72000
+    "duration_increment": 72000,
+    "extra_effects": [
+      {
+        "id": "eoc_summon_setup",
+        "hit_self": true
+      }
+    ]
   },
   {
     "id": "translocate_self",
     "type": "SPELL",
-    "name": { "str": "Translocate Self" },
+    "name": {
+      "str": "Translocate Self"
+    },
     "description": "Translocates the user to an attuned gate.",
-    "valid_targets": [ "self" ],
+    "valid_targets": [
+      "self"
+    ],
     "effect": "translocate",
     "shape": "blast",
     "difficulty": 15,
@@ -235,14 +382,29 @@
     "base_casting_time": 6000,
     "base_energy_cost": 675,
     "energy_source": "MANA",
-    "spell_class": "NONE"
+    "spell_class": "NONE",
+    "flags": [
+      "CONVEYANCE_SPELL",
+      "VERBAL",
+      "NO_LEGS"
+    ],
+    "extra_effects": [
+      {
+        "id": "eoc_conveyance_setup",
+        "hit_self": true
+      }
+    ]
   },
   {
     "id": "acid_resistance",
     "type": "SPELL",
-    "name": { "str": "Acid Resistance" },
+    "name": {
+      "str": "Acid Resistance"
+    },
     "description": "Protects the user from acid.",
-    "valid_targets": [ "none" ],
+    "valid_targets": [
+      "none"
+    ],
     "min_range": 0,
     "max_range": 0,
     "min_damage": 1,
@@ -252,7 +414,11 @@
     "shape": "blast",
     "energy_source": "MANA",
     "spell_class": "NONE",
-    "flags": [ "CONCENTRATE", "NO_LEGS" ],
+    "flags": [
+      "ENHANCEMENT_SPELL",
+      "CONCENTRATE",
+      "NO_LEGS"
+    ],
     "difficulty": 4,
     "max_level": 22,
     "base_casting_time": 200,
@@ -260,14 +426,26 @@
     "min_duration": 24000,
     "max_duration": 520000,
     "duration_increment": 24000,
-    "learn_spells": { "acid_resistance_greater": 15 }
+    "learn_spells": {
+      "acid_resistance_greater": 15
+    },
+    "extra_effects": [
+      {
+        "id": "eoc_summon_setup",
+        "hit_self": true
+      }
+    ]
   },
   {
     "id": "acid_resistance_greater",
     "type": "SPELL",
-    "name": { "str": "Greater Acid Resistance" },
+    "name": {
+      "str": "Greater Acid Resistance"
+    },
     "description": "Protects the user from acid.",
-    "valid_targets": [ "none" ],
+    "valid_targets": [
+      "none"
+    ],
     "min_range": 0,
     "max_range": 0,
     "min_damage": 1,
@@ -277,24 +455,41 @@
     "shape": "blast",
     "energy_source": "MANA",
     "spell_class": "NONE",
-    "flags": [ "CONCENTRATE", "NO_LEGS" ],
+    "flags": [
+      "ENHANCEMENT_SPELL",
+      "NO_LEGS"
+    ],
     "difficulty": 7,
     "max_level": 1,
     "base_casting_time": 200,
     "base_energy_cost": 250,
-    "min_duration": 180000
+    "min_duration": 180000,
+    "extra_effects": [
+      {
+        "id": "eoc_summon_setup",
+        "hit_self": true
+      }
+    ]
   },
   {
     "id": "thought_shield",
     "type": "SPELL",
-    "name": { "str": "Thought Shield" },
+    "name": {
+      "str": "Thought Shield"
+    },
     "description": "Two small shimmering spots appear on your temples, protecting your mind from outside influences.",
-    "valid_targets": [ "self" ],
+    "valid_targets": [
+      "self"
+    ],
     "effect": "spawn_item",
     "effect_str": "thought_shield_item",
     "shape": "blast",
     "energy_source": "MANA",
-    "flags": [ "CONCENTRATE", "NO_LEGS" ],
+    "flags": [
+      "ENHANCEMENT_SPELL",
+      "CONCENTRATE",
+      "NO_LEGS"
+    ],
     "difficulty": 6,
     "min_damage": 1,
     "max_damage": 1,
@@ -304,19 +499,35 @@
     "min_duration": 24000,
     "max_duration": 520000,
     "duration_increment": 24000,
-    "learn_spells": { "thought_shield_plus": 15 }
+    "learn_spells": {
+      "thought_shield_plus": 15
+    },
+    "extra_effects": [
+      {
+        "id": "eoc_summon_setup",
+        "hit_self": true
+      }
+    ]
   },
   {
     "id": "thought_shield_plus",
     "type": "SPELL",
-    "name": { "str": "Thought Suit" },
+    "name": {
+      "str": "Thought Suit"
+    },
     "description": "Why protect just your mind from outside influences?  More shields all over your body should also prevent you from being teleported forcefully",
-    "valid_targets": [ "self" ],
+    "valid_targets": [
+      "self"
+    ],
     "effect": "spawn_item",
     "effect_str": "thought_shield_plus_item",
     "shape": "blast",
     "energy_source": "MANA",
-    "flags": [ "NO_LEGS" ],
+    "flags": [
+      "ENHANCEMENT_SPELL",
+      "NO_LEGS",
+      "NO_FAIL"
+    ],
     "min_damage": 1,
     "max_damage": 1,
     "difficulty": 7,
@@ -329,15 +540,34 @@
     "energy_increment": -24,
     "min_duration": 360000,
     "max_duration": 3220000,
-    "duration_increment": 72000
+    "duration_increment": 72000,
+    "extra_effects": [
+      {
+        "id": "eoc_summon_setup",
+        "hit_self": true
+      }
+    ]
   },
   {
     "id": "sound_bomb",
     "type": "SPELL",
-    "name": { "str": "Sound Bomb" },
+    "name": {
+      "str": "Sound Bomb"
+    },
     "description": "Behind the cool name hides a common joke spell to spook your friends and restrain dogs.  It can be useful in some special cases.",
-    "valid_targets": [ "self", "ally", "hostile", "ground" ],
-    "flags": [ "CONCENTRATE", "SOMATIC", "LOUD", "NO_PROJECTILE" ],
+    "valid_targets": [
+      "self",
+      "ally",
+      "hostile",
+      "ground"
+    ],
+    "flags": [
+      "EVOCATION_SPELL",
+      "CONCENTRATE",
+      "SOMATIC",
+      "LOUD",
+      "NO_PROJECTILE"
+    ],
     "effect": "noise",
     "shape": "blast",
     "sound_description": "a loud, high pitched sound",
@@ -358,6 +588,12 @@
     "min_field_intensity": 1,
     "max_field_intensity": 1,
     "field_chance": 1,
-    "energy_source": "MANA"
+    "energy_source": "MANA",
+    "extra_effects": [
+      {
+        "id": "eoc_evocation_setup",
+        "hit_self": true
+      }
+    ]
   }
 ]

--- a/Kenan-Structured-Modpack/High-Maintenance-Huge-Mods/MagicRevampAdditions/Spells_Override/dragonbreath.json
+++ b/Kenan-Structured-Modpack/High-Maintenance-Huge-Mods/MagicRevampAdditions/Spells_Override/dragonbreath.json
@@ -2,13 +2,28 @@
   {
     "type": "SPELL",
     "id": "dragon_deep_breath",
-    "name": { "str": "Take a Deep Breath" },
+    "name": {
+      "str": "Take a Deep Breath"
+    },
     "description": "Preps for using dragon breath.",
-    "flags": [ "VERBAL", "NO_HANDS", "NO_LEGS" ],
-    "valid_targets": [ "hostile" ],
+    "flags": [
+      "VERBAL",
+      "NO_HANDS",
+      "NO_LEGS",
+      "MUST_HAVE_CLASS_TO_LEARN"
+    ],
+    "valid_targets": [
+      "hostile"
+    ],
     "max_level": 40,
     "effect": "attack",
-    "extra_effects": [ { "id": "dragon_deep_breath_self", "hit_self": true, "max_level": 1 } ],
+    "extra_effects": [
+      {
+        "id": "dragon_deep_breath_self",
+        "hit_self": true,
+        "max_level": 1
+      }
+    ],
     "shape": "blast",
     "min_range": 8,
     "max_range": 12,
@@ -17,10 +32,19 @@
   {
     "type": "SPELL",
     "id": "dragon_deep_breath_self",
-    "name": { "str": "Took a Deep Breath" },
+    "name": {
+      "str": "Took a Deep Breath"
+    },
     "description": "Grants the effect for a dragon to use deep breath.",
-    "flags": [ "VERBAL", "NO_HANDS", "NO_LEGS" ],
-    "valid_targets": [ "self" ],
+    "flags": [
+      "VERBAL",
+      "NO_HANDS",
+      "NO_LEGS",
+      "MUST_HAVE_CLASS_TO_LEARN"
+    ],
+    "valid_targets": [
+      "self"
+    ],
     "max_level": 1,
     "effect": "attack",
     "effect_str": "effect_dragon_deep_breath",
@@ -31,14 +55,20 @@
   {
     "type": "SPELL",
     "id": "dragon_breath_black",
-    "name": { "str": "Black Dragons' Breath" },
+    "name": {
+      "str": "Black Dragons' Breath"
+    },
     "description": "Spews a line of acid from your mouth.",
-    "valid_targets": [ "hostile", "ally", "ground" ],
+    "valid_targets": [
+      "hostile",
+      "ally",
+      "ground"
+    ],
     "damage_type": "acid",
     "max_level": 60,
     "min_damage": 6,
     "max_damage": 360,
-    "damage_increment": 6.0,
+    "damage_increment": 6,
     "min_range": 8,
     "max_range": 21,
     "range_increment": 0.1,
@@ -49,6 +79,11 @@
     "max_field_intensity": 4,
     "field_chance": 2,
     "field_intensity_increment": 0.1,
-    "flags": [ "VERBAL", "NO_HANDS", "NO_LEGS" ]
+    "flags": [
+      "VERBAL",
+      "NO_HANDS",
+      "NO_LEGS",
+      "MUST_HAVE_CLASS_TO_LEARN"
+    ]
   }
 ]

--- a/Kenan-Structured-Modpack/High-Maintenance-Huge-Mods/MagicRevampAdditions/Spells_Override/druid.json
+++ b/Kenan-Structured-Modpack/High-Maintenance-Huge-Mods/MagicRevampAdditions/Spells_Override/druid.json
@@ -2,10 +2,22 @@
   {
     "id": "druid_veggrasp",
     "type": "SPELL",
-    "name": { "str": "Vegetative Grasp" },
+    "name": {
+      "str": "Vegetative Grasp"
+    },
     "description": "This spell causes roots and vines to burst forth from the ground and grab your foes, slowing them and doing a small amount of damage as they dig in.",
-    "valid_targets": [ "hostile", "ground" ],
-    "flags": [ "LOUD", "SOMATIC", "VERBAL", "NO_LEGS", "NO_PROJECTILE" ],
+    "valid_targets": [
+      "hostile",
+      "ground"
+    ],
+    "flags": [
+      "EVOCATION_SPELL",
+      "LOUD",
+      "SOMATIC",
+      "VERBAL",
+      "NO_LEGS",
+      "NO_PROJECTILE"
+    ],
     "effect": "attack",
     "effect_str": "entangled",
     "shape": "blast",
@@ -17,13 +29,13 @@
     "max_level": 30,
     "min_damage": 1,
     "max_damage": 30,
-    "damage_increment": 1.0,
+    "damage_increment": 1,
     "min_aoe": 4,
     "max_aoe": 22,
-    "aoe_increment": 1.0,
+    "aoe_increment": 1,
     "min_range": 3,
     "max_range": 10,
-    "range_increment": 1.0,
+    "range_increment": 1,
     "min_dot": 0,
     "max_dot": 3,
     "dot_increment": 0.1,
@@ -33,15 +45,32 @@
     "min_pierce": 1,
     "max_pierce": 8,
     "pierce_increment": 0.25,
-    "damage_type": "stab"
+    "damage_type": "stab",
+    "extra_effects": [
+      {
+        "id": "eoc_evocation_setup",
+        "hit_self": true
+      }
+    ]
   },
   {
     "id": "druid_rootstrike",
     "type": "SPELL",
-    "name": { "str": "Root Strike" },
+    "name": {
+      "str": "Root Strike"
+    },
     "description": "This spell causes roots to spear out the ground and stab into your foes in an arc, impaling them.",
-    "valid_targets": [ "hostile", "ground" ],
-    "flags": [ "LOUD", "SOMATIC", "VERBAL", "NO_LEGS" ],
+    "valid_targets": [
+      "hostile",
+      "ground"
+    ],
+    "flags": [
+      "EVOCATION_SPELL",
+      "LOUD",
+      "SOMATIC",
+      "VERBAL",
+      "NO_LEGS"
+    ],
     "effect": "attack",
     "effect_str": "root_impale",
     "shape": "cone",
@@ -56,7 +85,7 @@
     "damage_increment": 2.5,
     "min_aoe": 25,
     "max_aoe": 65,
-    "aoe_increment": 1.0,
+    "aoe_increment": 1,
     "min_range": 4,
     "max_range": 15,
     "range_increment": 0.5,
@@ -69,15 +98,31 @@
     "min_pierce": 10,
     "max_pierce": 30,
     "pierce_increment": 0.5,
-    "damage_type": "stab"
+    "damage_type": "stab",
+    "extra_effects": [
+      {
+        "id": "eoc_evocation_setup",
+        "hit_self": true
+      }
+    ]
   },
   {
     "id": "druid_woodshaft",
     "type": "SPELL",
-    "name": { "str": "Wooden Shaft" },
+    "name": {
+      "str": "Wooden Shaft"
+    },
     "description": "This spell creates a projectile of hardwood that shoots forth from the caster's hand at high speed to stab into an enemy.",
-    "valid_targets": [ "hostile" ],
-    "flags": [ "LOUD", "SOMATIC", "VERBAL", "NO_LEGS" ],
+    "valid_targets": [
+      "hostile"
+    ],
+    "flags": [
+      "EVOCATION_SPELL",
+      "LOUD",
+      "SOMATIC",
+      "VERBAL",
+      "NO_LEGS"
+    ],
     "effect": "attack",
     "shape": "blast",
     "spell_class": "DRUID",
@@ -95,16 +140,43 @@
     "min_pierce": 1,
     "max_pierce": 8,
     "pierce_increment": 0.5,
-    "damage_type": "bash"
+    "damage_type": "bash",
+    "extra_effects": [
+      {
+        "id": "eoc_evocation_setup",
+        "hit_self": true
+      }
+    ]
   },
   {
     "id": "druid_naturebow1",
     "type": "SPELL",
-    "name": { "str": "Nature's Bow" },
+    "name": {
+      "str": "Nature's Bow"
+    },
     "description": "This spell conjures a magical wooden recurve bow that fires endless arrows for as long as it lasts.",
-    "valid_targets": [ "none" ],
-    "flags": [ "CONCENTRATE", "SOMATIC", "VERBAL", "NO_LEGS" ],
-    "extra_effects": [ { "id": "druid_naturequiver1" }, { "id": "druid_naturearrows1" } ],
+    "valid_targets": [
+      "none"
+    ],
+    "flags": [
+      "CONJURATION_SPELL",
+      "CONCENTRATE",
+      "SOMATIC",
+      "VERBAL",
+      "NO_LEGS"
+    ],
+    "extra_effects": [
+      {
+        "id": "druid_naturequiver1"
+      },
+      {
+        "id": "druid_naturearrows1"
+      },
+      {
+        "id": "eoc_summon_setup",
+        "hit_self": true
+      }
+    ],
     "min_damage": 1,
     "max_damage": 1,
     "effect": "spawn_item",
@@ -119,16 +191,39 @@
     "max_level": 22,
     "spell_class": "DRUID",
     "energy_source": "MANA",
-    "learn_spells": { "druid_naturebow1_plus": 15 }
+    "learn_spells": {
+      "druid_naturebow1_plus": 15
+    }
   },
   {
     "id": "druid_naturebow1_plus",
     "type": "SPELL",
-    "name": { "str": "Improved Nature's Bow" },
+    "name": {
+      "str": "Improved Nature's Bow"
+    },
     "description": "This spell conjures a magical wooden recurve bow, as well as a quiver and a set of arrows to go with it.  Now you know this spell like the back of your hand, and have started to design your own version.",
-    "valid_targets": [ "none" ],
-    "flags": [ "SOMATIC", "VERBAL", "NO_LEGS" ],
-    "extra_effects": [ { "id": "druid_naturequiver1_plus" }, { "id": "druid_naturearrows1_plus" } ],
+    "valid_targets": [
+      "none"
+    ],
+    "flags": [
+      "CONJURATION_SPELL",
+      "SOMATIC",
+      "VERBAL",
+      "NO_LEGS",
+      "NO_FAIL"
+    ],
+    "extra_effects": [
+      {
+        "id": "druid_naturequiver1_plus"
+      },
+      {
+        "id": "druid_naturearrows1_plus"
+      },
+      {
+        "id": "eoc_summon_setup",
+        "hit_self": true
+      }
+    ],
     "min_damage": 1,
     "max_damage": 1,
     "effect": "spawn_item",
@@ -151,10 +246,19 @@
   {
     "id": "recover_sleepiness",
     "type": "SPELL",
-    "name": { "str": "Nature's Trance" },
+    "name": {
+      "str": "Nature's Trance"
+    },
     "description": "Your connection to living things allows you to go into a magical trance.  This allows you to recover from fatigue quickly in exchange for mana.",
-    "valid_targets": [ "self" ],
-    "flags": [ "CONCENTRATE", "SILENT", "NO_HANDS" ],
+    "valid_targets": [
+      "self"
+    ],
+    "flags": [
+      "RESTORATION_SPELL",
+      "CONCENTRATE",
+      "SILENT",
+      "NO_HANDS"
+    ],
     "spell_class": "DRUID",
     "energy_source": "MANA",
     "effect": "recover_energy",
@@ -162,24 +266,40 @@
     "shape": "blast",
     "base_casting_time": 10000,
     "min_damage": 50,
-    "damage_increment": 10.0,
+    "damage_increment": 10,
     "max_damage": 450,
     "max_level": 35,
     "base_energy_cost": 500,
-    "energy_increment": 25.0,
+    "energy_increment": 25,
     "final_energy_cost": 1685,
-    "difficulty": 4
+    "difficulty": 4,
+    "extra_effects": [
+      {
+        "id": "eoc_restoration_setup",
+        "hit_self": true
+      }
+    ]
   },
   {
     "id": "summon_cats",
     "type": "SPELL",
-    "name": { "str": "Bag of Cats" },
+    "name": {
+      "str": "Bag of Cats"
+    },
     "description": "Are you the crazy cat lady?",
-    "valid_targets": [ "ground" ],
-    "flags": [ "LOUD", "SOMATIC", "SPAWN_GROUP" ],
+    "valid_targets": [
+      "ground"
+    ],
+    "flags": [
+      "CONJURATION_SPELL",
+      "LOUD",
+      "SOMATIC",
+      "SPAWN_GROUP",
+      "NO_CORPSE_QUIET"
+    ],
     "min_damage": 1,
     "max_damage": 18,
-    "damage_increment": 1.0,
+    "damage_increment": 1,
     "min_range": 3,
     "range_increment": 0.8,
     "max_range": 10,
@@ -196,14 +316,24 @@
     "base_energy_cost": 265,
     "shape": "blast",
     "effect": "summon",
-    "effect_str": "GROUP_STRAY_CATS"
+    "effect_str": "GROUP_STRAY_CATS",
+    "extra_effects": [
+      {
+        "id": "eoc_summon_setup",
+        "hit_self": true
+      }
+    ]
   },
   {
     "id": "summon_bear",
     "type": "SPELL",
-    "name": { "str": "Cause Bear" },
+    "name": {
+      "str": "Cause Bear"
+    },
     "description": "This spell appears to be very smudged.  You're fairly sure the name should be Cause Fear, but you're also fairly sure it won't have the desired effect because the instructions are hardly legible.  No time like the Cataclysm to find out, though!",
-    "valid_targets": [ "ground" ],
+    "valid_targets": [
+      "ground"
+    ],
     "min_damage": 1,
     "max_damage": 1,
     "min_range": 3,
@@ -217,37 +347,74 @@
     "max_duration": 45000,
     "base_energy_cost": 675,
     "final_energy_cost": 425,
-    "energy_increment": -5.0,
-    "flags": [ "HOSTILE_50", "CONCENTRATE", "SOMATIC", "VERBAL", "NO_LEGS" ],
+    "energy_increment": -5,
+    "flags": [
+      "CONJURATION_SPELL",
+      "HOSTILE_50",
+      "CONCENTRATE",
+      "SOMATIC",
+      "VERBAL",
+      "NO_LEGS",
+      "NO_CORPSE_QUIET"
+    ],
     "shape": "blast",
     "effect": "summon",
-    "effect_str": "mon_bear"
+    "effect_str": "mon_bear",
+    "extra_effects": [
+      {
+        "id": "eoc_summon_setup",
+        "hit_self": true
+      }
+    ]
   },
   {
     "id": "fungicide",
     "type": "SPELL",
-    "name": { "str": "Kill Fungus" },
+    "name": {
+      "str": "Kill Fungus"
+    },
     "description": "Kills fungus affected areas",
-    "valid_targets": [ "ground", "hostile" ],
+    "valid_targets": [
+      "ground",
+      "hostile"
+    ],
     "effect": "ter_transform",
     "effect_str": "fungicide",
     "shape": "blast",
     "min_aoe": 5,
     "max_aoe": 35,
-    "aoe_increment": 1.0,
+    "aoe_increment": 1,
     "max_level": 30,
     "difficulty": 4,
     "energy_source": "MANA",
     "base_energy_cost": 175,
     "base_casting_time": 550,
-    "flags": [ "CONCENTRATE", "VERBAL", "SOMATIC", "NO_LEGS", "NO_HANDS", "NO_PROJECTILE" ]
+    "flags": [
+      "CHANNELING_SPELL",
+      "CONCENTRATE",
+      "VERBAL",
+      "SOMATIC",
+      "NO_LEGS",
+      "NO_HANDS",
+      "NO_PROJECTILE"
+    ],
+    "extra_effects": [
+      {
+        "id": "eoc_channeling_setup",
+        "hit_self": true
+      }
+    ]
   },
   {
     "id": "create_rune_druid",
     "type": "SPELL",
-    "name": { "str": "Druid Rune" },
+    "name": {
+      "str": "Druid Rune"
+    },
     "description": "This ritual creates a small pebble attuned to Druids.  You can use the rune as a catalyst for recipes.",
-    "valid_targets": [ "self" ],
+    "valid_targets": [
+      "self"
+    ],
     "min_damage": 1,
     "max_damage": 1,
     "effect": "spawn_item",
@@ -262,14 +429,29 @@
     "max_level": 0,
     "spell_class": "DRUID",
     "energy_source": "MANA",
-    "flags": [ "PERMANENT", "NO_LEGS", "CONCENTRATE" ]
+    "flags": [
+      "CHANNELING_SPELL",
+      "PERMANENT",
+      "NO_LEGS",
+      "CONCENTRATE"
+    ],
+    "extra_effects": [
+      {
+        "id": "eoc_channeling_setup",
+        "hit_self": true
+      }
+    ]
   },
   {
     "id": "purify_seed",
     "type": "SPELL",
-    "name": { "str": "Purification Seed" },
+    "name": {
+      "str": "Purification Seed"
+    },
     "description": "You summon a gift of the earth which will purify water.  Rapidly degrades if not utilized.",
-    "valid_targets": [ "self" ],
+    "valid_targets": [
+      "self"
+    ],
     "min_damage": 1,
     "max_damage": 1,
     "effect": "spawn_item",
@@ -277,7 +459,7 @@
     "shape": "blast",
     "base_casting_time": 30000,
     "final_casting_time": 6000,
-    "casting_time_increment": -1200.0,
+    "casting_time_increment": -1200,
     "base_energy_cost": 1000,
     "final_energy_cost": 1000,
     "min_duration": 6000,
@@ -286,18 +468,40 @@
     "max_level": 20,
     "spell_class": "DRUID",
     "energy_source": "MANA",
-    "flags": [ "NO_LEGS", "CONCENTRATE" ]
+    "flags": [
+      "CONJURATION_SPELL",
+      "NO_LEGS",
+      "CONCENTRATE"
+    ],
+    "extra_effects": [
+      {
+        "id": "eoc_summon_setup",
+        "hit_self": true
+      }
+    ]
   },
   {
     "id": "druidic_regrowth",
     "type": "SPELL",
-    "name": { "str": "Sacrificial Regrowth" },
+    "name": {
+      "str": "Sacrificial Regrowth"
+    },
     "description": "Through giving of one's own life force, you restore withered and barren plant life nearby.  What remains will need time to regrow its full strength.",
-    "valid_targets": [ "ground" ],
+    "valid_targets": [
+      "ground"
+    ],
     "effect": "ter_transform",
     "effect_str": "druidic_renewal",
     "shape": "blast",
-    "flags": [ "CONCENTRATE", "VERBAL", "SOMATIC", "NO_LEGS", "NO_HANDS", "NO_PROJECTILE" ],
+    "flags": [
+      "RESTORATION_SPELL",
+      "CONCENTRATE",
+      "VERBAL",
+      "SOMATIC",
+      "NO_LEGS",
+      "NO_HANDS",
+      "NO_PROJECTILE"
+    ],
     "spell_class": "DRUID",
     "energy_source": "HP",
     "difficulty": 6,
@@ -309,17 +513,35 @@
     "aoe_increment": 0.2,
     "min_range": 3,
     "max_range": 9,
-    "range_increment": 0.3
+    "range_increment": 0.3,
+    "extra_effects": [
+      {
+        "id": "eoc_restoration_setup",
+        "hit_self": true
+      }
+    ]
   },
   {
     "id": "druidic_healing",
     "type": "SPELL",
-    "name": { "str": "Sacrificial Healing" },
+    "name": {
+      "str": "Sacrificial Healing"
+    },
     "description": "Channels some of the user's own life force into healing energy, for the sake of ones allies.",
-    "valid_targets": [ "ally" ],
+    "valid_targets": [
+      "ally"
+    ],
     "effect": "attack",
     "shape": "blast",
-    "flags": [ "CONCENTRATE", "VERBAL", "SOMATIC", "NO_LEGS", "NO_HANDS", "NO_PROJECTILE" ],
+    "flags": [
+      "RESTORATION_SPELL",
+      "CONCENTRATE",
+      "VERBAL",
+      "SOMATIC",
+      "NO_LEGS",
+      "NO_HANDS",
+      "NO_PROJECTILE"
+    ],
     "spell_class": "DRUID",
     "energy_source": "HP",
     "difficulty": 5,
@@ -336,19 +558,47 @@
     "aoe_increment": 0.2,
     "min_range": 2,
     "max_range": 6,
-    "range_increment": 0.2
+    "range_increment": 0.2,
+    "extra_effects": [
+      {
+        "id": "eoc_restoration_setup",
+        "hit_self": true
+      }
+    ]
   },
   {
     "id": "druid_tornskin",
     "type": "SPELL",
-    "name": { "str": "Tornskin" },
+    "name": {
+      "str": "Tornskin"
+    },
     "description": "This spell, which resembles Thornskin through the sap & needles covering the page, seemed to involve thorns and bleeding wounds.  The marred words may have altered the function.",
-    "valid_targets": [ "hostile", "ground", "ally", "self" ],
-    "flags": [ "SOMATIC" ],
+    "valid_targets": [
+      "hostile",
+      "ground",
+      "ally",
+      "self"
+    ],
+    "flags": [
+      "EVOCATION_SPELL",
+      "SOMATIC"
+    ],
     "effect": "attack",
     "effect_str": "tornskin_pain",
     "shape": "blast",
-    "affected_body_parts": [ "head", "torso", "mouth", "eyes", "arm_l", "arm_r", "hand_r", "hand_l", "leg_l", "foot_l", "foot_r" ],
+    "affected_body_parts": [
+      "head",
+      "torso",
+      "mouth",
+      "eyes",
+      "arm_l",
+      "arm_r",
+      "hand_r",
+      "hand_l",
+      "leg_l",
+      "foot_l",
+      "foot_r"
+    ],
     "min_dot": 1,
     "max_dot": 6,
     "dot_increment": 0.3,
@@ -373,18 +623,32 @@
     "min_pierce": 0,
     "max_pierce": 5,
     "pierce_increment": 0.3,
-    "damage_type": "cut"
+    "damage_type": "cut",
+    "extra_effects": [
+      {
+        "id": "eoc_evocation_setup",
+        "hit_self": true
+      }
+    ]
   },
   {
     "id": "druid_feralform",
     "type": "SPELL",
-    "name": { "str": "Feral Form" },
+    "name": {
+      "str": "Feral Form"
+    },
     "description": "This spell unleashs your inner beast, growing claws & fangs to rend your foes limb from limb.",
-    "valid_targets": [ "self" ],
+    "valid_targets": [
+      "self"
+    ],
     "effect": "spawn_item",
     "effect_str": "aura_feral",
     "shape": "blast",
-    "flags": [ "SOMATIC", "VERBAL" ],
+    "flags": [
+      "TRANSFORMATION_SPELL",
+      "SOMATIC",
+      "VERBAL"
+    ],
     "components": "spell_components_feralform",
     "spell_class": "DRUID",
     "energy_source": "MANA",
@@ -397,18 +661,34 @@
     "min_duration": 24000,
     "max_duration": 520000,
     "duration_increment": 24000,
-    "learn_spells": { "druid_feralform_plus": 15 }
+    "learn_spells": {
+      "druid_feralform_plus": 15
+    },
+    "extra_effects": [
+      {
+        "id": "eoc_transformation_setup",
+        "hit_self": true
+      }
+    ]
   },
   {
     "id": "druid_feralform_plus",
     "type": "SPELL",
-    "name": { "str": "Enhanced Feral Form" },
+    "name": {
+      "str": "Enhanced Feral Form"
+    },
     "description": "This spell unleashes your inner beast, growing claws & fangs to rend your foes limb from limb.  Now you know this spell like the back of your hand, and start to design your own version.",
-    "valid_targets": [ "self" ],
+    "valid_targets": [
+      "self"
+    ],
     "effect": "spawn_item",
     "effect_str": "aura_feral_plus",
     "shape": "blast",
-    "flags": [ "SOMATIC" ],
+    "flags": [
+      "TRANSFORMATION_SPELL",
+      "SOMATIC",
+      "NO_FAIL"
+    ],
     "components": "spell_components_feralform",
     "spell_class": "DRUID",
     "energy_source": "MANA",
@@ -424,14 +704,24 @@
     "max_damage": 1,
     "min_duration": 360000,
     "max_duration": 3220000,
-    "duration_increment": 72000
+    "duration_increment": 72000,
+    "extra_effects": [
+      {
+        "id": "eoc_transformation_setup",
+        "hit_self": true
+      }
+    ]
   },
   {
     "id": "summon_wolf_druid",
     "type": "SPELL",
-    "name": { "str": "Summon Wolf" },
+    "name": {
+      "str": "Summon Wolf"
+    },
     "description": "Call to the wilds for aid from some wolves.",
-    "valid_targets": [ "ground" ],
+    "valid_targets": [
+      "ground"
+    ],
     "min_damage": 1,
     "max_damage": 3,
     "damage_increment": 0.08,
@@ -449,18 +739,34 @@
     "max_duration": 1620000,
     "duration_increment": 37000,
     "base_energy_cost": 400,
-    "flags": [ "SOMATIC", "VERBAL", "NO_LEGS" ],
+    "flags": [
+      "CONJURATION_SPELL",
+      "SOMATIC",
+      "VERBAL",
+      "NO_LEGS",
+      "NO_CORPSE_QUIET"
+    ],
     "shape": "blast",
     "effect": "summon",
-    "effect_str": "mon_wolf"
+    "effect_str": "mon_wolf",
+    "extra_effects": [
+      {
+        "id": "eoc_summon_setup",
+        "hit_self": true
+      }
+    ]
   },
   {
     "id": "druid_growth",
     "type": "SPELL",
     "spell_class": "DRUID",
-    "name": { "str": "Seed of Growth" },
+    "name": {
+      "str": "Seed of Growth"
+    },
     "description": "Offer some of your life in a ritual to get tokens of growth in return.",
-    "valid_targets": [ "self" ],
+    "valid_targets": [
+      "self"
+    ],
     "effect": "spawn_item",
     "effect_str": "druid_fertilizer",
     "shape": "blast",
@@ -475,18 +781,39 @@
     "max_damage": 120,
     "damage_increment": 4,
     "//": "The spell can only be permanent without being at maximum level because of how items with charges work",
-    "flags": [ "SOMATIC", "NO_LEGS", "PERMANENT" ]
+    "flags": [
+      "CONJURATION_SPELL",
+      "SOMATIC",
+      "NO_LEGS",
+      "PERMANENT"
+    ],
+    "extra_effects": [
+      {
+        "id": "eoc_summon_setup",
+        "hit_self": true
+      }
+    ]
   },
   {
     "id": "druid_healing",
     "type": "SPELL",
-    "name": { "str": "Restoration" },
+    "name": {
+      "str": "Restoration"
+    },
     "description": "Directed magical energy that slowly heals your body from wounds.",
-    "valid_targets": [ "self" ],
+    "valid_targets": [
+      "self"
+    ],
     "effect": "attack",
     "effect_str": "flask_regeneration",
     "shape": "blast",
-    "flags": [ "CONCENTRATE", "SOMATIC", "VERBAL", "NO_LEGS" ],
+    "flags": [
+      "RESTORATION_SPELL",
+      "CONCENTRATE",
+      "SOMATIC",
+      "VERBAL",
+      "NO_LEGS"
+    ],
     "energy_source": "MANA",
     "spell_class": "DRUID",
     "difficulty": 8,
@@ -499,18 +826,34 @@
     "max_level": 37,
     "min_duration": 15000,
     "max_duration": 135000,
-    "duration_increment": 3000
+    "duration_increment": 3000,
+    "extra_effects": [
+      {
+        "id": "eoc_restoration_setup",
+        "hit_self": true
+      }
+    ]
   },
   {
     "id": "druid_healing_herb",
     "type": "SPELL",
-    "name": { "str": "Floral Healing" },
+    "name": {
+      "str": "Floral Healing"
+    },
     "description": "Use some magic herbs to heal yourself.",
     "components": "spell_components_healing_herb",
-    "valid_targets": [ "self" ],
+    "valid_targets": [
+      "self"
+    ],
     "effect": "attack",
     "shape": "blast",
-    "flags": [ "CONCENTRATE", "SOMATIC", "VERBAL", "NO_LEGS" ],
+    "flags": [
+      "RESTORATION_SPELL",
+      "CONCENTRATE",
+      "SOMATIC",
+      "VERBAL",
+      "NO_LEGS"
+    ],
     "energy_source": "MANA",
     "spell_class": "DRUID",
     "min_damage": -5,
@@ -521,15 +864,31 @@
     "base_energy_cost": 400,
     "final_energy_cost": 100,
     "energy_increment": -16.7,
-    "max_level": 22
+    "max_level": 22,
+    "extra_effects": [
+      {
+        "id": "eoc_restoration_setup",
+        "hit_self": true
+      }
+    ]
   },
   {
     "id": "druid_bandage_heal",
     "type": "SPELL",
-    "name": { "str": "Vegetative Poultice" },
+    "name": {
+      "str": "Vegetative Poultice"
+    },
     "description": "This spell turns a mixture of bark and leaves into a powerful salve capable of stopping even grievous wounds from bleeding.",
-    "valid_targets": [ "none" ],
-    "flags": [ "CONCENTRATE", "SOMATIC", "VERBAL", "NO_LEGS" ],
+    "valid_targets": [
+      "none"
+    ],
+    "flags": [
+      "TRANSFORMATION_SPELL",
+      "CONCENTRATE",
+      "SOMATIC",
+      "VERBAL",
+      "NO_LEGS"
+    ],
     "min_damage": 1,
     "max_damage": 1,
     "effect": "spawn_item",
@@ -544,15 +903,29 @@
     "difficulty": 5,
     "max_level": 22,
     "spell_class": "DRUID",
-    "energy_source": "MANA"
+    "energy_source": "MANA",
+    "extra_effects": [
+      {
+        "id": "eoc_transformation_setup",
+        "hit_self": true
+      }
+    ]
   },
   {
     "id": "druid_summon_tanglevine",
     "type": "SPELL",
-    "name": { "str": "Summon Tanglevine" },
+    "name": {
+      "str": "Summon Tanglevine"
+    },
     "description": "This spell causes an animated vine to burst from the ground and attempt to seize a nearby target and hold it fast.",
-    "valid_targets": [ "ground" ],
-    "flags": [ "VERBAL", "SOMATIC" ],
+    "valid_targets": [
+      "ground"
+    ],
+    "flags": [
+      "CONJURATION_SPELL",
+      "VERBAL",
+      "SOMATIC"
+    ],
     "effect": "summon",
     "effect_str": "mon_tanglevine",
     "shape": "blast",
@@ -571,15 +944,30 @@
     "duration_increment": 2000,
     "base_energy_cost": 650,
     "final_energy_cost": 375,
-    "energy_increment": -16.677
+    "energy_increment": -16.677,
+    "extra_effects": [
+      {
+        "id": "eoc_summon_setup",
+        "hit_self": true
+      }
+    ]
   },
   {
     "id": "druid_beguile_savage_beast",
     "type": "SPELL",
-    "name": { "str": "Beguiling the Savage Beast" },
+    "name": {
+      "str": "Beguiling the Savage Beast"
+    },
     "description": "Using your connection to nature, you can sway an animal to your service.  This spell even works on mutated animals.",
-    "valid_targets": [ "hostile" ],
-    "flags": [ "VERBAL", "SOMATIC", "SILENT" ],
+    "valid_targets": [
+      "hostile"
+    ],
+    "flags": [
+      "ENERVATION_SPELL",
+      "VERBAL",
+      "SOMATIC",
+      "SILENT"
+    ],
     "effect": "charm_monster",
     "shape": "blast",
     "spell_class": "DRUID",
@@ -599,15 +987,33 @@
     "min_duration": 30000,
     "max_duration": 135000,
     "duration_increment": 4000,
-    "targeted_monster_species": [ "MAMMAL", "BIRD" ]
+    "targeted_monster_species": [
+      "MAMMAL",
+      "BIRD"
+    ],
+    "extra_effects": [
+      {
+        "id": "eoc_enervation_setup",
+        "hit_self": true
+      }
+    ]
   },
   {
     "id": "druid_bramble_spear",
     "type": "SPELL",
-    "name": { "str": "Spear of Brambles" },
+    "name": {
+      "str": "Spear of Brambles"
+    },
     "description": "This spell turns a stick into a vicious spear that drips with sticky sap.",
-    "valid_targets": [ "none" ],
-    "flags": [ "CONCENTRATE", "VERBAL", "NO_HANDS" ],
+    "valid_targets": [
+      "none"
+    ],
+    "flags": [
+      "TRANSFORMATION_SPELL",
+      "CONCENTRATE",
+      "VERBAL",
+      "NO_HANDS"
+    ],
     "//": "NO_HANDS so you can hold on to the stick and cast the spell and then be holding the spear",
     "effect": "spawn_item",
     "effect_str": "druid_bramble_spear_item",
@@ -624,15 +1030,33 @@
     "min_duration": 24000,
     "max_duration": 520000,
     "duration_increment": 24000,
-    "learn_spells": { "druid_bramble_spear_enhanced": 15 }
+    "learn_spells": {
+      "druid_bramble_spear_enhanced": 15
+    },
+    "extra_effects": [
+      {
+        "id": "eoc_transformation_setup",
+        "hit_self": true
+      }
+    ]
   },
   {
     "id": "druid_bramble_spear_enhanced",
     "type": "SPELL",
-    "name": { "str": "Enhanced Spear of Brambles" },
+    "name": {
+      "str": "Enhanced Spear of Brambles"
+    },
     "description": "This spell turns a bit of bark or a twig into a vicious spear that drips with sticky sap.  You now know this spell like the back of your hand, and no longer need such massive spell components as you did previously.",
-    "valid_targets": [ "none" ],
-    "flags": [ "CONCENTRATE", "VERBAL", "NO_HANDS" ],
+    "valid_targets": [
+      "none"
+    ],
+    "flags": [
+      "TRANSFORMATION_SPELL",
+      "CONCENTRATE",
+      "VERBAL",
+      "NO_HANDS",
+      "NO_FAIL"
+    ],
     "effect": "spawn_item",
     "effect_str": "druid_bramble_spear_item",
     "shape": "blast",
@@ -646,15 +1070,30 @@
     "base_energy_cost": 250,
     "min_duration": 360000,
     "max_duration": 3220000,
-    "duration_increment": 72000
+    "duration_increment": 72000,
+    "extra_effects": [
+      {
+        "id": "eoc_transformation_setup",
+        "hit_self": true
+      }
+    ]
   },
   {
     "id": "druid_thorn_skin",
     "type": "SPELL",
-    "name": { "str": "Thornskin" },
+    "name": {
+      "str": "Thornskin"
+    },
     "description": "This spell transforms the druid's skin into a bark-like material covered in large thorns.  It provides excellent protection but slightly slows you and makes you vulnerable to fire.",
-    "valid_targets": [ "self" ],
-    "flags": [ "CONCENTRATE", "VERBAL", "SOMATIC" ],
+    "valid_targets": [
+      "self"
+    ],
+    "flags": [
+      "TRANSFORMATION_SPELL",
+      "CONCENTRATE",
+      "VERBAL",
+      "SOMATIC"
+    ],
     "effect": "spawn_item",
     "effect_str": "druid_thorn_skin_item",
     "shape": "blast",
@@ -668,6 +1107,12 @@
     "base_energy_cost": 500,
     "min_duration": 24000,
     "max_duration": 520000,
-    "duration_increment": 24000
+    "duration_increment": 24000,
+    "extra_effects": [
+      {
+        "id": "eoc_transformation_setup",
+        "hit_self": true
+      }
+    ]
   }
 ]

--- a/Kenan-Structured-Modpack/High-Maintenance-Huge-Mods/MagicRevampAdditions/Spells_Override/earthshaper.json
+++ b/Kenan-Structured-Modpack/High-Maintenance-Huge-Mods/MagicRevampAdditions/Spells_Override/earthshaper.json
@@ -2,10 +2,18 @@
   {
     "id": "stonefist",
     "type": "SPELL",
-    "name": { "str": "Stonefist" },
+    "name": {
+      "str": "Stonefist"
+    },
     "description": "Encases your arms and hands in a sheath of magical stone, you can punch and defend yourself with it in melee combat.",
-    "valid_targets": [ "self" ],
-    "flags": [ "SOMATIC", "LOUD" ],
+    "valid_targets": [
+      "self"
+    ],
+    "flags": [
+      "CONJURATION_SPELL",
+      "SOMATIC",
+      "LOUD"
+    ],
     "min_damage": 1,
     "max_damage": 1,
     "effect": "spawn_item",
@@ -20,15 +28,31 @@
     "min_duration": 24000,
     "max_duration": 520000,
     "duration_increment": 24000,
-    "learn_spells": { "stonefist_plus": 15 }
+    "learn_spells": {
+      "stonefist_plus": 15
+    },
+    "extra_effects": [
+      {
+        "id": "eoc_summon_setup",
+        "hit_self": true
+      }
+    ]
   },
   {
     "id": "stonefist_plus",
     "type": "SPELL",
-    "name": { "str": "Improved Stonefist" },
+    "name": {
+      "str": "Improved Stonefist"
+    },
     "description": "Encases your arms and hands in a sheath of magical stone, you can punch and defend yourself with it in melee combat.  Now you know this spell like the back of your hand, and start to design your own version.",
-    "valid_targets": [ "self" ],
-    "flags": [ "SOMATIC" ],
+    "valid_targets": [
+      "self"
+    ],
+    "flags": [
+      "CONJURATION_SPELL",
+      "SOMATIC",
+      "NO_FAIL"
+    ],
     "min_damage": 1,
     "max_damage": 1,
     "effect": "spawn_item",
@@ -46,18 +70,35 @@
     "energy_increment": -2,
     "min_duration": 360000,
     "max_duration": 5220000,
-    "duration_increment": 72000
+    "duration_increment": 72000,
+    "extra_effects": [
+      {
+        "id": "eoc_summon_setup",
+        "hit_self": true
+      }
+    ]
   },
   {
     "id": "seismic_stomp",
     "type": "SPELL",
-    "name": { "str": "Seismic Stomp" },
+    "name": {
+      "str": "Seismic Stomp"
+    },
     "description": "Focusing mana into your leg, you stomp your foot and send out a shockwave, knocking enemies around you onto the ground.",
     "effect": "attack",
     "effect_str": "downed",
     "shape": "blast",
-    "valid_targets": [ "hostile", "ground", "none" ],
-    "flags": [ "SOMATIC", "LOUD", "NO_PROJECTILE" ],
+    "valid_targets": [
+      "hostile",
+      "ground",
+      "none"
+    ],
+    "flags": [
+      "EVOCATION_SPELL",
+      "SOMATIC",
+      "LOUD",
+      "NO_PROJECTILE"
+    ],
     "max_level": 15,
     "min_damage": 2,
     "max_damage": 15,
@@ -73,21 +114,36 @@
     "base_energy_cost": 250,
     "energy_source": "MANA",
     "difficulty": 2,
-    "damage_type": "bash"
+    "damage_type": "bash",
+    "extra_effects": [
+      {
+        "id": "eoc_evocation_setup",
+        "hit_self": true
+      }
+    ]
   },
   {
     "id": "recover_stamina",
     "type": "SPELL",
-    "name": { "str": "Stone's Endurance" },
+    "name": {
+      "str": "Stone's Endurance"
+    },
     "description": "You focus on the stones beneath you and draw from their agelessness.  Your mana is converted to stamina.",
     "effect": "recover_energy",
     "effect_str": "STAMINA",
     "shape": "blast",
-    "valid_targets": [ "self" ],
-    "flags": [ "NO_HANDS", "CONCENTRATE", "SILENT" ],
+    "valid_targets": [
+      "self"
+    ],
+    "flags": [
+      "RESTORATION_SPELL",
+      "NO_HANDS",
+      "CONCENTRATE",
+      "SILENT"
+    ],
     "min_damage": 1500,
     "max_damage": 15000,
-    "damage_increment": 750.0,
+    "damage_increment": 750,
     "max_level": 18,
     "spell_class": "EARTHSHAPER",
     "base_casting_time": 500,
@@ -97,15 +153,32 @@
     "base_energy_cost": 150,
     "energy_increment": 75,
     "final_energy_cost": 1500,
-    "difficulty": 5
+    "difficulty": 5,
+    "extra_effects": [
+      {
+        "id": "eoc_restoration_setup",
+        "hit_self": true
+      }
+    ]
   },
   {
     "id": "eshaper_shardspray",
     "type": "SPELL",
-    "name": { "str": "Shardspray" },
+    "name": {
+      "str": "Shardspray"
+    },
     "description": "This spell projects a wide spray of sharp metal shards, cutting into your foes and friends alike.",
-    "valid_targets": [ "hostile", "ground", "ally" ],
-    "flags": [ "SOMATIC", "LOUD", "NO_HANDS" ],
+    "valid_targets": [
+      "hostile",
+      "ground",
+      "ally"
+    ],
+    "flags": [
+      "EVOCATION_SPELL",
+      "SOMATIC",
+      "LOUD",
+      "NO_HANDS"
+    ],
     "components": "spell_components_shardspray",
     "effect": "attack",
     "shape": "cone",
@@ -127,15 +200,29 @@
     "range_increment": 0.5,
     "min_pierce": 0,
     "max_pierce": 8,
-    "pierce_increment": 0.4
+    "pierce_increment": 0.4,
+    "extra_effects": [
+      {
+        "id": "eoc_evocation_setup",
+        "hit_self": true
+      }
+    ]
   },
   {
     "id": "eshaper_piercing_bolt",
     "type": "SPELL",
-    "name": { "str": "Piercing Bolt" },
+    "name": {
+      "str": "Piercing Bolt"
+    },
     "description": "This spell projects a piercing rod of conjured iron at those that dare oppose you.",
-    "valid_targets": [ "hostile" ],
-    "flags": [ "SOMATIC", "LOUD" ],
+    "valid_targets": [
+      "hostile"
+    ],
+    "flags": [
+      "EVOCATION_SPELL",
+      "SOMATIC",
+      "LOUD"
+    ],
     "effect": "attack",
     "shape": "blast",
     "spell_class": "EARTHSHAPER",
@@ -146,19 +233,35 @@
     "max_level": 30,
     "min_damage": 20,
     "max_damage": 75,
-    "damage_increment": 3.0,
+    "damage_increment": 3,
     "damage_type": "stab",
     "min_range": 8,
     "max_range": 39,
-    "range_increment": 1.5
+    "range_increment": 1.5,
+    "extra_effects": [
+      {
+        "id": "eoc_evocation_setup",
+        "hit_self": true
+      }
+    ]
   },
   {
     "id": "eshaper_shardstorm",
     "type": "SPELL",
-    "name": { "str": "Shardstorm" },
+    "name": {
+      "str": "Shardstorm"
+    },
     "description": "Creates an omnidirectional spray of razor sharp metal shards all around you.",
-    "valid_targets": [ "hostile", "ally", "ground" ],
-    "flags": [ "SOMATIC", "LOUD" ],
+    "valid_targets": [
+      "hostile",
+      "ally",
+      "ground"
+    ],
+    "flags": [
+      "EVOCATION_SPELL",
+      "SOMATIC",
+      "LOUD"
+    ],
     "min_damage": 20,
     "max_damage": 90,
     "damage_increment": 1.85,
@@ -173,15 +276,30 @@
     "base_casting_time": 100,
     "energy_source": "MANA",
     "shape": "blast",
-    "effect": "attack"
+    "effect": "attack",
+    "extra_effects": [
+      {
+        "id": "eoc_evocation_setup",
+        "hit_self": true
+      }
+    ]
   },
   {
     "id": "eshaper_rockbolt",
     "type": "SPELL",
-    "name": { "str": "Rockbolt" },
+    "name": {
+      "str": "Rockbolt"
+    },
     "description": "Fires a conjured stone projectile at high velocity.",
-    "valid_targets": [ "hostile", "ally" ],
-    "flags": [ "SOMATIC", "LOUD" ],
+    "valid_targets": [
+      "hostile",
+      "ally"
+    ],
+    "flags": [
+      "EVOCATION_SPELL",
+      "SOMATIC",
+      "LOUD"
+    ],
     "min_damage": 5,
     "damage_increment": 1.5,
     "damage_type": "bash",
@@ -196,15 +314,33 @@
     "base_casting_time": 100,
     "energy_source": "MANA",
     "shape": "blast",
-    "effect": "attack"
+    "effect": "attack",
+    "extra_effects": [
+      {
+        "id": "eoc_evocation_setup",
+        "hit_self": true
+      }
+    ]
   },
   {
     "id": "move_earth",
     "type": "SPELL",
-    "name": { "str": "Move Earth" },
+    "name": {
+      "str": "Move Earth"
+    },
     "description": "Your essense flows around you, and the earth follows.",
-    "valid_targets": [ "hostile", "ally", "ground", "self" ],
-    "flags": [ "SOMATIC", "LOUD", "NO_PROJECTILE" ],
+    "valid_targets": [
+      "hostile",
+      "ally",
+      "ground",
+      "self"
+    ],
+    "flags": [
+      "CHANNELING_SPELL",
+      "SOMATIC",
+      "LOUD",
+      "NO_PROJECTILE"
+    ],
     "min_aoe": 1,
     "max_aoe": 2,
     "min_damage": 100,
@@ -223,14 +359,24 @@
     "energy_source": "MANA",
     "shape": "blast",
     "effect": "ter_transform",
-    "effect_str": "move_earth"
+    "effect_str": "move_earth",
+    "extra_effects": [
+      {
+        "id": "eoc_channeling_setup",
+        "hit_self": true
+      }
+    ]
   },
   {
     "id": "create_rune_earthshaper",
     "type": "SPELL",
-    "name": { "str": "Earthshaper Rune" },
+    "name": {
+      "str": "Earthshaper Rune"
+    },
     "description": "This ritual creates a small pebble attuned to Earthshapers.  You can use the rune as a catalyst for recipes.",
-    "valid_targets": [ "self" ],
+    "valid_targets": [
+      "self"
+    ],
     "min_damage": 1,
     "max_damage": 1,
     "effect": "spawn_item",
@@ -245,17 +391,40 @@
     "max_level": 0,
     "spell_class": "EARTHSHAPER",
     "energy_source": "MANA",
-    "flags": [ "PERMANENT", "NO_LEGS", "CONCENTRATE" ]
+    "flags": [
+      "CHANNELING_SPELL",
+      "PERMANENT",
+      "NO_LEGS",
+      "CONCENTRATE"
+    ],
+    "extra_effects": [
+      {
+        "id": "eoc_channeling_setup",
+        "hit_self": true
+      }
+    ]
   },
   {
     "id": "clairvoyance",
     "type": "SPELL",
-    "name": { "str": "Clairvoyance" },
+    "name": {
+      "str": "Clairvoyance"
+    },
     "description": "You close your eyes and the earth surrenders its secrets to you.",
     "effect": "attack",
     "shape": "blast",
-    "valid_targets": [ "ally", "hostile", "ground" ],
-    "flags": [ "SOMATIC", "VERBAL", "IGNORE_WALLS", "NO_PROJECTILE" ],
+    "valid_targets": [
+      "ally",
+      "hostile",
+      "ground"
+    ],
+    "flags": [
+      "CHANNELING_SPELL",
+      "SOMATIC",
+      "VERBAL",
+      "IGNORE_WALLS",
+      "NO_PROJECTILE"
+    ],
     "max_level": 30,
     "min_aoe": 4,
     "max_aoe": 19,
@@ -267,18 +436,32 @@
     "difficulty": 4,
     "field_id": "fd_clairvoyant",
     "min_field_intensity": 1,
-    "max_field_intensity": 1
+    "max_field_intensity": 1,
+    "extra_effects": [
+      {
+        "id": "eoc_channeling_setup",
+        "hit_self": true
+      }
+    ]
   },
   {
     "id": "earthshaper_stoneskin",
     "type": "SPELL",
-    "name": { "str": "Stoneskin" },
+    "name": {
+      "str": "Stoneskin"
+    },
     "description": "Envelops your entire body in armor formed from living rock, encumbering yet protective.",
-    "valid_targets": [ "self" ],
+    "valid_targets": [
+      "self"
+    ],
     "effect": "spawn_item",
     "effect_str": "aura_stoneskin",
     "shape": "blast",
-    "flags": [ "SOMATIC", "LOUD" ],
+    "flags": [
+      "CONJURATION_SPELL",
+      "SOMATIC",
+      "LOUD"
+    ],
     "spell_class": "EARTHSHAPER",
     "energy_source": "MANA",
     "difficulty": 4,
@@ -289,19 +472,42 @@
     "max_damage": 1,
     "min_duration": 10000,
     "max_duration": 150000,
-    "duration_increment": 2000
+    "duration_increment": 2000,
+    "extra_effects": [
+      {
+        "id": "eoc_summon_setup",
+        "hit_self": true
+      }
+    ]
   },
   {
     "id": "earthshaper_pillar",
     "type": "SPELL",
-    "name": { "str": "Pillar of Stone" },
+    "name": {
+      "str": "Pillar of Stone"
+    },
     "description": "Drawing upon the surrounding earth, you form a pillar of solid rock.  Experience will make the task easier, and less disruptive to the surrounding area.",
-    "valid_targets": [ "ground" ],
+    "valid_targets": [
+      "ground"
+    ],
     "effect": "ter_transform",
     "effect_str": "earthshaper_pillar",
     "shape": "blast",
-    "extra_effects": [ { "id": "earthshaper_pillar_side_effect" } ],
-    "flags": [ "SOMATIC", "LOUD", "NO_PROJECTILE" ],
+    "extra_effects": [
+      {
+        "id": "earthshaper_pillar_side_effect"
+      },
+      {
+        "id": "eoc_channeling_setup",
+        "hit_self": true
+      }
+    ],
+    "flags": [
+      "CHANNELING_SPELL",
+      "SOMATIC",
+      "LOUD",
+      "NO_PROJECTILE"
+    ],
     "spell_class": "EARTHSHAPER",
     "energy_source": "MANA",
     "difficulty": 3,
@@ -317,12 +523,20 @@
   {
     "id": "earthshaper_pillar_side_effect",
     "type": "SPELL",
-    "name": { "str": "Pillar Side Effect" },
+    "name": {
+      "str": "Pillar Side Effect"
+    },
     "description": "Bash effect that follows, levels reduce damage and AoE.",
-    "valid_targets": [ "ground" ],
+    "valid_targets": [
+      "ground"
+    ],
     "effect": "bash",
     "shape": "blast",
-    "flags": [ "IGNORE_WALLS", "SILENT", "NO_PROJECTILE" ],
+    "flags": [
+      "IGNORE_WALLS",
+      "SILENT",
+      "NO_PROJECTILE"
+    ],
     "max_level": 10,
     "min_damage": 80,
     "max_damage": 20,
@@ -334,10 +548,19 @@
   {
     "id": "pertifying_touch",
     "type": "SPELL",
-    "name": { "str": "Petrifying Touch" },
+    "name": {
+      "str": "Petrifying Touch"
+    },
     "description": "Your hands tries to transform the body of your enemy into a pure stone.  The effect is temporary, but it can deal significant damage.",
-    "valid_targets": [ "hostile" ],
-    "flags": [ "NO_PROJECTILE", "SILENT", "NO_HANDS" ],
+    "valid_targets": [
+      "hostile"
+    ],
+    "flags": [
+      "EVOCATION_SPELL",
+      "NO_PROJECTILE",
+      "SILENT",
+      "NO_HANDS"
+    ],
     "effect": "attack",
     "shape": "blast",
     "damage_type": "stab",
@@ -355,20 +578,39 @@
     "base_casting_time": 150,
     "final_casting_time": 60,
     "casting_time_increment": -6,
-    "extra_effects": [ { "id": "pertifying_touch_moves" } ],
+    "extra_effects": [
+      {
+        "id": "pertifying_touch_moves"
+      },
+      {
+        "id": "eoc_evocation_setup",
+        "hit_self": true
+      }
+    ],
     "energy_source": "MANA"
   },
   {
     "id": "reactive_armor",
     "type": "SPELL",
-    "name": { "str": "Reactive Armour" },
+    "name": {
+      "str": "Reactive Armour"
+    },
     "description": "Explode your stone skin, to deal massive damage to all enemies around.",
     "effect": "attack",
     "effect_str": "downed",
     "shape": "blast",
     "components": "spell_components_reactive_armor",
-    "valid_targets": [ "hostile", "ground" ],
-    "flags": [ "SOMATIC", "LOUD", "NO_HANDS", "RANDOM_DURATION" ],
+    "valid_targets": [
+      "hostile",
+      "ground"
+    ],
+    "flags": [
+      "EVOCATION_SPELL",
+      "SOMATIC",
+      "LOUD",
+      "NO_HANDS",
+      "RANDOM_DURATION"
+    ],
     "max_level": 30,
     "min_damage": 20,
     "max_damage": 300,
@@ -387,17 +629,34 @@
     "energy_increment": -5,
     "energy_source": "MANA",
     "difficulty": 5,
-    "damage_type": "stab"
+    "damage_type": "stab",
+    "extra_effects": [
+      {
+        "id": "eoc_evocation_setup",
+        "hit_self": true
+      }
+    ]
   },
   {
     "id": "eshaper_impalement",
     "type": "SPELL",
-    "name": { "str": "Impalement" },
+    "name": {
+      "str": "Impalement"
+    },
     "description": "Summon a stone spikes underground, that penetrate your enemies, and nail them for a while.",
     "effect": "attack",
     "shape": "blast",
-    "valid_targets": [ "hostile", "ground" ],
-    "flags": [ "SOMATIC", "VERBAL", "NO_PROJECTILE", "NO_LEGS" ],
+    "valid_targets": [
+      "hostile",
+      "ground"
+    ],
+    "flags": [
+      "EVOCATION_SPELL",
+      "SOMATIC",
+      "VERBAL",
+      "NO_PROJECTILE",
+      "NO_LEGS"
+    ],
     "max_level": 20,
     "min_damage": 16,
     "max_damage": 159,
@@ -407,25 +666,42 @@
     "aoe_increment": 0.3,
     "min_range": 6,
     "max_range": 30,
-    "range_increment": 1.0,
+    "range_increment": 1,
     "spell_class": "EARTHSHAPER",
     "base_casting_time": 200,
     "base_energy_cost": 300,
     "energy_source": "MANA",
     "difficulty": 5,
     "damage_type": "stab",
-    "extra_effects": [ { "id": "eshaper_impalement_moves" } ]
+    "extra_effects": [
+      {
+        "id": "eshaper_impalement_moves"
+      },
+      {
+        "id": "eoc_evocation_setup",
+        "hit_self": true
+      }
+    ]
   },
   {
     "id": "eshaper_melee_damage",
     "type": "SPELL",
-    "name": { "str": "Weighting" },
+    "name": {
+      "str": "Weighting"
+    },
     "description": "Fill yourself with the power of Earth, and make each your attacks as devastating as an earthquake.",
-    "valid_targets": [ "self" ],
+    "valid_targets": [
+      "self"
+    ],
     "effect": "attack",
     "effect_str": "eshaper_melee_damage",
     "shape": "blast",
-    "flags": [ "NO_LEGS", "SILENT", "NO_EXPLOSION_SFX" ],
+    "flags": [
+      "ENHANCEMENT_SPELL",
+      "NO_LEGS",
+      "SILENT",
+      "NO_EXPLOSION_SFX"
+    ],
     "spell_class": "EARTHSHAPER",
     "energy_source": "MANA",
     "difficulty": 6,
@@ -438,18 +714,33 @@
     "max_level": 35,
     "min_duration": 14400,
     "max_duration": 520000,
-    "duration_increment": 14400
+    "duration_increment": 14400,
+    "extra_effects": [
+      {
+        "id": "eoc_enhancement_setup",
+        "hit_self": true
+      }
+    ]
   },
   {
     "id": "eshaper_crystal_wrap",
     "type": "SPELL",
-    "name": { "str": "Crystal Wrapping" },
+    "name": {
+      "str": "Crystal Wrapping"
+    },
     "description": "You cover your body with a layer of small, razor-sharp crystals.  It makes monsters that attack you take some damage in return, and gives you some additional cut damage in melee.",
-    "valid_targets": [ "self" ],
+    "valid_targets": [
+      "self"
+    ],
     "effect": "attack",
     "effect_str": "eshaper_crystal_wrap",
     "shape": "blast",
-    "flags": [ "NO_LEGS", "SILENT", "NO_EXPLOSION_SFX" ],
+    "flags": [
+      "CONJURATION_SPELL",
+      "NO_LEGS",
+      "SILENT",
+      "NO_EXPLOSION_SFX"
+    ],
     "spell_class": "EARTHSHAPER",
     "energy_source": "MANA",
     "difficulty": 6,
@@ -462,14 +753,24 @@
     "max_level": 35,
     "min_duration": 14400,
     "max_duration": 520000,
-    "duration_increment": 14400
+    "duration_increment": 14400,
+    "extra_effects": [
+      {
+        "id": "eoc_summon_setup",
+        "hit_self": true
+      }
+    ]
   },
   {
     "id": "summon_eshaper_golem",
     "type": "SPELL",
-    "name": { "str": "Summon Earthshaper's Golem" },
+    "name": {
+      "str": "Summon Earthshaper's Golem"
+    },
     "description": "Shape a strong golem out of stone.  It may help for a while, but you haven't enough energy to support it forever.",
-    "valid_targets": [ "ground" ],
+    "valid_targets": [
+      "ground"
+    ],
     "min_damage": 1,
     "max_damage": 1,
     "max_level": 45,
@@ -487,21 +788,40 @@
     "casting_time_increment": -6000,
     "min_aoe": 1,
     "max_aoe": 1,
-    "flags": [ "SOMATIC", "VERBAL", "CONCENTRATE" ],
+    "flags": [
+      "CONJURATION_SPELL",
+      "SOMATIC",
+      "VERBAL",
+      "CONCENTRATE"
+    ],
     "min_duration": 12000,
     "max_duration": 520000,
-    "duration_increment": 12000
+    "duration_increment": 12000,
+    "extra_effects": [
+      {
+        "id": "eoc_summon_setup",
+        "hit_self": true
+      }
+    ]
   },
   {
     "id": "earthshaper_boulder",
     "type": "SPELL",
-    "name": { "str": "Summon Boulder" },
+    "name": {
+      "str": "Summon Boulder"
+    },
     "description": "Pull the smooth rock underground, using your forces of earth shaping.  You can use it as a table, or as a primitive anvil.",
-    "valid_targets": [ "ground" ],
+    "valid_targets": [
+      "ground"
+    ],
     "effect": "ter_transform",
     "effect_str": "earthshaper_boulder",
     "shape": "blast",
-    "flags": [ "SOMATIC", "NO_PROJECTILE" ],
+    "flags": [
+      "CONJURATION_SPELL",
+      "SOMATIC",
+      "NO_PROJECTILE"
+    ],
     "spell_class": "EARTHSHAPER",
     "energy_source": "MANA",
     "difficulty": 3,
@@ -511,15 +831,30 @@
     "base_energy_cost": 500,
     "max_level": 15,
     "min_range": 1,
-    "max_range": 1
+    "max_range": 1,
+    "extra_effects": [
+      {
+        "id": "eoc_summon_setup",
+        "hit_self": true
+      }
+    ]
   },
   {
     "id": "earthshaper_fortitude_of_stone",
     "type": "SPELL",
-    "name": { "str": "Stones' Fortitude" },
+    "name": {
+      "str": "Stones' Fortitude"
+    },
     "description": "Draw on the eternal endurance of the stones, slowing your metabolism and staving off hunger and thirst.  However, while the enchantment is in effect, you will not heal.",
-    "flags": [ "CONCENTRATE", "SOMATIC", "VERBAL" ],
-    "valid_targets": [ "self" ],
+    "flags": [
+      "ENHANCEMENT_SPELL",
+      "CONCENTRATE",
+      "SOMATIC",
+      "VERBAL"
+    ],
+    "valid_targets": [
+      "self"
+    ],
     "spell_class": "EARTHSHAPER",
     "energy_source": "MANA",
     "effect": "attack",
@@ -531,6 +866,12 @@
     "max_level": 30,
     "min_duration": 360000,
     "max_duration": 3220000,
-    "duration_increment": 100000
+    "duration_increment": 100000,
+    "extra_effects": [
+      {
+        "id": "eoc_enhancement_setup",
+        "hit_self": true
+      }
+    ]
   }
 ]

--- a/Kenan-Structured-Modpack/High-Maintenance-Huge-Mods/MagicRevampAdditions/Spells_Override/item_only.json
+++ b/Kenan-Structured-Modpack/High-Maintenance-Huge-Mods/MagicRevampAdditions/Spells_Override/item_only.json
@@ -2,11 +2,20 @@
   {
     "id": "twisted_restore",
     "type": "SPELL",
-    "name": { "str": "Twisted Restoration" },
+    "name": {
+      "str": "Twisted Restoration"
+    },
     "//": "Used for potion of Twisted Restoration, not castable",
     "description": "This spell overclocks your heart, generating new flesh and muscle.  It is unwise to use this in immediate danger, and may be fatal if done in critical condition.",
-    "valid_targets": [ "self" ],
-    "flags": [ "SILENT", "NO_LEGS", "NO_HANDS", "NO_PROJECTILE" ],
+    "valid_targets": [
+      "self"
+    ],
+    "flags": [
+      "SILENT",
+      "NO_LEGS",
+      "NO_HANDS",
+      "NO_PROJECTILE"
+    ],
     "max_level": 1,
     "min_damage": 10,
     "max_damage": 10,
@@ -20,22 +29,43 @@
     "base_casting_time": 30000,
     "base_energy_cost": 2,
     "extra_effects": [
-      { "id": "light_healing" },
-      { "id": "pain_damage" },
-      { "id": "pain_damage" },
-      { "id": "stamina_damage" },
-      { "id": "stamina_damage" },
-      { "id": "stamina_damage" }
+      {
+        "id": "light_healing"
+      },
+      {
+        "id": "pain_damage"
+      },
+      {
+        "id": "pain_damage"
+      },
+      {
+        "id": "stamina_damage"
+      },
+      {
+        "id": "stamina_damage"
+      },
+      {
+        "id": "stamina_damage"
+      }
     ]
   },
   {
     "id": "twisted_restore_improved",
     "type": "SPELL",
-    "name": { "str": "Improved Twisted Restoration" },
+    "name": {
+      "str": "Improved Twisted Restoration"
+    },
     "//": "Used for Animist-exclusive potion, not castable",
     "description": "This spell overclocks your heart, generating new flesh and muscle.  It is unwise to use this in immediate danger, and may be fatal if done in critical condition.  Improved brewing mitigates the strain of the spell.",
-    "valid_targets": [ "self" ],
-    "flags": [ "SILENT", "NO_LEGS", "NO_HANDS", "NO_PROJECTILE" ],
+    "valid_targets": [
+      "self"
+    ],
+    "flags": [
+      "SILENT",
+      "NO_LEGS",
+      "NO_HANDS",
+      "NO_PROJECTILE"
+    ],
     "max_level": 1,
     "min_damage": 8,
     "max_damage": 8,
@@ -48,14 +78,31 @@
     "energy_source": "HP",
     "base_casting_time": 12000,
     "base_energy_cost": 2,
-    "extra_effects": [ { "id": "light_healing" }, { "id": "pain_damage" }, { "id": "stamina_damage" }, { "id": "stamina_damage" } ]
+    "extra_effects": [
+      {
+        "id": "light_healing"
+      },
+      {
+        "id": "pain_damage"
+      },
+      {
+        "id": "stamina_damage"
+      },
+      {
+        "id": "stamina_damage"
+      }
+    ]
   },
   {
     "id": "conj_throwing_blade3",
     "type": "SPELL",
-    "name": { "str": "Conjure Throwing Blade I" },
+    "name": {
+      "str": "Conjure Throwing Blade I"
+    },
     "description": "conjures 3 throwing knives",
-    "valid_targets": [ "self" ],
+    "valid_targets": [
+      "self"
+    ],
     "effect": "spawn_item",
     "effect_str": "throwing_knife",
     "shape": "blast",
@@ -72,10 +119,16 @@
     "id": "conj_mag_throw_blade_group",
     "type": "SPELL",
     "//": "In future summoned knives should give temp buff to throwing skill",
-    "name": { "str": "Conjure Random Magical Throwing Blade" },
+    "name": {
+      "str": "Conjure Random Magical Throwing Blade"
+    },
     "description": "conjures a magical throwing knife, one of the spells specified in extra effects",
-    "valid_targets": [ "self" ],
-    "flags": [ "WONDER" ],
+    "valid_targets": [
+      "self"
+    ],
+    "flags": [
+      "WONDER"
+    ],
     "effect": "none",
     "message": "",
     "shape": "blast",
@@ -84,28 +137,58 @@
     "max_damage": 1,
     "base_casting_time": 30,
     "extra_effects": [
-      { "id": "conj_mag_throw_blade_1" },
-      { "id": "conj_mag_throw_blade_1" },
-      { "id": "conj_mag_throw_blade_1" },
-      { "id": "conj_mag_throw_blade_1" },
-      { "id": "conj_mag_throw_blade_fire" },
-      { "id": "conj_mag_throw_blade_fire" },
-      { "id": "conj_mag_throw_blade_cold" },
-      { "id": "conj_mag_throw_blade_cold" },
-      { "id": "conj_mag_throw_blade_cut" },
-      { "id": "conj_mag_throw_blade_cut" },
-      { "id": "conj_mag_throw_blade_biological" },
-      { "id": "conj_mag_throw_blade_biological" },
-      { "id": "magical_throwing_knife_pure_special" }
+      {
+        "id": "conj_mag_throw_blade_1"
+      },
+      {
+        "id": "conj_mag_throw_blade_1"
+      },
+      {
+        "id": "conj_mag_throw_blade_1"
+      },
+      {
+        "id": "conj_mag_throw_blade_1"
+      },
+      {
+        "id": "conj_mag_throw_blade_fire"
+      },
+      {
+        "id": "conj_mag_throw_blade_fire"
+      },
+      {
+        "id": "conj_mag_throw_blade_cold"
+      },
+      {
+        "id": "conj_mag_throw_blade_cold"
+      },
+      {
+        "id": "conj_mag_throw_blade_cut"
+      },
+      {
+        "id": "conj_mag_throw_blade_cut"
+      },
+      {
+        "id": "conj_mag_throw_blade_biological"
+      },
+      {
+        "id": "conj_mag_throw_blade_biological"
+      },
+      {
+        "id": "magical_throwing_knife_pure_special"
+      }
     ]
   },
   {
     "id": "conj_mag_throw_blade_1",
     "type": "SPELL",
     "//": "In future summoned knives will give temp buff to throwing skill",
-    "name": { "str": "Conjure Magical Throwing Blade I" },
+    "name": {
+      "str": "Conjure Magical Throwing Blade I"
+    },
     "description": "conjures 1 magical throwing knife",
-    "valid_targets": [ "self" ],
+    "valid_targets": [
+      "self"
+    ],
     "effect": "spawn_item",
     "effect_str": "magical_throwing_knife",
     "shape": "blast",
@@ -120,9 +203,13 @@
     "id": "conj_mag_throw_blade_fire",
     "type": "SPELL",
     "//": "In future summoned knives will give temp buff to throwing skill",
-    "name": { "str": "Conjure Magical Throwing Blade Fire" },
+    "name": {
+      "str": "Conjure Magical Throwing Blade Fire"
+    },
     "description": "conjures 1 magical throwing knife",
-    "valid_targets": [ "self" ],
+    "valid_targets": [
+      "self"
+    ],
     "effect": "spawn_item",
     "effect_str": "magical_throwing_knife_fire",
     "shape": "blast",
@@ -138,9 +225,13 @@
     "id": "conj_mag_throw_blade_cold",
     "type": "SPELL",
     "//": "In future summoned knives will give temp buff to throwing skill",
-    "name": { "str": "Conjure Magical Throwing Blade Cold" },
+    "name": {
+      "str": "Conjure Magical Throwing Blade Cold"
+    },
     "description": "conjures 1 magical throwing knife",
-    "valid_targets": [ "self" ],
+    "valid_targets": [
+      "self"
+    ],
     "effect": "spawn_item",
     "effect_str": "magical_throwing_knife_cold",
     "shape": "blast",
@@ -156,9 +247,13 @@
     "id": "conj_mag_throw_blade_cut",
     "type": "SPELL",
     "//": "In future summoned knives will give temp buff to throwing skill",
-    "name": { "str": "Conjure Magical Throwing Blade Cut" },
+    "name": {
+      "str": "Conjure Magical Throwing Blade Cut"
+    },
     "description": "conjures 1 magical throwing knife",
-    "valid_targets": [ "self" ],
+    "valid_targets": [
+      "self"
+    ],
     "effect": "spawn_item",
     "effect_str": "magical_throwing_knife_cut",
     "shape": "blast",
@@ -174,9 +269,13 @@
     "id": "conj_mag_throw_blade_biological",
     "type": "SPELL",
     "//": "In future summoned knives will give temp buff to throwing skill",
-    "name": { "str": "Conjure Magical Throwing Blade Biological" },
+    "name": {
+      "str": "Conjure Magical Throwing Blade Biological"
+    },
     "description": "conjures 1 magical throwing knife",
-    "valid_targets": [ "self" ],
+    "valid_targets": [
+      "self"
+    ],
     "effect": "spawn_item",
     "effect_str": "magical_throwing_knife_biological",
     "shape": "blast",
@@ -192,9 +291,13 @@
     "id": "magical_throwing_knife_pure_special",
     "type": "SPELL",
     "//": "In future summoned knives will give temp buff to throwing skill",
-    "name": { "str": "Conjure Magical Throwing Blade Pure" },
+    "name": {
+      "str": "Conjure Magical Throwing Blade Pure"
+    },
     "description": "conjures 1 magical throwing knife",
-    "valid_targets": [ "self" ],
+    "valid_targets": [
+      "self"
+    ],
     "effect": "spawn_item",
     "effect_str": "magical_throwing_knife_pure_special",
     "shape": "blast",
@@ -209,11 +312,15 @@
   {
     "id": "potion_recover_mana",
     "type": "SPELL",
-    "name": { "str": "Recover Mana" },
+    "name": {
+      "str": "Recover Mana"
+    },
     "description": "You regain mana.",
-    "valid_targets": [ "self" ],
+    "valid_targets": [
+      "self"
+    ],
     "min_damage": 250,
-    "damage_increment": 50.0,
+    "damage_increment": 50,
     "max_damage": 3000,
     "max_level": 50,
     "effect": "recover_energy",
@@ -225,36 +332,59 @@
     "base_energy_cost": 0,
     "energy_increment": 0,
     "final_energy_cost": 0,
-    "flags": [ "SILENT", "NO_LEGS" ],
+    "flags": [
+      "SILENT",
+      "NO_LEGS"
+    ],
     "difficulty": 3
   },
   {
     "id": "mana_doping",
     "type": "SPELL",
-    "name": { "str": "Pain" },
+    "name": {
+      "str": "Pain"
+    },
     "description": "Increases pain",
-    "valid_targets": [ "self" ],
-    "flags": [ "SILENT", "NO_LEGS", "NO_HANDS" ],
+    "valid_targets": [
+      "self"
+    ],
+    "flags": [
+      "SILENT",
+      "NO_LEGS",
+      "NO_HANDS"
+    ],
     "//": "Listed as a recover energy effect with a negative modifier that decreases with each level of the spell, which makes it cause damage instead.",
     "min_damage": -25,
     "max_damage": -335,
-    "damage_increment": -50.0,
+    "damage_increment": -50,
     "max_level": 15,
     "effect": "recover_energy",
     "effect_str": "PAIN",
     "shape": "blast",
     "spell_class": "NONE",
     "message": "Your veins feel like they are on fire!\nYou start regenerating mana!",
-    "extra_effects": [ { "id": "potion_recover_mana" } ]
+    "extra_effects": [
+      {
+        "id": "potion_recover_mana"
+      }
+    ]
   },
   {
     "id": "lupercalia",
     "type": "SPELL",
-    "name": { "str": "Lupercalian Release" },
+    "name": {
+      "str": "Lupercalian Release"
+    },
     "//": "Used for wolfshead cufflinks not castable",
     "description": "This spell transforms you into a werewolf.  There may be some cons to this.",
-    "valid_targets": [ "self" ],
-    "flags": [ "SILENT", "NO_LEGS", "NO_HANDS" ],
+    "valid_targets": [
+      "self"
+    ],
+    "flags": [
+      "SILENT",
+      "NO_LEGS",
+      "NO_HANDS"
+    ],
     "effect": "spawn_item",
     "effect_str": "aura_werewolf",
     "shape": "blast",
@@ -273,10 +403,17 @@
   {
     "id": "wolfsbane",
     "type": "SPELL",
-    "name": { "str": "Wolfsbane" },
+    "name": {
+      "str": "Wolfsbane"
+    },
     "description": "The tip of the spear glows white hot as you strike.",
-    "valid_targets": [ "hostile" ],
-    "flags": [ "NO_HANDS", "NO_LEGS" ],
+    "valid_targets": [
+      "hostile"
+    ],
+    "flags": [
+      "NO_HANDS",
+      "NO_LEGS"
+    ],
     "damage_type": "heat",
     "min_damage": 35,
     "min_range": 2,

--- a/Kenan-Structured-Modpack/High-Maintenance-Huge-Mods/MagicRevampAdditions/Spells_Override/kelvinist.json
+++ b/Kenan-Structured-Modpack/High-Maintenance-Huge-Mods/MagicRevampAdditions/Spells_Override/kelvinist.json
@@ -2,15 +2,25 @@
   {
     "id": "point_flare",
     "type": "SPELL",
-    "name": { "str": "Point Flare" },
+    "name": {
+      "str": "Point Flare"
+    },
     "description": "Causes an intense heat at the location, damaging the target.",
-    "valid_targets": [ "hostile" ],
-    "flags": [ "CONCENTRATE", "SOMATIC", "LOUD", "NO_PROJECTILE" ],
+    "valid_targets": [
+      "hostile"
+    ],
+    "flags": [
+      "EVOCATION_SPELL",
+      "CONCENTRATE",
+      "SOMATIC",
+      "LOUD",
+      "NO_PROJECTILE"
+    ],
     "effect": "attack",
     "shape": "blast",
     "damage_type": "heat",
     "min_damage": 16,
-    "damage_increment": 4.0,
+    "damage_increment": 4,
     "max_damage": 120,
     "min_range": 3,
     "range_increment": 0.5,
@@ -20,21 +30,37 @@
     "difficulty": 4,
     "max_level": 22,
     "base_casting_time": 300,
-    "energy_source": "MANA"
+    "energy_source": "MANA",
+    "extra_effects": [
+      {
+        "id": "eoc_evocation_setup",
+        "hit_self": true
+      }
+    ]
   },
   {
     "id": "nova_flare",
     "type": "SPELL",
-    "name": { "str": "Nova Flare" },
+    "name": {
+      "str": "Nova Flare"
+    },
     "description": "Causes an intense heat at the location, greatly damaging the target.",
-    "valid_targets": [ "hostile" ],
-    "flags": [ "CONCENTRATE", "SOMATIC", "LOUD", "NO_PROJECTILE" ],
+    "valid_targets": [
+      "hostile"
+    ],
+    "flags": [
+      "EVOCATION_SPELL",
+      "CONCENTRATE",
+      "SOMATIC",
+      "LOUD",
+      "NO_PROJECTILE"
+    ],
     "components": "spell_components_nova_flare",
     "effect": "attack",
     "shape": "blast",
     "damage_type": "heat",
     "min_damage": 45,
-    "damage_increment": 6.0,
+    "damage_increment": 6,
     "max_damage": 201,
     "min_range": 3,
     "range_increment": 0.5,
@@ -44,15 +70,28 @@
     "difficulty": 8,
     "max_level": 24,
     "base_casting_time": 300,
-    "energy_source": "MANA"
+    "energy_source": "MANA",
+    "extra_effects": [
+      {
+        "id": "eoc_evocation_setup",
+        "hit_self": true
+      }
+    ]
   },
   {
     "id": "create_lighter",
     "type": "SPELL",
-    "name": { "str": "Finger Firelighter" },
+    "name": {
+      "str": "Finger Firelighter"
+    },
     "description": "Summons a small flame that does not burn you, but you can use it to light things on fire.  It seems to need you to have some intent to light things on fire, because you are able to put it in your pocket with no issue.",
-    "valid_targets": [ "none" ],
-    "flags": [ "NO_LEGS" ],
+    "valid_targets": [
+      "none"
+    ],
+    "flags": [
+      "CONJURATION_SPELL",
+      "NO_LEGS"
+    ],
     "effect": "spawn_item",
     "effect_str": "finger_firelighter",
     "shape": "blast",
@@ -66,17 +105,34 @@
     "energy_source": "MANA",
     "base_casting_time": 250,
     "final_casting_time": 50,
-    "casting_time_increment": -20.0,
+    "casting_time_increment": -20,
     "base_energy_cost": 65,
-    "difficulty": 0
+    "difficulty": 0,
+    "extra_effects": [
+      {
+        "id": "eoc_summon_setup",
+        "hit_self": true
+      }
+    ]
   },
   {
     "id": "ice_spike",
     "type": "SPELL",
-    "name": { "str": "Ice Spike" },
+    "name": {
+      "str": "Ice Spike"
+    },
     "description": "Causes jagged icicles to form in the air above the target, falling and damaging it.",
-    "valid_targets": [ "hostile" ],
-    "flags": [ "CONCENTRATE", "SOMATIC", "LOUD", "VERBAL", "NO_PROJECTILE" ],
+    "valid_targets": [
+      "hostile"
+    ],
+    "flags": [
+      "EVOCATION_SPELL",
+      "CONCENTRATE",
+      "SOMATIC",
+      "LOUD",
+      "VERBAL",
+      "NO_PROJECTILE"
+    ],
     "effect": "attack",
     "shape": "blast",
     "damage_type": "cold",
@@ -91,53 +147,88 @@
     "spell_class": "KELVINIST",
     "base_casting_time": 200,
     "energy_source": "MANA",
-    "base_energy_cost": 100
+    "base_energy_cost": 100,
+    "extra_effects": [
+      {
+        "id": "eoc_evocation_setup",
+        "hit_self": true
+      }
+    ]
   },
   {
     "id": "fireball",
     "type": "SPELL",
-    "name": { "str": "Fireball" },
+    "name": {
+      "str": "Fireball"
+    },
     "description": "You hurl a pea-sized glowing orb that when reaches its target or an obstacle produces a pressure-less blast of searing heat.",
     "effect": "attack",
     "shape": "blast",
-    "valid_targets": [ "self", "ally", "hostile", "ground" ],
-    "flags": [ "SOMATIC", "VERBAL", "NO_LEGS", "IGNITE_FLAMMABLE" ],
+    "valid_targets": [
+      "self",
+      "ally",
+      "hostile",
+      "ground"
+    ],
+    "flags": [
+      "EVOCATION_SPELL",
+      "SOMATIC",
+      "VERBAL",
+      "NO_LEGS",
+      "IGNITE_FLAMMABLE"
+    ],
     "max_level": 30,
     "min_damage": 24,
     "max_damage": 102,
-    "damage_increment": 2.0,
+    "damage_increment": 2,
     "min_aoe": 3,
     "max_aoe": 7,
     "aoe_increment": 0.1,
     "min_range": 6,
     "max_range": 30,
-    "range_increment": 1.0,
+    "range_increment": 1,
     "spell_class": "KELVINIST",
     "base_casting_time": 200,
     "base_energy_cost": 350,
     "energy_source": "MANA",
     "difficulty": 4,
-    "damage_type": "heat"
+    "damage_type": "heat",
+    "extra_effects": [
+      {
+        "id": "eoc_evocation_setup",
+        "hit_self": true
+      }
+    ]
   },
   {
     "id": "cone_cold",
     "type": "SPELL",
-    "name": { "str": "Cone of Cold" },
+    "name": {
+      "str": "Cone of Cold"
+    },
     "description": "You blast a cone of frigid air toward the target.",
     "effect": "attack",
     "shape": "cone",
-    "valid_targets": [ "ally", "hostile", "ground" ],
-    "flags": [ "SOMATIC", "VERBAL" ],
+    "valid_targets": [
+      "ally",
+      "hostile",
+      "ground"
+    ],
+    "flags": [
+      "EVOCATION_SPELL",
+      "SOMATIC",
+      "VERBAL"
+    ],
     "max_level": 30,
     "min_damage": 24,
     "max_damage": 102,
-    "damage_increment": 2.0,
+    "damage_increment": 2,
     "min_aoe": 30,
     "max_aoe": 90,
     "aoe_increment": 1.4,
     "min_range": 6,
     "max_range": 30,
-    "range_increment": 1.0,
+    "range_increment": 1,
     "spell_class": "KELVINIST",
     "base_casting_time": 200,
     "base_energy_cost": 350,
@@ -147,76 +238,129 @@
     "min_field_intensity": 0,
     "max_field_intensity": 4,
     "field_intensity_increment": 0.5,
-    "damage_type": "cold"
+    "damage_type": "cold",
+    "extra_effects": [
+      {
+        "id": "eoc_evocation_setup",
+        "hit_self": true
+      }
+    ]
   },
   {
     "id": "burning_hands",
     "type": "SPELL",
-    "name": { "str": "Burning Hands" },
+    "name": {
+      "str": "Burning Hands"
+    },
     "description": "You're pretty sure you saw this in a game somewhere.  You fire a short-range cone of fire.",
     "effect": "attack",
     "shape": "cone",
-    "valid_targets": [ "ally", "hostile", "ground" ],
-    "flags": [ "SOMATIC", "VERBAL", "IGNITE_FLAMMABLE", "NO_HANDS" ],
+    "valid_targets": [
+      "ally",
+      "hostile",
+      "ground"
+    ],
+    "flags": [
+      "EVOCATION_SPELL",
+      "SOMATIC",
+      "VERBAL",
+      "IGNITE_FLAMMABLE",
+      "NO_HANDS"
+    ],
     "max_level": 30,
     "min_damage": 8,
     "max_damage": 95,
-    "damage_increment": 4.0,
+    "damage_increment": 4,
     "min_range": 3,
     "max_range": 8,
     "range_increment": 0.25,
     "min_aoe": 25,
     "max_aoe": 90,
-    "aoe_increment": 5.0,
+    "aoe_increment": 5,
     "spell_class": "KELVINIST",
     "base_casting_time": 100,
     "base_energy_cost": 150,
     "energy_source": "MANA",
     "difficulty": 2,
-    "damage_type": "heat"
+    "damage_type": "heat",
+    "extra_effects": [
+      {
+        "id": "eoc_evocation_setup",
+        "hit_self": true
+      }
+    ]
   },
   {
     "id": "frost_spray",
     "type": "SPELL",
-    "name": { "str": "Frost Spray" },
+    "name": {
+      "str": "Frost Spray"
+    },
     "description": "You're pretty sure you saw this in a game somewhere.  You fire a short-range cone of ice and cold.",
     "effect": "attack",
     "effect_str": "cold",
     "shape": "cone",
-    "affected_body_parts": [ "torso" ],
-    "valid_targets": [ "ally", "hostile", "ground" ],
-    "flags": [ "SOMATIC", "VERBAL", "NO_HANDS" ],
+    "affected_body_parts": [
+      "torso"
+    ],
+    "valid_targets": [
+      "ally",
+      "hostile",
+      "ground"
+    ],
+    "flags": [
+      "EVOCATION_SPELL",
+      "SOMATIC",
+      "VERBAL",
+      "NO_HANDS"
+    ],
     "max_level": 30,
     "min_damage": 8,
     "max_damage": 95,
-    "damage_increment": 4.0,
+    "damage_increment": 4,
     "min_range": 3,
     "max_range": 8,
     "range_increment": 0.25,
     "min_aoe": 25,
     "max_aoe": 90,
-    "aoe_increment": 5.0,
+    "aoe_increment": 5,
     "spell_class": "KELVINIST",
     "base_casting_time": 100,
     "base_energy_cost": 100,
     "energy_source": "MANA",
     "difficulty": 2,
-    "damage_type": "cold"
+    "damage_type": "cold",
+    "extra_effects": [
+      {
+        "id": "eoc_evocation_setup",
+        "hit_self": true
+      }
+    ]
   },
   {
     "id": "chilling_touch",
     "type": "SPELL",
-    "name": { "str": "Chilling Touch" },
+    "name": {
+      "str": "Chilling Touch"
+    },
     "description": "Freezes the touched target with intense cold.",
-    "valid_targets": [ "hostile" ],
-    "flags": [ "SOMATIC", "NO_PROJECTILE" ],
+    "valid_targets": [
+      "hostile"
+    ],
+    "flags": [
+      "EVOCATION_SPELL",
+      "SOMATIC",
+      "NO_PROJECTILE"
+    ],
     "effect": "attack",
     "effect_str": "cold",
     "shape": "blast",
-    "affected_body_parts": [ "torso" ],
+    "affected_body_parts": [
+      "torso"
+    ],
     "damage_type": "cold",
     "min_damage": 3,
-    "damage_increment": 4.0,
+    "damage_increment": 4,
     "max_damage": 60,
     "min_range": 1,
     "max_range": 1,
@@ -225,15 +369,31 @@
     "difficulty": 1,
     "max_level": 15,
     "base_casting_time": 100,
-    "energy_source": "MANA"
+    "energy_source": "MANA",
+    "extra_effects": [
+      {
+        "id": "eoc_evocation_setup",
+        "hit_self": true
+      }
+    ]
   },
   {
     "id": "glide_ice",
     "type": "SPELL",
-    "name": { "str": "Glide on Ice" },
+    "name": {
+      "str": "Glide on Ice"
+    },
     "description": "Encases your feet in a magical coating of ice, allowing you to glide along smooth surfaces faster.",
-    "valid_targets": [ "none" ],
-    "flags": [ "VERBAL", "NO_HANDS", "NO_LEGS", "CONCENTRATE" ],
+    "valid_targets": [
+      "none"
+    ],
+    "flags": [
+      "CONJURATION_SPELL",
+      "VERBAL",
+      "NO_HANDS",
+      "NO_LEGS",
+      "CONCENTRATE"
+    ],
     "min_damage": 1,
     "max_damage": 1,
     "effect": "spawn_item",
@@ -248,15 +408,33 @@
     "min_duration": 24000,
     "max_duration": 520000,
     "duration_increment": 24000,
-    "learn_spells": { "glide_ice_plus": 15 }
+    "learn_spells": {
+      "glide_ice_plus": 15
+    },
+    "extra_effects": [
+      {
+        "id": "eoc_summon_setup",
+        "hit_self": true
+      }
+    ]
   },
   {
     "id": "glide_ice_plus",
     "type": "SPELL",
-    "name": { "str": "Enhanced Glide on Ice" },
+    "name": {
+      "str": "Enhanced Glide on Ice"
+    },
     "description": "Encases your feet in a magical coating of ice, allowing you to glide along smooth surfaces faster.",
-    "valid_targets": [ "none" ],
-    "flags": [ "VERBAL", "NO_HANDS", "NO_LEGS" ],
+    "valid_targets": [
+      "none"
+    ],
+    "flags": [
+      "CONJURATION_SPELL",
+      "VERBAL",
+      "NO_HANDS",
+      "NO_LEGS",
+      "NO_FAIL"
+    ],
     "min_damage": 1,
     "max_damage": 1,
     "effect": "spawn_item",
@@ -274,43 +452,78 @@
     "energy_increment": -2,
     "min_duration": 360000,
     "max_duration": 14500000,
-    "duration_increment": 360000
+    "duration_increment": 360000,
+    "extra_effects": [
+      {
+        "id": "eoc_summon_setup",
+        "hit_self": true
+      }
+    ]
   },
   {
     "id": "hoary_blast",
     "type": "SPELL",
-    "name": { "str": "Hoary Blast" },
+    "name": {
+      "str": "Hoary Blast"
+    },
     "description": "You project a glowing white crystal of ice and it explodes on impact into a blossom of shattering cold.",
     "effect": "attack",
     "effect_str": "cold",
     "shape": "blast",
-    "affected_body_parts": [ "torso" ],
-    "valid_targets": [ "self", "ally", "hostile", "ground" ],
-    "flags": [ "SOMATIC", "VERBAL", "NO_LEGS" ],
+    "affected_body_parts": [
+      "torso"
+    ],
+    "valid_targets": [
+      "self",
+      "ally",
+      "hostile",
+      "ground"
+    ],
+    "flags": [
+      "EVOCATION_SPELL",
+      "SOMATIC",
+      "VERBAL",
+      "NO_LEGS"
+    ],
     "max_level": 30,
     "min_damage": 24,
     "max_damage": 102,
-    "damage_increment": 2.0,
+    "damage_increment": 2,
     "min_aoe": 3,
     "max_aoe": 8,
     "aoe_increment": 0.1,
     "min_range": 6,
     "max_range": 30,
-    "range_increment": 1.0,
+    "range_increment": 1,
     "spell_class": "KELVINIST",
     "base_casting_time": 200,
     "base_energy_cost": 350,
     "energy_source": "MANA",
     "difficulty": 4,
-    "damage_type": "cold"
+    "damage_type": "cold",
+    "extra_effects": [
+      {
+        "id": "eoc_evocation_setup",
+        "hit_self": true
+      }
+    ]
   },
   {
     "id": "ice_shield",
     "type": "SPELL",
-    "name": { "str": "Ice Shield" },
+    "name": {
+      "str": "Ice Shield"
+    },
     "description": "Creates a magical shield of ice on your arm, you can defend yourself with it in melee combat and use it to bash.",
-    "valid_targets": [ "none" ],
-    "flags": [ "NO_LEGS", "CONCENTRATE", "VERBAL" ],
+    "valid_targets": [
+      "none"
+    ],
+    "flags": [
+      "CONJURATION_SPELL",
+      "NO_LEGS",
+      "CONCENTRATE",
+      "VERBAL"
+    ],
     "min_damage": 1,
     "max_damage": 1,
     "effect": "spawn_item",
@@ -325,15 +538,32 @@
     "min_duration": 24000,
     "max_duration": 520000,
     "duration_increment": 24000,
-    "learn_spells": { "ice_shield_plus": 15 }
+    "learn_spells": {
+      "ice_shield_plus": 15
+    },
+    "extra_effects": [
+      {
+        "id": "eoc_summon_setup",
+        "hit_self": true
+      }
+    ]
   },
   {
     "id": "ice_shield_plus",
     "type": "SPELL",
-    "name": { "str": "Enhanced Ice Shield" },
+    "name": {
+      "str": "Enhanced Ice Shield"
+    },
     "description": "Creates a magical shield of ice on your arm, you can defend yourself with it in melee combat and use it to bash.  Now you know this spell like the back of your hand, and start to design your own version.",
-    "valid_targets": [ "self" ],
-    "flags": [ "NO_LEGS", "VERBAL" ],
+    "valid_targets": [
+      "self"
+    ],
+    "flags": [
+      "CONJURATION_SPELL",
+      "NO_LEGS",
+      "VERBAL",
+      "NO_FAIL"
+    ],
     "min_damage": 1,
     "max_damage": 1,
     "effect": "spawn_item",
@@ -351,19 +581,42 @@
     "energy_increment": -2,
     "min_duration": 360000,
     "max_duration": 14500000,
-    "duration_increment": 360000
+    "duration_increment": 360000,
+    "extra_effects": [
+      {
+        "id": "eoc_summon_setup",
+        "hit_self": true
+      }
+    ]
   },
   {
     "id": "frost_armor",
     "type": "SPELL",
-    "name": { "str": "Frost Armor" },
+    "name": {
+      "str": "Frost Armor"
+    },
     "description": "Covers you in a thin layer of magical ice to protect you from harm.",
-    "valid_targets": [ "self" ],
-    "flags": [ "NO_LEGS", "CONCENTRATE", "VERBAL", "SOMATIC" ],
+    "valid_targets": [
+      "self"
+    ],
+    "flags": [
+      "CONJURATION_SPELL",
+      "NO_LEGS",
+      "CONCENTRATE",
+      "VERBAL",
+      "SOMATIC"
+    ],
     "effect": "spawn_item",
     "effect_str": "armor_frost",
     "shape": "blast",
-    "affected_body_parts": [ "head", "torso", "leg_l", "leg_r", "arm_r", "arm_l" ],
+    "affected_body_parts": [
+      "head",
+      "torso",
+      "leg_l",
+      "leg_r",
+      "arm_r",
+      "arm_l"
+    ],
     "energy_source": "MANA",
     "spell_class": "KELVINIST",
     "difficulty": 5,
@@ -373,19 +626,44 @@
     "min_duration": 24000,
     "max_duration": 520000,
     "duration_increment": 24000,
-    "learn_spells": { "frost_armor_plus": 15 }
+    "learn_spells": {
+      "frost_armor_plus": 15
+    },
+    "extra_effects": [
+      {
+        "id": "eoc_summon_setup",
+        "hit_self": true
+      }
+    ]
   },
   {
     "id": "frost_armor_plus",
     "type": "SPELL",
-    "name": { "str": "Enhanced Frost Armor" },
+    "name": {
+      "str": "Enhanced Frost Armor"
+    },
     "description": "Covers you in a thin layer of magical ice to attack the enemies nearby.",
-    "valid_targets": [ "self" ],
-    "flags": [ "NO_LEGS", "VERBAL", "SOMATIC" ],
+    "valid_targets": [
+      "self"
+    ],
+    "flags": [
+      "CONJURATION_SPELL",
+      "NO_LEGS",
+      "VERBAL",
+      "SOMATIC",
+      "NO_FAIL"
+    ],
     "effect": "spawn_item",
     "effect_str": "armor_frost",
     "shape": "blast",
-    "affected_body_parts": [ "head", "torso", "leg_l", "leg_r", "arm_r", "arm_l" ],
+    "affected_body_parts": [
+      "head",
+      "torso",
+      "leg_l",
+      "leg_r",
+      "arm_r",
+      "arm_l"
+    ],
     "energy_source": "MANA",
     "spell_class": "KELVINIST",
     "difficulty": 5,
@@ -398,14 +676,24 @@
     "energy_increment": -14,
     "min_duration": 360000,
     "max_duration": 14500000,
-    "duration_increment": 72000
+    "duration_increment": 72000,
+    "extra_effects": [
+      {
+        "id": "eoc_summon_setup",
+        "hit_self": true
+      }
+    ]
   },
   {
     "id": "create_rune_kelvinist",
     "type": "SPELL",
-    "name": { "str": "Kelvinist Rune" },
+    "name": {
+      "str": "Kelvinist Rune"
+    },
     "description": "This ritual creates a small pebble attuned to Kelvinists.  You can use the rune as a catalyst for recipes.",
-    "valid_targets": [ "self" ],
+    "valid_targets": [
+      "self"
+    ],
     "min_damage": 1,
     "max_damage": 1,
     "effect": "spawn_item",
@@ -420,15 +708,34 @@
     "max_level": 0,
     "spell_class": "KELVINIST",
     "energy_source": "MANA",
-    "flags": [ "PERMANENT", "NO_LEGS", "CONCENTRATE" ]
+    "flags": [
+      "CHANNELING_SPELL",
+      "PERMANENT",
+      "NO_LEGS",
+      "CONCENTRATE"
+    ],
+    "extra_effects": [
+      {
+        "id": "eoc_channeling_setup",
+        "hit_self": true
+      }
+    ]
   },
   {
     "id": "kelvinist_summon_flamesword",
     "type": "SPELL",
-    "name": { "str": "Flamesword" },
+    "name": {
+      "str": "Flamesword"
+    },
     "description": "This spell ignites a wooden sword, creating a flaming blade able to burn, bruise, and chop.",
-    "valid_targets": [ "none" ],
-    "flags": [ "NO_LEGS" ],
+    "valid_targets": [
+      "none"
+    ],
+    "flags": [
+      "CONJURATION_SPELL",
+      "NO_LEGS",
+      "SOMATIC"
+    ],
     "effect": "spawn_item",
     "effect_str": "flamesword",
     "shape": "blast",
@@ -444,15 +751,32 @@
     "base_casting_time": 250,
     "base_energy_cost": 300,
     "difficulty": 4,
-    "learn_spells": { "kelvinist_summon_flamesword_plus": 15 }
+    "learn_spells": {
+      "kelvinist_summon_flamesword_plus": 15
+    },
+    "extra_effects": [
+      {
+        "id": "eoc_summon_setup",
+        "hit_self": true
+      }
+    ]
   },
   {
     "id": "kelvinist_summon_flamesword_plus",
     "type": "SPELL",
-    "name": { "str": "Enhanced Flamesword" },
+    "name": {
+      "str": "Enhanced Flamesword"
+    },
     "description": "This spell ignites a wooden sword, creating a flaming blade able to burn, bruise, and chop.  Now you know this spell like the back of your hand, and start to design your own version.",
-    "valid_targets": [ "self" ],
-    "flags": [ "NO_LEGS", "NO_HANDS" ],
+    "valid_targets": [
+      "self"
+    ],
+    "flags": [
+      "CONJURATION_SPELL",
+      "NO_LEGS",
+      "NO_HANDS",
+      "NO_FAIL"
+    ],
     "effect": "spawn_item",
     "effect_str": "flamesword",
     "shape": "blast",
@@ -471,22 +795,39 @@
     "base_energy_cost": 300,
     "final_energy_cost": 100,
     "energy_increment": -8,
-    "difficulty": 6
+    "difficulty": 6,
+    "extra_effects": [
+      {
+        "id": "eoc_summon_setup",
+        "hit_self": true
+      }
+    ]
   },
   {
     "id": "kelvinist_flamebreath",
     "type": "SPELL",
-    "name": { "str": "Flamebreath" },
+    "name": {
+      "str": "Flamebreath"
+    },
     "description": "This spell ignites dust scattered in the air, creating a cone of flame.  The hot ashes can cling to targets, causing additional burns over time.",
     "effect": "attack",
     "shape": "cone",
-    "valid_targets": [ "ally", "hostile", "ground" ],
-    "flags": [ "SOMATIC", "CONCENTRATE", "IGNITE_FLAMMABLE" ],
+    "valid_targets": [
+      "ally",
+      "hostile",
+      "ground"
+    ],
+    "flags": [
+      "EVOCATION_SPELL",
+      "SOMATIC",
+      "CONCENTRATE",
+      "IGNITE_FLAMMABLE"
+    ],
     "components": "spell_components_flamebreath",
     "max_level": 15,
     "min_damage": 25,
     "max_damage": 67,
-    "damage_increment": 2.0,
+    "damage_increment": 2,
     "min_dot": 2,
     "max_dot": 7,
     "dot_increment": 0.3,
@@ -504,15 +845,31 @@
     "base_energy_cost": 200,
     "energy_source": "MANA",
     "difficulty": 5,
-    "damage_type": "heat"
+    "damage_type": "heat",
+    "extra_effects": [
+      {
+        "id": "eoc_evocation_setup",
+        "hit_self": true
+      }
+    ]
   },
   {
     "id": "freezing_touch",
     "type": "SPELL",
-    "name": { "str": "Freezing Touch" },
+    "name": {
+      "str": "Freezing Touch"
+    },
     "description": "Your hands freeze anything they touch at temperatures so cold it slows down your foes.",
-    "valid_targets": [ "hostile" ],
-    "flags": [ "NO_PROJECTILE", "SILENT", "NO_HANDS", "NO_HANDS" ],
+    "valid_targets": [
+      "hostile"
+    ],
+    "flags": [
+      "EVOCATION_SPELL",
+      "NO_PROJECTILE",
+      "SILENT",
+      "NO_HANDS",
+      "NO_HANDS"
+    ],
     "effect": "attack",
     "effect_str": "slow_freeze_effect",
     "shape": "blast",
@@ -533,16 +890,31 @@
     "base_casting_time": 150,
     "final_casting_time": 60,
     "casting_time_increment": -6,
-    "energy_source": "MANA"
+    "energy_source": "MANA",
+    "extra_effects": [
+      {
+        "id": "eoc_evocation_setup",
+        "hit_self": true
+      }
+    ]
   },
   {
     "id": "kelvinist_anti_cold",
     "type": "SPELL",
-    "name": { "str": "Cloak of Warmth" },
+    "name": {
+      "str": "Cloak of Warmth"
+    },
     "description": "Heat the nearby air, keeping you warm and providing some protection against ice and cold.",
-    "valid_targets": [ "self" ],
+    "valid_targets": [
+      "self"
+    ],
     "spell_class": "KELVINIST",
-    "flags": [ "CONCENTRATE", "VERBAL", "SOMATIC" ],
+    "flags": [
+      "ENHANCEMENT_SPELL",
+      "CONCENTRATE",
+      "VERBAL",
+      "SOMATIC"
+    ],
     "effect": "attack",
     "effect_str": "effect_kelvinist_anti_cold",
     "shape": "blast",
@@ -553,16 +925,31 @@
     "duration_increment": 99000,
     "energy_source": "MANA",
     "base_energy_cost": 450,
-    "base_casting_time": 1500
+    "base_casting_time": 1500,
+    "extra_effects": [
+      {
+        "id": "eoc_enhancement_setup",
+        "hit_self": true
+      }
+    ]
   },
   {
     "id": "kelvinist_anti_heat",
     "type": "SPELL",
-    "name": { "str": "Cloak of Chill" },
+    "name": {
+      "str": "Cloak of Chill"
+    },
     "description": "Cool the nearby air, keeping you cool and providing some protection against heat and flame.",
-    "valid_targets": [ "self" ],
+    "valid_targets": [
+      "self"
+    ],
     "spell_class": "KELVINIST",
-    "flags": [ "CONCENTRATE", "VERBAL", "SOMATIC" ],
+    "flags": [
+      "ENHANCEMENT_SPELL",
+      "CONCENTRATE",
+      "VERBAL",
+      "SOMATIC"
+    ],
     "effect": "attack",
     "effect_str": "effect_kelvinist_anti_heat",
     "shape": "blast",
@@ -573,6 +960,12 @@
     "duration_increment": 99000,
     "energy_source": "MANA",
     "base_energy_cost": 450,
-    "base_casting_time": 1500
+    "base_casting_time": 1500,
+    "extra_effects": [
+      {
+        "id": "eoc_enhancement_setup",
+        "hit_self": true
+      }
+    ]
   }
 ]

--- a/Kenan-Structured-Modpack/High-Maintenance-Huge-Mods/MagicRevampAdditions/Spells_Override/magus.json
+++ b/Kenan-Structured-Modpack/High-Maintenance-Huge-Mods/MagicRevampAdditions/Spells_Override/magus.json
@@ -2,14 +2,19 @@
   {
     "id": "shadow_field",
     "type": "SPELL",
-    "name": { "str": "Shadow Field" },
+    "name": {
+      "str": "Shadow Field"
+    },
     "description": "Cast a field of intense shadows.",
     "effect": "attack",
     "field_id": "fd_darkness",
     "min_field_intensity": 1,
     "max_field_intensity": 1,
     "shape": "blast",
-    "valid_targets": [ "self", "ground" ],
+    "valid_targets": [
+      "self",
+      "ground"
+    ],
     "min_duration": 3000,
     "max_duration": 63000,
     "min_range": 10,
@@ -24,15 +29,37 @@
     "base_energy_cost": 250,
     "base_casting_time": 100,
     "difficulty": 1,
-    "flags": [ "NO_LEGS", "SOMATIC", "CONCENTRATE" ]
+    "flags": [
+      "EVOCATION_SPELL",
+      "NO_LEGS",
+      "SOMATIC",
+      "CONCENTRATE"
+    ],
+    "extra_effects": [
+      {
+        "id": "eoc_evocation_setup",
+        "hit_self": true
+      }
+    ]
   },
   {
     "id": "magic_missile",
     "type": "SPELL",
-    "name": { "str": "Magic Missile" },
+    "name": {
+      "str": "Magic Missile"
+    },
     "description": "I cast Magic Missile at the darkness!",
-    "valid_targets": [ "hostile" ],
-    "flags": [ "VERBAL", "SOMATIC", "NO_LEGS", "SILENT", "NO_PROJECTILE" ],
+    "valid_targets": [
+      "hostile"
+    ],
+    "flags": [
+      "EVOCATION_SPELL",
+      "VERBAL",
+      "SOMATIC",
+      "NO_LEGS",
+      "SILENT",
+      "NO_PROJECTILE"
+    ],
     "min_damage": 1,
     "damage_increment": 1.5,
     "damage_type": "pure",
@@ -47,17 +74,32 @@
     "base_casting_time": 100,
     "energy_source": "MANA",
     "shape": "blast",
-    "effect": "attack"
+    "effect": "attack",
+    "extra_effects": [
+      {
+        "id": "eoc_evocation_setup",
+        "hit_self": true
+      }
+    ]
   },
   {
     "id": "phase_door",
     "type": "SPELL",
-    "name": { "str": "Phase Door" },
+    "name": {
+      "str": "Phase Door"
+    },
     "description": "Teleports you in a random direction a short distance.",
     "effect": "short_range_teleport",
     "shape": "blast",
-    "valid_targets": [ "none" ],
-    "flags": [ "SOMATIC", "SILENT", "NO_LEGS" ],
+    "valid_targets": [
+      "none"
+    ],
+    "flags": [
+      "CONVEYANCE_SPELL",
+      "SOMATIC",
+      "SILENT",
+      "NO_LEGS"
+    ],
     "min_range": 3,
     "max_range": 6,
     "range_increment": 0.1,
@@ -70,17 +112,35 @@
     "base_casting_time": 100,
     "energy_source": "MANA",
     "base_energy_cost": 100,
-    "learn_spells": { "dimension_door": 10 }
+    "learn_spells": {
+      "dimension_door": 10
+    },
+    "extra_effects": [
+      {
+        "id": "eoc_conveyance_setup",
+        "hit_self": true
+      }
+    ]
   },
   {
     "id": "dimension_door",
     "type": "SPELL",
-    "name": { "str": "Dimension Door" },
+    "name": {
+      "str": "Dimension Door"
+    },
     "description": "Teleports you randomly near a target location.",
     "effect": "short_range_teleport",
     "shape": "blast",
-    "valid_targets": [ "ground" ],
-    "flags": [ "SOMATIC", "SILENT", "NO_LEGS", "TARGET_TELEPORT" ],
+    "valid_targets": [
+      "ground"
+    ],
+    "flags": [
+      "CONVEYANCE_SPELL",
+      "SOMATIC",
+      "SILENT",
+      "NO_LEGS",
+      "TARGET_TELEPORT"
+    ],
     "min_range": 10,
     "max_range": 30,
     "range_increment": 1,
@@ -94,17 +154,36 @@
     "energy_source": "MANA",
     "base_energy_cost": 600,
     "energy_increment": -10,
-    "final_energy_cost": 250
+    "final_energy_cost": 250,
+    "extra_effects": [
+      {
+        "id": "eoc_conveyance_setup",
+        "hit_self": true
+      }
+    ]
   },
   {
     "id": "gravity_well",
     "type": "SPELL",
-    "name": { "str": "Gravity Well" },
+    "name": {
+      "str": "Gravity Well"
+    },
     "description": "Summons a well of gravity with the epicenter at the location.  Deals bashing damage to all creatures in the affected area.",
     "effect": "attack",
     "shape": "blast",
-    "valid_targets": [ "self", "ally", "hostile", "ground" ],
-    "flags": [ "SOMATIC", "VERBAL", "CONCENTRATE", "NO_PROJECTILE" ],
+    "valid_targets": [
+      "self",
+      "ally",
+      "hostile",
+      "ground"
+    ],
+    "flags": [
+      "EVOCATION_SPELL",
+      "SOMATIC",
+      "VERBAL",
+      "CONCENTRATE",
+      "NO_PROJECTILE"
+    ],
     "min_damage": 20,
     "max_damage": 65,
     "damage_increment": 1.2,
@@ -120,15 +199,31 @@
     "spell_class": "MAGUS",
     "base_casting_time": 600,
     "energy_source": "MANA",
-    "base_energy_cost": 350
+    "base_energy_cost": 350,
+    "extra_effects": [
+      {
+        "id": "eoc_evocation_setup",
+        "hit_self": true
+      }
+    ]
   },
   {
     "id": "magus_mana_blast",
     "type": "SPELL",
-    "name": { "str": "Mana Blast" },
+    "name": {
+      "str": "Mana Blast"
+    },
     "description": "A blast of concentrated magical power that obliterates a large area.",
-    "valid_targets": [ "hostile", "ground" ],
-    "flags": [ "VERBAL", "SOMATIC", "NO_LEGS" ],
+    "valid_targets": [
+      "hostile",
+      "ground"
+    ],
+    "flags": [
+      "EVOCATION_SPELL",
+      "VERBAL",
+      "SOMATIC",
+      "NO_LEGS"
+    ],
     "effect": "attack",
     "shape": "blast",
     "spell_class": "MAGUS",
@@ -139,22 +234,37 @@
     "max_level": 30,
     "min_damage": 20,
     "max_damage": 120,
-    "damage_increment": 3.0,
+    "damage_increment": 3,
     "damage_type": "pure",
     "min_aoe": 1,
     "max_aoe": 5,
     "aoe_increment": 0.25,
     "min_range": 5,
     "max_range": 30,
-    "range_increment": 1
+    "range_increment": 1,
+    "extra_effects": [
+      {
+        "id": "eoc_evocation_setup",
+        "hit_self": true
+      }
+    ]
   },
   {
     "id": "magus_mana_bolt",
     "type": "SPELL",
-    "name": { "str": "Mana Bolt" },
+    "name": {
+      "str": "Mana Bolt"
+    },
     "description": "A bolt of magical power that only damages your foes.",
-    "valid_targets": [ "hostile" ],
-    "flags": [ "VERBAL", "SOMATIC", "NO_LEGS" ],
+    "valid_targets": [
+      "hostile"
+    ],
+    "flags": [
+      "EVOCATION_SPELL",
+      "VERBAL",
+      "SOMATIC",
+      "NO_LEGS"
+    ],
     "effect": "attack",
     "shape": "blast",
     "spell_class": "MAGUS",
@@ -165,19 +275,35 @@
     "max_level": 30,
     "min_damage": 20,
     "max_damage": 210,
-    "damage_increment": 7.0,
+    "damage_increment": 7,
     "damage_type": "pure",
     "min_range": 5,
     "max_range": 45,
-    "range_increment": 1.5
+    "range_increment": 1.5,
+    "extra_effects": [
+      {
+        "id": "eoc_evocation_setup",
+        "hit_self": true
+      }
+    ]
   },
   {
     "id": "magus_haste",
     "type": "SPELL",
-    "name": { "str": "Haste" },
+    "name": {
+      "str": "Haste"
+    },
     "description": "This spell gives you an enormous boost of speed lasting a short period of time.",
-    "valid_targets": [ "self" ],
-    "flags": [ "LOUD", "VERBAL", "SOMATIC", "NO_PROJECTILE" ],
+    "valid_targets": [
+      "self"
+    ],
+    "flags": [
+      "ENHANCEMENT_SPELL",
+      "LOUD",
+      "VERBAL",
+      "SOMATIC",
+      "NO_PROJECTILE"
+    ],
     "effect": "attack",
     "effect_str": "haste",
     "shape": "blast",
@@ -191,15 +317,31 @@
     "max_level": 30,
     "min_duration": 600,
     "max_duration": 18000,
-    "duration_increment": 600
+    "duration_increment": 600,
+    "extra_effects": [
+      {
+        "id": "eoc_enhancement_setup",
+        "hit_self": true
+      }
+    ]
   },
   {
     "id": "magus_baleful_polymorph",
     "type": "SPELL",
-    "name": { "str": "Baleful Polymorph" },
+    "name": {
+      "str": "Baleful Polymorph"
+    },
     "description": "Transform your enemies into frogs.",
-    "valid_targets": [ "hostile" ],
-    "flags": [ "VERBAL", "SOMATIC", "NO_LEGS", "NO_PROJECTILE" ],
+    "valid_targets": [
+      "hostile"
+    ],
+    "flags": [
+      "TRANSFORMATION_SPELL",
+      "VERBAL",
+      "SOMATIC",
+      "NO_LEGS",
+      "NO_PROJECTILE"
+    ],
     "effect": "targeted_polymorph",
     "effect_str": "mon_baleful_polymorph_frog",
     "shape": "blast",
@@ -211,19 +353,36 @@
     "max_level": 30,
     "min_damage": 20,
     "max_damage": 60,
-    "damage_increment": 2.0,
+    "damage_increment": 2,
     "damage_type": "pure",
     "min_range": 5,
     "max_range": 45,
-    "range_increment": 1.5
+    "range_increment": 1.5,
+    "extra_effects": [
+      {
+        "id": "eoc_transformation_setup",
+        "hit_self": true
+      }
+    ]
   },
   {
     "id": "magus_mana_beam",
     "type": "SPELL",
-    "name": { "str": "Mana Beam" },
+    "name": {
+      "str": "Mana Beam"
+    },
     "description": "A beam of focused magical power that damages any foes in its path.",
-    "valid_targets": [ "hostile", "ground" ],
-    "flags": [ "VERBAL", "SOMATIC", "NO_LEGS", "LOUD" ],
+    "valid_targets": [
+      "hostile",
+      "ground"
+    ],
+    "flags": [
+      "EVOCATION_SPELL",
+      "VERBAL",
+      "SOMATIC",
+      "NO_LEGS",
+      "LOUD"
+    ],
     "effect": "attack",
     "shape": "line",
     "spell_class": "MAGUS",
@@ -234,23 +393,39 @@
     "max_level": 30,
     "min_damage": 15,
     "max_damage": 90,
-    "damage_increment": 3.0,
+    "damage_increment": 3,
     "damage_type": "pure",
     "min_aoe": 1,
     "max_aoe": 1,
     "min_range": 5,
     "max_range": 30,
-    "range_increment": 1
+    "range_increment": 1,
+    "extra_effects": [
+      {
+        "id": "eoc_evocation_setup",
+        "hit_self": true
+      }
+    ]
   },
   {
     "id": "magus_escape",
     "type": "SPELL",
-    "name": { "str": "Escape" },
+    "name": {
+      "str": "Escape"
+    },
     "description": "Teleports you in a random direction a medium distance, to help escape your foes in dangerous situations.",
     "effect": "short_range_teleport",
     "shape": "blast",
-    "valid_targets": [ "none" ],
-    "flags": [ "SOMATIC", "SILENT", "NO_LEGS", "VERBAL" ],
+    "valid_targets": [
+      "none"
+    ],
+    "flags": [
+      "CONVEYANCE_SPELL",
+      "SOMATIC",
+      "SILENT",
+      "NO_LEGS",
+      "VERBAL"
+    ],
     "min_aoe": 5,
     "max_aoe": 15,
     "aoe_increment": 0.25,
@@ -262,14 +437,24 @@
     "spell_class": "MAGUS",
     "base_casting_time": 100,
     "energy_source": "MANA",
-    "base_energy_cost": 250
+    "base_energy_cost": 250,
+    "extra_effects": [
+      {
+        "id": "eoc_conveyance_setup",
+        "hit_self": true
+      }
+    ]
   },
   {
     "id": "create_rune_magus",
     "type": "SPELL",
-    "name": { "str": "Magus Rune" },
+    "name": {
+      "str": "Magus Rune"
+    },
     "description": "This ritual creates a small pebble attuned to Magi.  You can use the rune as a catalyst for recipes.",
-    "valid_targets": [ "self" ],
+    "valid_targets": [
+      "self"
+    ],
     "min_damage": 1,
     "max_damage": 1,
     "effect": "spawn_item",
@@ -284,14 +469,29 @@
     "max_level": 0,
     "spell_class": "MAGUS",
     "energy_source": "MANA",
-    "flags": [ "PERMANENT", "NO_LEGS", "CONCENTRATE" ]
+    "flags": [
+      "CHANNELING_SPELL",
+      "PERMANENT",
+      "NO_LEGS",
+      "CONCENTRATE"
+    ],
+    "extra_effects": [
+      {
+        "id": "eoc_channeling_setup",
+        "hit_self": true
+      }
+    ]
   },
   {
     "id": "cats_grace",
     "type": "SPELL",
-    "name": { "str": "Cat's Grace" },
+    "name": {
+      "str": "Cat's Grace"
+    },
     "description": "You become more graceful, agile, and coordinated.",
-    "valid_targets": [ "self" ],
+    "valid_targets": [
+      "self"
+    ],
     "min_duration": 6000,
     "max_duration": 520000,
     "duration_increment": 16000,
@@ -299,21 +499,37 @@
     "spell_class": "MAGUS",
     "energy_source": "MANA",
     "base_energy_cost": 400,
-    "energy_increment": -7.0,
+    "energy_increment": -7,
     "final_energy_cost": 200,
     "base_casting_time": 250,
     "difficulty": 5,
-    "flags": [ "VERBAL", "SOMATIC", "NO_LEGS", "NO_PROJECTILE" ],
+    "flags": [
+      "ENHANCEMENT_SPELL",
+      "VERBAL",
+      "SOMATIC",
+      "NO_LEGS",
+      "NO_PROJECTILE"
+    ],
     "shape": "blast",
     "effect": "attack",
-    "effect_str": "cats_grace"
+    "effect_str": "cats_grace",
+    "extra_effects": [
+      {
+        "id": "eoc_enhancement_setup",
+        "hit_self": true
+      }
+    ]
   },
   {
     "id": "eagles_sight",
     "type": "SPELL",
-    "name": { "str": "Eagle's Sight" },
+    "name": {
+      "str": "Eagle's Sight"
+    },
     "description": "You gain the perception of an eagle.",
-    "valid_targets": [ "self" ],
+    "valid_targets": [
+      "self"
+    ],
     "min_duration": 6000,
     "max_duration": 520000,
     "duration_increment": 16000,
@@ -321,21 +537,37 @@
     "spell_class": "MAGUS",
     "energy_source": "MANA",
     "base_energy_cost": 400,
-    "energy_increment": -7.0,
+    "energy_increment": -7,
     "final_energy_cost": 200,
     "base_casting_time": 250,
     "difficulty": 5,
-    "flags": [ "VERBAL", "SOMATIC", "NO_LEGS", "NO_PROJECTILE" ],
+    "flags": [
+      "ENHANCEMENT_SPELL",
+      "VERBAL",
+      "SOMATIC",
+      "NO_LEGS",
+      "NO_PROJECTILE"
+    ],
     "shape": "blast",
     "effect": "attack",
-    "effect_str": "eagles_sight"
+    "effect_str": "eagles_sight",
+    "extra_effects": [
+      {
+        "id": "eoc_enhancement_setup",
+        "hit_self": true
+      }
+    ]
   },
   {
     "id": "ogres_strength",
     "type": "SPELL",
-    "name": { "str": "Ogre's Strength" },
+    "name": {
+      "str": "Ogre's Strength"
+    },
     "description": "You gain the strength of an ogre.",
-    "valid_targets": [ "self" ],
+    "valid_targets": [
+      "self"
+    ],
     "min_duration": 6000,
     "max_duration": 520000,
     "duration_increment": 16000,
@@ -343,21 +575,37 @@
     "spell_class": "MAGUS",
     "energy_source": "MANA",
     "base_energy_cost": 400,
-    "energy_increment": -7.0,
+    "energy_increment": -7,
     "final_energy_cost": 200,
     "base_casting_time": 250,
     "difficulty": 5,
-    "flags": [ "VERBAL", "SOMATIC", "NO_LEGS", "NO_PROJECTILE" ],
+    "flags": [
+      "ENHANCEMENT_SPELL",
+      "VERBAL",
+      "SOMATIC",
+      "NO_LEGS",
+      "NO_PROJECTILE"
+    ],
     "shape": "blast",
     "effect": "attack",
-    "effect_str": "ogres_strength"
+    "effect_str": "ogres_strength",
+    "extra_effects": [
+      {
+        "id": "eoc_enhancement_setup",
+        "hit_self": true
+      }
+    ]
   },
   {
     "id": "foxs_cunning",
     "type": "SPELL",
-    "name": { "str": "Fox's Cunning" },
+    "name": {
+      "str": "Fox's Cunning"
+    },
     "description": "You become wily like a fox.",
-    "valid_targets": [ "self" ],
+    "valid_targets": [
+      "self"
+    ],
     "min_duration": 6000,
     "max_duration": 520000,
     "duration_increment": 16000,
@@ -365,25 +613,46 @@
     "spell_class": "MAGUS",
     "energy_source": "MANA",
     "base_energy_cost": 400,
-    "energy_increment": -7.0,
+    "energy_increment": -7,
     "final_energy_cost": 200,
     "base_casting_time": 250,
     "difficulty": 5,
-    "flags": [ "VERBAL", "SOMATIC", "NO_LEGS", "NO_PROJECTILE" ],
+    "flags": [
+      "ENHANCEMENT_SPELL",
+      "VERBAL",
+      "SOMATIC",
+      "NO_LEGS",
+      "NO_PROJECTILE"
+    ],
     "shape": "blast",
     "effect": "attack",
-    "effect_str": "foxs_cunning"
+    "effect_str": "foxs_cunning",
+    "extra_effects": [
+      {
+        "id": "eoc_enhancement_setup",
+        "hit_self": true
+      }
+    ]
   },
   {
     "id": "magus_force_jar",
     "type": "SPELL",
-    "name": { "str": "Jar of Force" },
+    "name": {
+      "str": "Jar of Force"
+    },
     "description": "Summon a jar of force in which you can store liquids.",
     "effect": "spawn_item",
     "effect_str": "jar_3l_force",
     "shape": "blast",
-    "valid_targets": [ "self" ],
-    "flags": [ "SOMATIC", "CONCENTRATE", "VERBAL" ],
+    "valid_targets": [
+      "self"
+    ],
+    "flags": [
+      "CONJURATION_SPELL",
+      "SOMATIC",
+      "CONCENTRATE",
+      "VERBAL"
+    ],
     "max_level": 22,
     "min_damage": 1,
     "max_damage": 1,
@@ -394,18 +663,33 @@
     "base_casting_time": 400,
     "base_energy_cost": 350,
     "energy_source": "MANA",
-    "difficulty": 3
+    "difficulty": 3,
+    "extra_effects": [
+      {
+        "id": "eoc_summon_setup",
+        "hit_self": true
+      }
+    ]
   },
   {
     "id": "magus_summon_impact_sling",
     "type": "SPELL",
-    "name": { "str": "Impact Sling" },
+    "name": {
+      "str": "Impact Sling"
+    },
     "description": "This spell infuses a sling with tremendous force, delivering devasting pebble shots until the energy tears it apart.",
     "effect": "spawn_item",
     "effect_str": "impactsling",
     "shape": "blast",
-    "valid_targets": [ "self" ],
-    "flags": [ "SOMATIC", "CONCENTRATE", "VERBAL" ],
+    "valid_targets": [
+      "self"
+    ],
+    "flags": [
+      "CONJURATION_SPELL",
+      "SOMATIC",
+      "CONCENTRATE",
+      "VERBAL"
+    ],
     "components": "spell_components_impactsling",
     "max_level": 22,
     "min_damage": 1,
@@ -418,18 +702,35 @@
     "base_energy_cost": 350,
     "energy_source": "MANA",
     "difficulty": 4,
-    "learn_spells": { "magus_summon_impact_sling_plus": 15 }
+    "learn_spells": {
+      "magus_summon_impact_sling_plus": 15
+    },
+    "extra_effects": [
+      {
+        "id": "eoc_summon_setup",
+        "hit_self": true
+      }
+    ]
   },
   {
     "id": "magus_summon_impact_sling_plus",
     "type": "SPELL",
-    "name": { "str": "Enhanced Impact Sling" },
+    "name": {
+      "str": "Enhanced Impact Sling"
+    },
     "description": "This spell infuses a sling with tremendous force, delivering devastating pebble shots until the energy tears it apart.  Now you know this spell like the back of your hand, and start to design your own version.",
     "effect": "spawn_item",
     "effect_str": "impactsling",
     "shape": "blast",
-    "valid_targets": [ "self" ],
-    "flags": [ "SOMATIC", "VERBAL" ],
+    "valid_targets": [
+      "self"
+    ],
+    "flags": [
+      "CONJURATION_SPELL",
+      "SOMATIC",
+      "VERBAL",
+      "NO_FAIL"
+    ],
     "components": "spell_components_impactsling",
     "max_level": 37,
     "min_damage": 1,
@@ -445,21 +746,39 @@
     "final_energy_cost": 100,
     "energy_increment": -10,
     "energy_source": "MANA",
-    "difficulty": 6
+    "difficulty": 6,
+    "extra_effects": [
+      {
+        "id": "eoc_summon_setup",
+        "hit_self": true
+      }
+    ]
   },
   {
     "id": "focused_bolt",
     "type": "SPELL",
-    "name": { "str": "Focused Bolt" },
+    "name": {
+      "str": "Focused Bolt"
+    },
     "description": "You focus your mana into a microscopically thin pulsed beam of pure energy, capable of extreme range and precision; as well as unparalleled penetration, provided proper skill.  Once the invention of a notorious assassin, this spell has slain many a king and noble.  Passed on only through direct descendants over the ages, though occasionally shared by them to others.",
     "effect": "attack",
     "shape": "line",
-    "valid_targets": [ "hostile", "ground" ],
-    "flags": [ "SOMATIC", "NO_LEGS", "CONCENTRATE", "SILENT", "NO_PROJECTILE" ],
+    "valid_targets": [
+      "hostile",
+      "ground"
+    ],
+    "flags": [
+      "EVOCATION_SPELL",
+      "SOMATIC",
+      "NO_LEGS",
+      "CONCENTRATE",
+      "SILENT",
+      "NO_PROJECTILE"
+    ],
     "max_level": 45,
     "min_damage": 5,
     "max_damage": 195,
-    "damage_increment": 5.0,
+    "damage_increment": 5,
     "damage_type": "pure",
     "min_range": 5,
     "max_range": 75,
@@ -471,16 +790,31 @@
     "base_casting_time": 500,
     "base_energy_cost": 400,
     "energy_source": "MANA",
-    "difficulty": 8
+    "difficulty": 8,
+    "extra_effects": [
+      {
+        "id": "eoc_evocation_setup",
+        "hit_self": true
+      }
+    ]
   },
   {
     "id": "magus_slowfall",
     "type": "SPELL",
-    "name": { "str": "Slowfall" },
+    "name": {
+      "str": "Slowfall"
+    },
     "description": "Reduce the velocity of your falls by a great amount, or to zero if at high mastery.",
-    "valid_targets": [ "self" ],
+    "valid_targets": [
+      "self"
+    ],
     "spell_class": "MAGUS",
-    "flags": [ "CONCENTRATE", "VERBAL", "SOMATIC" ],
+    "flags": [
+      "ENHANCEMENT_SPELL",
+      "CONCENTRATE",
+      "VERBAL",
+      "SOMATIC"
+    ],
     "effect": "attack",
     "effect_str": "effect_magus_slowfall",
     "shape": "blast",
@@ -491,16 +825,31 @@
     "duration_increment": 2400,
     "energy_source": "MANA",
     "base_energy_cost": 150,
-    "base_casting_time": 150
+    "base_casting_time": 150,
+    "extra_effects": [
+      {
+        "id": "eoc_enhancement_setup",
+        "hit_self": true
+      }
+    ]
   },
   {
     "id": "magus_spiderclimb",
     "type": "SPELL",
-    "name": { "str": "Spider Climb" },
+    "name": {
+      "str": "Spider Climb"
+    },
     "description": "Ascend even the most sheer wall with ease as you cling to surfaces using the power of magic.",
-    "valid_targets": [ "self" ],
+    "valid_targets": [
+      "self"
+    ],
     "spell_class": "MAGUS",
-    "flags": [ "CONCENTRATE", "VERBAL", "SOMATIC" ],
+    "flags": [
+      "ENHANCEMENT_SPELL",
+      "CONCENTRATE",
+      "VERBAL",
+      "SOMATIC"
+    ],
     "effect": "attack",
     "effect_str": "effect_magus_spiderclimb",
     "shape": "blast",
@@ -511,10 +860,12 @@
     "duration_increment": 7000,
     "energy_source": "MANA",
     "base_energy_cost": 250,
-    "base_casting_time": 250
+    "base_casting_time": 250,
+    "extra_effects": [
+      {
+        "id": "eoc_enhancement_setup",
+        "hit_self": true
+      }
+    ]
   }
 ]
-
-
-
-

--- a/Kenan-Structured-Modpack/High-Maintenance-Huge-Mods/MagicRevampAdditions/Spells_Override/manatouched.json
+++ b/Kenan-Structured-Modpack/High-Maintenance-Huge-Mods/MagicRevampAdditions/Spells_Override/manatouched.json
@@ -2,11 +2,22 @@
   {
     "id": "manatouched_crystal",
     "type": "SPELL",
-    "name": { "str": "Crystallize Mana" },
+    "name": {
+      "str": "Crystallize Mana"
+    },
     "description": "Crystallizes mana into solid form.  Your physiological changes have made this spell much more efficient and easier to cast.",
-    "valid_targets": [ "self" ],
+    "valid_targets": [
+      "self"
+    ],
     "spell_class": "MANA_CRYST_MANA",
-    "flags": [ "PERMANENT", "NO_LEGS", "CONCENTRATE", "NO_HANDS" ],
+    "flags": [
+      "CONJURATION_SPELL",
+      "PERMANENT",
+      "NO_LEGS",
+      "CONCENTRATE",
+      "NO_HANDS",
+      "MUST_HAVE_CLASS_TO_LEARN"
+    ],
     "max_level": 5,
     "difficulty": 3,
     "min_damage": 4,
@@ -20,20 +31,28 @@
     "final_energy_cost": 1000,
     "base_casting_time": 600000,
     "final_casting_time": 600000,
-    "extra_effects": [ { "id": "mana_fatigue" } ]
+    "extra_effects": [
+      {
+        "id": "mana_fatigue"
+      }
+    ]
   },
   {
     "id": "manatouched_seeker_bolts",
     "type": "SPELL",
-    "name": { "str": "Seeker Bolts" },
+    "name": {
+      "str": "Seeker Bolts"
+    },
     "effect": "attack",
     "shape": "blast",
     "description": "Fires bolts of mana from your fingertips that home in on randomly selected targets in range.",
-    "valid_targets": [ "hostile" ],
+    "valid_targets": [
+      "hostile"
+    ],
     "spell_class": "MANA_SEEKER_BOLTS",
     "min_damage": 6,
     "max_damage": 27,
-    "damage_increment": 1.0,
+    "damage_increment": 1,
     "max_level": 18,
     "min_range": 6,
     "max_range": 18,
@@ -43,7 +62,26 @@
     "base_casting_time": 85,
     "final_casting_time": 85,
     "sound_description": "a zing",
-    "flags": [ "RANDOM_TARGET", "SOMATIC", "NO_LEGS" ],
-    "extra_effects": [ { "id": "magic_missile" }, { "id": "magic_missile" }, { "id": "magic_missile" }, { "id": "magic_missile" } ]
+    "flags": [
+      "CHANNELING_SPELL",
+      "RANDOM_TARGET",
+      "SOMATIC",
+      "NO_LEGS",
+      "MUST_HAVE_CLASS_TO_LEARN"
+    ],
+    "extra_effects": [
+      {
+        "id": "magic_missile"
+      },
+      {
+        "id": "magic_missile"
+      },
+      {
+        "id": "magic_missile"
+      },
+      {
+        "id": "magic_missile"
+      }
+    ]
   }
 ]

--- a/Kenan-Structured-Modpack/High-Maintenance-Huge-Mods/MagicRevampAdditions/Spells_Override/stormshaper.json
+++ b/Kenan-Structured-Modpack/High-Maintenance-Huge-Mods/MagicRevampAdditions/Spells_Override/stormshaper.json
@@ -2,16 +2,27 @@
   {
     "id": "jolt",
     "type": "SPELL",
-    "name": { "str": "Jolt" },
+    "name": {
+      "str": "Jolt"
+    },
     "description": "A short-ranged fan of electricity shoots from your fingers.",
     "effect": "attack",
     "shape": "cone",
-    "valid_targets": [ "ally", "hostile", "ground" ],
-    "flags": [ "LOUD", "SOMATIC", "NO_HANDS" ],
+    "valid_targets": [
+      "ally",
+      "hostile",
+      "ground"
+    ],
+    "flags": [
+      "EVOCATION_SPELL",
+      "LOUD",
+      "SOMATIC",
+      "NO_HANDS"
+    ],
     "max_level": 30,
     "min_damage": 8,
     "max_damage": 95,
-    "damage_increment": 4.0,
+    "damage_increment": 4,
     "min_range": 3,
     "max_range": 8,
     "range_increment": 0.25,
@@ -24,17 +35,31 @@
     "energy_source": "MANA",
     "difficulty": 2,
     "sound_description": "a crackle",
-    "damage_type": "electric"
+    "damage_type": "electric",
+    "extra_effects": [
+      {
+        "id": "eoc_evocation_setup",
+        "hit_self": true
+      }
+    ]
   },
   {
     "id": "shocking_lash_base",
     "type": "SPELL",
-    "name": { "str": "Shocking Lash Base" },
+    "name": {
+      "str": "Shocking Lash Base"
+    },
     "description": "Reference spell definition used for Shocking Lash and Shocking Lash Jump",
     "effect": "attack",
     "shape": "blast",
-    "valid_targets": [ "hostile" ],
-    "flags": [ "SOMATIC", "NO_LEGS" ],
+    "valid_targets": [
+      "hostile"
+    ],
+    "flags": [
+      "EVOCATION_SPELL",
+      "SOMATIC",
+      "NO_LEGS"
+    ],
     "max_level": 30,
     "min_damage": 2,
     "max_damage": 36,
@@ -53,20 +78,33 @@
   {
     "id": "shocking_lash",
     "type": "SPELL",
-    "name": { "str": "Shocking Lash" },
+    "name": {
+      "str": "Shocking Lash"
+    },
     "description": "A quick burst of electricity strikes a target and possibly one other nearby.",
     "copy-from": "shocking_lash_base",
     "field_id": "none",
-    "extra_effects": [ { "id": "shocking_lash_2" } ]
+    "extra_effects": [
+      {
+        "id": "shocking_lash_2"
+      },
+      {
+        "id": "eoc_evocation_setup"
+      }
+    ]
   },
   {
     "id": "shocking_lash_2",
     "type": "SPELL",
-    "name": { "str": "Shocking Lash Jump" },
+    "name": {
+      "str": "Shocking Lash Jump"
+    },
     "description": "The secondary jump from Shocking Lash.",
     "copy-from": "shocking_lash_base",
     "field_id": "none",
-    "flags": [ "RANDOM_TARGET" ],
+    "flags": [
+      "RANDOM_TARGET"
+    ],
     "min_range": 1,
     "max_range": 2,
     "range_increment": 0.07
@@ -74,16 +112,28 @@
   {
     "id": "lightning_bolt",
     "type": "SPELL",
-    "name": { "str": "Lightning Bolt" },
+    "name": {
+      "str": "Lightning Bolt"
+    },
     "description": "The goto spell for many Stormshapers, this iconic spell does just what you expect: you shoot lightning from your fingertips.  However, this lightning is more directed than most lightning, and travels in a line through most non-solid targets.",
     "effect": "attack",
     "shape": "line",
-    "valid_targets": [ "ally", "hostile", "ground" ],
-    "flags": [ "LOUD", "SOMATIC", "NO_LEGS", "NO_HANDS" ],
+    "valid_targets": [
+      "ally",
+      "hostile",
+      "ground"
+    ],
+    "flags": [
+      "EVOCATION_SPELL",
+      "LOUD",
+      "SOMATIC",
+      "NO_LEGS",
+      "NO_HANDS"
+    ],
     "max_level": 50,
     "min_damage": 8,
     "max_damage": 300,
-    "damage_increment": 6.0,
+    "damage_increment": 6,
     "min_range": 4,
     "max_range": 12,
     "range_increment": 0.25,
@@ -101,19 +151,39 @@
     "field_chance": 1,
     "damage_type": "electric",
     "sound_description": "a crackle",
-    "energy_source": "MANA"
+    "energy_source": "MANA",
+    "extra_effects": [
+      {
+        "id": "eoc_evocation_setup",
+        "hit_self": true
+      }
+    ]
   },
   {
     "id": "windstrike",
     "type": "SPELL",
-    "name": { "str": "Windstrike" },
+    "name": {
+      "str": "Windstrike"
+    },
     "description": "A powerful blast of wind slams into anything in front of your outstretched hand.",
     "effect": "attack",
     "effect_str": "downed",
     "shape": "cone",
-    "affected_body_parts": [ "leg_l", "leg_r" ],
-    "valid_targets": [ "ally", "hostile", "ground" ],
-    "flags": [ "SOMATIC", "NO_LEGS", "NO_HANDS" ],
+    "affected_body_parts": [
+      "leg_l",
+      "leg_r"
+    ],
+    "valid_targets": [
+      "ally",
+      "hostile",
+      "ground"
+    ],
+    "flags": [
+      "EVOCATION_SPELL",
+      "SOMATIC",
+      "NO_LEGS",
+      "NO_HANDS"
+    ],
     "max_level": 30,
     "min_damage": 24,
     "max_damage": 136,
@@ -133,13 +203,23 @@
     "energy_source": "MANA",
     "difficulty": 3,
     "sound_description": "a whoosh",
-    "learn_spells": { "storm_shipwrecker": 15 },
-    "damage_type": "bash"
+    "learn_spells": {
+      "storm_shipwrecker": 15
+    },
+    "damage_type": "bash",
+    "extra_effects": [
+      {
+        "id": "eoc_evocation_setup",
+        "hit_self": true
+      }
+    ]
   },
   {
     "id": "windrun",
     "type": "SPELL",
-    "name": { "str": "Windrunning" },
+    "name": {
+      "str": "Windrunning"
+    },
     "description": "A magical wind pushes you forward as you move, easing your movements and increasing speed.",
     "base_casting_time": 110,
     "casting_time_increment": -5,
@@ -153,24 +233,52 @@
     "effect": "attack",
     "effect_str": "enchant_windrun",
     "shape": "blast",
-    "affected_body_parts": [ "torso" ],
-    "valid_targets": [ "ally", "self" ],
-    "flags": [ "CONCENTRATE", "SILENT", "VERBAL", "NO_HANDS", "NO_PROJECTILE" ],
+    "affected_body_parts": [
+      "torso"
+    ],
+    "valid_targets": [
+      "ally",
+      "self"
+    ],
+    "flags": [
+      "ENHANCEMENT_SPELL",
+      "CONCENTRATE",
+      "SILENT",
+      "VERBAL",
+      "NO_HANDS",
+      "NO_PROJECTILE"
+    ],
     "max_level": 15,
     "min_duration": 2000,
     "max_duration": 15000,
     "duration_increment": 1000,
     "min_range": 1,
     "max_range": 15,
-    "range_increment": 1
+    "range_increment": 1,
+    "extra_effects": [
+      {
+        "id": "eoc_enhancement_setup",
+        "hit_self": true
+      }
+    ]
   },
   {
     "id": "storm_hammer",
     "type": "SPELL",
-    "name": { "str": "Call Stormhammer" },
+    "name": {
+      "str": "Call Stormhammer"
+    },
     "description": "Creates a crackling magical warhammer full of lightning to smite your foes with, and of course, smash things to bits!",
-    "valid_targets": [ "self" ],
-    "flags": [ "CONCENTRATE", "LOUD", "VERBAL", "NO_LEGS" ],
+    "valid_targets": [
+      "self"
+    ],
+    "flags": [
+      "CONJURATION_SPELL",
+      "CONCENTRATE",
+      "LOUD",
+      "VERBAL",
+      "NO_LEGS"
+    ],
     "min_damage": 1,
     "max_damage": 1,
     "effect": "spawn_item",
@@ -185,15 +293,33 @@
     "min_duration": 24000,
     "max_duration": 520000,
     "duration_increment": 24000,
-    "learn_spells": { "storm_hammer_plus": 15 }
+    "learn_spells": {
+      "storm_hammer_plus": 15
+    },
+    "extra_effects": [
+      {
+        "id": "eoc_summon_setup",
+        "hit_self": true
+      }
+    ]
   },
   {
     "id": "storm_hammer_plus",
     "type": "SPELL",
-    "name": { "str": "Enhanced Call Stormhammer" },
+    "name": {
+      "str": "Enhanced Call Stormhammer"
+    },
     "description": "Creates a crackling magical warhammer full of lightning to smite your foes with, and of course, smash things to bits!  Now you know this spell like the back of your hand, and start to design your own version.",
-    "valid_targets": [ "self" ],
-    "flags": [ "LOUD", "VERBAL", "NO_LEGS" ],
+    "valid_targets": [
+      "self"
+    ],
+    "flags": [
+      "CONJURATION_SPELL",
+      "LOUD",
+      "VERBAL",
+      "NO_LEGS",
+      "NO_FAIL"
+    ],
     "min_damage": 1,
     "max_damage": 1,
     "effect": "spawn_item",
@@ -211,14 +337,24 @@
     "energy_increment": -8,
     "min_duration": 360000,
     "max_duration": 3220000,
-    "duration_increment": 72000
+    "duration_increment": 72000,
+    "extra_effects": [
+      {
+        "id": "eoc_summon_setup",
+        "hit_self": true
+      }
+    ]
   },
   {
     "id": "create_rune_stormshaper",
     "type": "SPELL",
-    "name": { "str": "Stormshaper Rune" },
+    "name": {
+      "str": "Stormshaper Rune"
+    },
     "description": "This ritual creates a small pebble attuned to Stormshapers.  You can use the rune as a catalyst for recipes.",
-    "valid_targets": [ "self" ],
+    "valid_targets": [
+      "self"
+    ],
     "min_damage": 1,
     "max_damage": 1,
     "effect": "spawn_item",
@@ -233,15 +369,38 @@
     "max_level": 0,
     "spell_class": "STORMSHAPER",
     "energy_source": "MANA",
-    "flags": [ "PERMANENT", "NO_LEGS", "CONCENTRATE" ]
+    "flags": [
+      "CHANNELING_SPELL",
+      "PERMANENT",
+      "NO_LEGS",
+      "CONCENTRATE"
+    ],
+    "extra_effects": [
+      {
+        "id": "eoc_channeling_setup",
+        "hit_self": true
+      }
+    ]
   },
   {
     "id": "lightning_blast",
     "type": "SPELL",
-    "name": { "str": "Lightning Blast" },
+    "name": {
+      "str": "Lightning Blast"
+    },
     "description": "You fire a small concentrated ball of lightning at the target.  The electricity diffuses quickly, so it doesn't do much damage, but you're able to fire off several quick ones in a row.",
-    "valid_targets": [ "hostile", "ground", "self", "ally" ],
-    "flags": [ "LOUD", "SOMATIC", "NO_LEGS" ],
+    "valid_targets": [
+      "hostile",
+      "ground",
+      "self",
+      "ally"
+    ],
+    "flags": [
+      "EVOCATION_SPELL",
+      "LOUD",
+      "SOMATIC",
+      "NO_LEGS"
+    ],
     "min_aoe": 1,
     "max_aoe": 3,
     "aoe_increment": 0.05,
@@ -251,7 +410,7 @@
     "min_range": 6,
     "max_range": 18,
     "range_increment": 0.2,
-    "damage_increment": 3.0,
+    "damage_increment": 3,
     "difficulty": 10,
     "spell_class": "STORMSHAPER",
     "energy_source": "MANA",
@@ -262,15 +421,35 @@
     "damage_type": "electric",
     "sound_description": "a crackle",
     "shape": "blast",
-    "effect": "attack"
+    "effect": "attack",
+    "extra_effects": [
+      {
+        "id": "eoc_evocation_setup",
+        "hit_self": true
+      }
+    ]
   },
   {
     "id": "lightning_storm",
     "type": "SPELL",
-    "name": { "str": "Lightning Storm" },
+    "name": {
+      "str": "Lightning Storm"
+    },
     "description": "You call the power of the sky to strike the earth.  Several lightning blasts fire from your finger tips to strike the target.",
-    "valid_targets": [ "hostile", "ground", "self", "ally" ],
-    "flags": [ "CONCENTRATE", "LOUD", "VERBAL", "SOMATIC", "NO_LEGS" ],
+    "valid_targets": [
+      "hostile",
+      "ground",
+      "self",
+      "ally"
+    ],
+    "flags": [
+      "EVOCATION_SPELL",
+      "CONCENTRATE",
+      "LOUD",
+      "VERBAL",
+      "SOMATIC",
+      "NO_LEGS"
+    ],
     "min_aoe": 1,
     "max_aoe": 3,
     "aoe_increment": 0.05,
@@ -280,7 +459,7 @@
     "min_range": 6,
     "max_range": 12,
     "range_increment": 0.01,
-    "damage_increment": 4.0,
+    "damage_increment": 4,
     "difficulty": 20,
     "spell_class": "STORMSHAPER",
     "energy_source": "MANA",
@@ -289,18 +468,52 @@
     "damage_type": "electric",
     "effect": "attack",
     "shape": "blast",
-    "extra_effects": [ { "id": "lightning_blast" }, { "id": "lightning_blast" }, { "id": "lightning_blast" } ]
+    "extra_effects": [
+      {
+        "id": "lightning_blast"
+      },
+      {
+        "id": "lightning_blast"
+      },
+      {
+        "id": "lightning_blast"
+      },
+      {
+        "id": "eoc_evocation_setup",
+        "hit_self": true
+      }
+    ]
   },
   {
     "id": "stormshaper_ionization",
     "type": "SPELL",
-    "name": { "str": "Ionization" },
+    "name": {
+      "str": "Ionization"
+    },
     "description": "By manipulating the charge in the air, you can conjure a sharp snap of lightning over a wide area.  While its destructive potential is a far cry from natural lightning, the light and thunderclap produced will leave your foes reeling.",
-    "valid_targets": [ "hostile", "ground", "self", "ally" ],
+    "valid_targets": [
+      "hostile",
+      "ground",
+      "self",
+      "ally"
+    ],
     "effect": "attack",
     "shape": "blast",
-    "extra_effects": [ { "id": "stormshaper_ionization_thunderclap" } ],
-    "flags": [ "SOMATIC", "NO_LEGS", "NO_PROJECTILE" ],
+    "extra_effects": [
+      {
+        "id": "stormshaper_ionization_thunderclap"
+      },
+      {
+        "id": "eoc_evocation_setup",
+        "hit_self": true
+      }
+    ],
+    "flags": [
+      "EVOCATION_SPELL",
+      "SOMATIC",
+      "NO_LEGS",
+      "NO_PROJECTILE"
+    ],
     "energy_source": "MANA",
     "spell_class": "STORMSHAPER",
     "difficulty": 8,
@@ -328,12 +541,22 @@
   {
     "type": "SPELL",
     "id": "stormshaper_ionization_thunderclap",
-    "name": { "str": "Ionization Thunderclap" },
+    "name": {
+      "str": "Ionization Thunderclap"
+    },
     "description": "Adds the actual flashbang effect.",
-    "valid_targets": [ "hostile", "ground", "self", "ally" ],
+    "valid_targets": [
+      "hostile",
+      "ground",
+      "self",
+      "ally"
+    ],
     "effect": "flashbang",
     "shape": "blast",
-    "flags": [ "LOUD" ],
+    "flags": [
+      "EVOCATION_SPELL",
+      "LOUD"
+    ],
     "max_level": 45,
     "min_range": 12,
     "max_range": 36,
@@ -342,13 +565,24 @@
   {
     "id": "stormshaper_wall_of_fog",
     "type": "SPELL",
-    "name": { "str": "Wall of Fog" },
+    "name": {
+      "str": "Wall of Fog"
+    },
     "description": "Draws forth a broad wall of thick fog.  While the sudden force of air pressure will floor any enemies caught in it, the conjuration is otherwise harmless.",
-    "valid_targets": [ "hostile", "ground", "ally" ],
+    "valid_targets": [
+      "hostile",
+      "ground",
+      "ally"
+    ],
     "effect": "attack",
     "effect_str": "downed",
     "shape": "line",
-    "flags": [ "SOMATIC", "NO_LEGS", "NO_HANDS" ],
+    "flags": [
+      "EVOCATION_SPELL",
+      "SOMATIC",
+      "NO_LEGS",
+      "NO_HANDS"
+    ],
     "energy_source": "MANA",
     "spell_class": "STORMSHAPER",
     "difficulty": 2,
@@ -368,20 +602,34 @@
     "field_chance": 1,
     "min_field_intensity": 3,
     "max_field_intensity": 3,
-    "field_intensity_variance": 1
+    "field_intensity_variance": 1,
+    "extra_effects": [
+      {
+        "id": "eoc_evocation_setup",
+        "hit_self": true
+      }
+    ]
   },
   {
     "id": "thorns_zap",
     "type": "SPELL",
-    "name": { "str": "Repelling Arc Aura" },
+    "name": {
+      "str": "Repelling Arc Aura"
+    },
     "description": "This is a sub-spell of the Repelling Arc spell.",
-    "valid_targets": [ "hostile" ],
+    "valid_targets": [
+      "hostile"
+    ],
     "effect": "attack",
     "shape": "blast",
     "damage_type": "electric",
     "min_damage": 15,
     "max_damage": 15,
-    "flags": [ "LOUD", "NO_PROJECTILE" ],
+    "flags": [
+      "ENHANCEMENT_SPELL",
+      "LOUD",
+      "NO_PROJECTILE"
+    ],
     "sound_type": "combat",
     "sound_description": "arcing electricity!",
     "min_range": 5,
@@ -390,13 +638,22 @@
   {
     "id": "stormshaper_repelling_arc",
     "type": "SPELL",
-    "name": { "str": "Repelling Arc" },
+    "name": {
+      "str": "Repelling Arc"
+    },
     "description": "Manifests an aura of crackling electricity around you to strike attackers with baleful lightning.",
-    "valid_targets": [ "none" ],
+    "valid_targets": [
+      "none"
+    ],
     "effect": "spawn_item",
     "effect_str": "thorns_electric",
     "shape": "blast",
-    "flags": [ "SOMATIC", "NO_LEGS", "CONCENTRATE" ],
+    "flags": [
+      "ENHANCEMENT_SPELL",
+      "SOMATIC",
+      "NO_LEGS",
+      "CONCENTRATE"
+    ],
     "energy_source": "MANA",
     "spell_class": "STORMSHAPER",
     "difficulty": 4,
@@ -408,18 +665,35 @@
     "min_duration": 24000,
     "max_duration": 520000,
     "duration_increment": 24000,
-    "learn_spells": { "stormshaper_repelling_arc_plus": 15 }
+    "learn_spells": {
+      "stormshaper_repelling_arc_plus": 15
+    },
+    "extra_effects": [
+      {
+        "id": "eoc_enhancement_setup",
+        "hit_self": true
+      }
+    ]
   },
   {
     "id": "stormshaper_repelling_arc_plus",
     "type": "SPELL",
-    "name": { "str": "Enhanced Repelling Arc" },
+    "name": {
+      "str": "Enhanced Repelling Arc"
+    },
     "description": "Manifests an aura of crackling electricity around you to strike attackers with baleful lightning.  Now you know this spell like the back of your hand, and start to design your own version.",
-    "valid_targets": [ "self" ],
+    "valid_targets": [
+      "self"
+    ],
     "effect": "attack",
     "effect_str": "effect_thorns_electric",
     "shape": "blast",
-    "flags": [ "SOMATIC", "NO_LEGS" ],
+    "flags": [
+      "ENHANCEMENT_SPELL",
+      "SOMATIC",
+      "NO_LEGS",
+      "NO_FAIL"
+    ],
     "energy_source": "MANA",
     "spell_class": "STORMSHAPER",
     "difficulty": 6,
@@ -432,15 +706,30 @@
     "max_level": 37,
     "min_duration": 360000,
     "max_duration": 3220000,
-    "duration_increment": 72000
+    "duration_increment": 72000,
+    "extra_effects": [
+      {
+        "id": "eoc_enhancement_setup",
+        "hit_self": true
+      }
+    ]
   },
   {
     "id": "stormfist",
     "type": "SPELL",
-    "name": { "str": "Stormfist" },
+    "name": {
+      "str": "Stormfist"
+    },
     "description": "Encases your arm and hand in a sheath of crackling magical lightning, you can punch and defend yourself with it in melee combat.",
-    "flags": [ "LOUD", "VERBAL", "NO_LEGS" ],
-    "valid_targets": [ "self" ],
+    "flags": [
+      "CONJURATION_SPELL",
+      "LOUD",
+      "VERBAL",
+      "NO_LEGS"
+    ],
+    "valid_targets": [
+      "self"
+    ],
     "min_damage": 1,
     "max_damage": 1,
     "spell_class": "STORMSHAPER",
@@ -455,15 +744,32 @@
     "min_duration": 24000,
     "max_duration": 520000,
     "duration_increment": 24000,
-    "learn_spells": { "stormfist_plus": 15 }
+    "learn_spells": {
+      "stormfist_plus": 15
+    },
+    "extra_effects": [
+      {
+        "id": "eoc_summon_setup",
+        "hit_self": true
+      }
+    ]
   },
   {
     "id": "stormfist_plus",
     "type": "SPELL",
-    "name": { "str": "Enhanced Stormfist" },
+    "name": {
+      "str": "Enhanced Stormfist"
+    },
     "description": "Encases your arm and hand in a sheath of crackling magical lightning, you can punch and defend yourself with it in melee combat.  Now you know this spell like the back of your hand, and start to design your own version.",
-    "valid_targets": [ "self" ],
-    "flags": [ "LOUD", "NO_LEGS" ],
+    "valid_targets": [
+      "self"
+    ],
+    "flags": [
+      "CONJURATION_SPELL",
+      "LOUD",
+      "NO_LEGS",
+      "NO_FAIL"
+    ],
     "min_damage": 1,
     "max_damage": 1,
     "spell_class": "STORMSHAPER",
@@ -481,15 +787,28 @@
     "energy_increment": -10,
     "min_duration": 360000,
     "max_duration": 3220000,
-    "duration_increment": 72000
+    "duration_increment": 72000,
+    "extra_effects": [
+      {
+        "id": "eoc_summon_setup",
+        "hit_self": true
+      }
+    ]
   },
   {
     "id": "create_electric_lighter",
     "type": "SPELL",
-    "name": { "str": "Fire Spark" },
+    "name": {
+      "str": "Fire Spark"
+    },
     "description": "Summons a small electric spark, that doesn't harm anything.  You can use it to ignite something flammable.",
-    "valid_targets": [ "none" ],
-    "flags": [ "NO_LEGS" ],
+    "valid_targets": [
+      "none"
+    ],
+    "flags": [
+      "CONJURATION_SPELL",
+      "NO_LEGS"
+    ],
     "effect": "spawn_item",
     "effect_str": "electric_lighter",
     "shape": "blast",
@@ -503,17 +822,29 @@
     "energy_source": "MANA",
     "base_casting_time": 260,
     "final_casting_time": 60,
-    "casting_time_increment": -20.0,
+    "casting_time_increment": -20,
     "base_energy_cost": 65,
-    "difficulty": 0
+    "difficulty": 0,
+    "extra_effects": [
+      {
+        "id": "eoc_summon_setup",
+        "hit_self": true
+      }
+    ]
   },
   {
     "id": "storm_shipwrecker",
     "type": "SPELL",
-    "name": { "str": "Shipwrecker" },
+    "name": {
+      "str": "Shipwrecker"
+    },
     "description": "The spell moves out of your mouth, creating a giant shockwave that shatters everything in its path.",
     "//": "fus ro dah!",
-    "valid_targets": [ "ally", "hostile", "ground" ],
+    "valid_targets": [
+      "ally",
+      "hostile",
+      "ground"
+    ],
     "effect": "attack",
     "effect_str": "downed",
     "shape": "cone",
@@ -534,23 +865,52 @@
     "min_range": 2,
     "max_range": 15,
     "range_increment": 0.3,
-    "flags": [ "VERBAL", "LOUD", "NO_HANDS", "RANDOM_DURATION" ],
+    "flags": [
+      "EVOCATION_SPELL",
+      "VERBAL",
+      "LOUD",
+      "NO_HANDS",
+      "RANDOM_DURATION"
+    ],
     "min_duration": 200,
     "max_duration": 900,
     "min_aoe": 30,
     "max_aoe": 225,
     "aoe_increment": 5,
-    "extra_effects": [ { "id": "shipwrecker_push" }, { "id": "shipwrecker_push" } ]
+    "extra_effects": [
+      {
+        "id": "shipwrecker_push"
+      },
+      {
+        "id": "shipwrecker_push"
+      },
+      {
+        "id": "eoc_evocation_setup",
+        "hit_self": true
+      }
+    ]
   },
   {
     "id": "explosive_decompression",
     "type": "SPELL",
-    "name": { "str": "Explosive Decompression" },
+    "name": {
+      "str": "Explosive Decompression"
+    },
     "description": "Create a high-pressure zone originating from the selected point.  Shortly after, a massive pressure wave will crush everything inside, inflicting barotrarumatic injuries on everyone affected.",
     "effect": "attack",
     "shape": "blast",
-    "valid_targets": [ "self", "ally", "hostile", "ground" ],
-    "flags": [ "SOMATIC", "VERBAL", "NO_LEGS" ],
+    "valid_targets": [
+      "self",
+      "ally",
+      "hostile",
+      "ground"
+    ],
+    "flags": [
+      "EVOCATION_SPELL",
+      "SOMATIC",
+      "VERBAL",
+      "NO_LEGS"
+    ],
     "max_level": 15,
     "min_damage": 24,
     "max_damage": 137,
@@ -571,17 +931,38 @@
     "energy_source": "MANA",
     "difficulty": 4,
     "damage_type": "bash",
-    "learn_spells": { "vacuum_decompression": 15 }
+    "learn_spells": {
+      "vacuum_decompression": 15
+    },
+    "extra_effects": [
+      {
+        "id": "eoc_evocation_setup",
+        "hit_self": true
+      }
+    ]
   },
   {
     "id": "vacuum_decompression",
     "type": "SPELL",
-    "name": { "str": "Vacuum Decompression" },
+    "name": {
+      "str": "Vacuum Decompression"
+    },
     "description": "Create a high-pressure zone originating from the selected point.  Shortly after, a massive pressure wave will crush everything inside, inflicting barotrarumatic injuries on everyone affected.  The pressure differential will also pull unprepared creatures inside the zone before collapsing.",
     "effect": "attack",
     "shape": "blast",
-    "valid_targets": [ "self", "ally", "hostile", "ground" ],
-    "flags": [ "SOMATIC", "VERBAL", "NO_LEGS", "EXTRA_EFFECTS_FIRST" ],
+    "valid_targets": [
+      "self",
+      "ally",
+      "hostile",
+      "ground"
+    ],
+    "flags": [
+      "EVOCATION_SPELL",
+      "SOMATIC",
+      "VERBAL",
+      "NO_LEGS",
+      "EXTRA_EFFECTS_FIRST"
+    ],
     "max_level": 37,
     "min_damage": 38,
     "max_damage": 227,
@@ -603,22 +984,50 @@
     "difficulty": 7,
     "damage_type": "bash",
     "extra_effects": [
-      { "id": "vacuum_decompression_pull" },
-      { "id": "vacuum_decompression_pull" },
-      { "id": "vacuum_decompression_pull" },
-      { "id": "vacuum_decompression_pull" },
-      { "id": "vacuum_decompression_pull" },
-      { "id": "vacuum_decompression_pull" },
-      { "id": "vacuum_decompression_pull" }
+      {
+        "id": "vacuum_decompression_pull"
+      },
+      {
+        "id": "vacuum_decompression_pull"
+      },
+      {
+        "id": "vacuum_decompression_pull"
+      },
+      {
+        "id": "vacuum_decompression_pull"
+      },
+      {
+        "id": "vacuum_decompression_pull"
+      },
+      {
+        "id": "vacuum_decompression_pull"
+      },
+      {
+        "id": "vacuum_decompression_pull"
+      },
+      {
+        "id": "eoc_evocation_setup",
+        "hit_self": true
+      }
     ]
   },
   {
     "id": "air_bubble",
     "type": "SPELL",
-    "name": { "str": "Air Bubble" },
+    "name": {
+      "str": "Air Bubble"
+    },
     "description": "Cover your head with an air bubble, allowing you to breathe underwater or prevent breathing of toxic gases.",
-    "valid_targets": [ "self" ],
-    "flags": [ "CONCENTRATE", "LOUD", "VERBAL", "NO_LEGS" ],
+    "valid_targets": [
+      "self"
+    ],
+    "flags": [
+      "CONJURATION_SPELL",
+      "CONCENTRATE",
+      "LOUD",
+      "VERBAL",
+      "NO_LEGS"
+    ],
     "min_damage": 1,
     "max_damage": 1,
     "effect": "spawn_item",
@@ -632,14 +1041,26 @@
     "base_energy_cost": 200,
     "min_duration": 18000,
     "max_duration": 270000,
-    "duration_increment": 18000
+    "duration_increment": 18000,
+    "extra_effects": [
+      {
+        "id": "eoc_summon_setup",
+        "hit_self": true
+      }
+    ]
   },
   {
     "id": "storm_superconductor",
     "type": "SPELL",
-    "name": { "str": "Superconductor" },
+    "name": {
+      "str": "Superconductor"
+    },
     "description": "Create arcs of devastating electric charge in an area around you, roasting everything within.",
-    "valid_targets": [ "ally", "hostile", "ground" ],
+    "valid_targets": [
+      "ally",
+      "hostile",
+      "ground"
+    ],
     "effect": "attack",
     "effect_str": "zapped",
     "shape": "blast",
@@ -658,7 +1079,14 @@
     "damage_increment": 6,
     "damage_type": "electric",
     "range_increment": 0.3,
-    "flags": [ "VERBAL", "LOUD", "NO_HANDS", "NO_LEGS", "RANDOM_DURATION" ],
+    "flags": [
+      "EVOCATION_SPELL",
+      "VERBAL",
+      "LOUD",
+      "NO_HANDS",
+      "NO_LEGS",
+      "RANDOM_DURATION"
+    ],
     "min_duration": 100,
     "max_duration": 500,
     "min_aoe": 1,
@@ -669,15 +1097,30 @@
     "min_field_intensity": 1,
     "max_field_intensity": 10,
     "field_intensity_increment": 0.4,
-    "field_intensity_variance": 3
+    "field_intensity_variance": 3,
+    "extra_effects": [
+      {
+        "id": "eoc_evocation_setup",
+        "hit_self": true
+      }
+    ]
   },
   {
     "type": "SPELL",
     "id": "shocking_dash",
-    "name": { "str": "Shocking Dash" },
+    "name": {
+      "str": "Shocking Dash"
+    },
     "description": "Fill your legs with energy and quickly dash to a target destination.",
-    "valid_targets": [ "hostile", "ground" ],
-    "flags": [ "NO_HANDS", "LOUD" ],
+    "valid_targets": [
+      "hostile",
+      "ground"
+    ],
+    "flags": [
+      "CONVEYANCE_SPELL",
+      "NO_HANDS",
+      "LOUD"
+    ],
     "effect": "dash",
     "shape": "cone",
     "min_damage": 0,
@@ -697,15 +1140,33 @@
     "energy_increment": -6,
     "max_level": 37,
     "energy_source": "MANA",
-    "learn_spells": { "shocking_teleport": 15 }
+    "learn_spells": {
+      "shocking_teleport": 15
+    },
+    "extra_effects": [
+      {
+        "id": "eoc_conveyance_setup",
+        "hit_self": true
+      }
+    ]
   },
   {
     "type": "SPELL",
     "id": "shocking_teleport",
-    "name": { "str": "Shocking Teleport" },
+    "name": {
+      "str": "Shocking Teleport"
+    },
     "description": "Briefly become lightning to teleport to a chosen spot, ignoring all obstacles in-between.",
-    "valid_targets": [ "hostile", "ground" ],
-    "flags": [ "NO_HANDS", "LOUD", "TARGET_TELEPORT" ],
+    "valid_targets": [
+      "hostile",
+      "ground"
+    ],
+    "flags": [
+      "CONVEYANCE_SPELL",
+      "NO_HANDS",
+      "LOUD",
+      "TARGET_TELEPORT"
+    ],
     "effect": "short_range_teleport",
     "shape": "blast",
     "min_range": 4,
@@ -719,18 +1180,36 @@
     "final_energy_cost": 100,
     "energy_increment": -10,
     "max_level": 37,
-    "energy_source": "MANA"
+    "energy_source": "MANA",
+    "extra_effects": [
+      {
+        "id": "eoc_conveyance_setup",
+        "hit_self": true
+      }
+    ]
   },
   {
     "id": "toxtricity",
     "type": "SPELL",
-    "name": { "str": "Toxtricity" },
+    "name": {
+      "str": "Toxtricity"
+    },
     "description": "Inject a corrosive electric energy into targets within the affected area, weakening them and dealing huge damage over time.",
     "effect": "attack",
     "effect_str": "zapped",
     "shape": "blast",
-    "valid_targets": [ "self", "ally", "hostile", "ground" ],
-    "flags": [ "SOMATIC", "VERBAL", "NO_LEGS" ],
+    "valid_targets": [
+      "self",
+      "ally",
+      "hostile",
+      "ground"
+    ],
+    "flags": [
+      "EVOCATION_SPELL",
+      "SOMATIC",
+      "VERBAL",
+      "NO_LEGS"
+    ],
     "max_level": 37,
     "min_damage": 0,
     "max_damage": 21,
@@ -756,18 +1235,33 @@
     "min_dot": 0,
     "max_dot": 21,
     "dot_increment": 0.6,
-    "damage_type": "electric"
+    "damage_type": "electric",
+    "extra_effects": [
+      {
+        "id": "eoc_evocation_setup",
+        "hit_self": true
+      }
+    ]
   },
   {
     "id": "electric_eye",
     "type": "SPELL",
-    "name": { "str": "Electric Eye" },
+    "name": {
+      "str": "Electric Eye"
+    },
     "description": "Enhance your sight with your powers.  It allows you to see creatures of the same energy around you.  Enhanced perception speed enables you to see attacks coming, allowing for an additional block or dodge attempt.",
-    "valid_targets": [ "self" ],
+    "valid_targets": [
+      "self"
+    ],
     "effect": "attack",
     "effect_str": "electric_eye",
     "shape": "blast",
-    "flags": [ "NO_LEGS", "SILENT", "NO_EXPLOSION_SFX" ],
+    "flags": [
+      "ENHANCEMENT_SPELL",
+      "NO_LEGS",
+      "SILENT",
+      "NO_EXPLOSION_SFX"
+    ],
     "spell_class": "STORMSHAPER",
     "energy_source": "MANA",
     "difficulty": 4,
@@ -780,18 +1274,33 @@
     "max_level": 37,
     "min_duration": 57600,
     "max_duration": 2160000,
-    "duration_increment": 57600
+    "duration_increment": 57600,
+    "extra_effects": [
+      {
+        "id": "eoc_enhancement_setup",
+        "hit_self": true
+      }
+    ]
   },
   {
     "id": "electric_waves",
     "type": "SPELL",
-    "name": { "str": "Electric Waves" },
+    "name": {
+      "str": "Electric Waves"
+    },
     "description": "Your hands start to emit a huge amount of energy, that you release with each attack.  The damage is increased the more you master the spell.",
-    "valid_targets": [ "self" ],
+    "valid_targets": [
+      "self"
+    ],
     "effect": "attack",
     "effect_str": "electric_waves",
     "shape": "blast",
-    "flags": [ "NO_LEGS", "SILENT", "NO_EXPLOSION_SFX" ],
+    "flags": [
+      "ENHANCEMENT_SPELL",
+      "NO_LEGS",
+      "SILENT",
+      "NO_EXPLOSION_SFX"
+    ],
     "spell_class": "STORMSHAPER",
     "energy_source": "MANA",
     "difficulty": 5,
@@ -804,21 +1313,39 @@
     "max_level": 37,
     "min_duration": 14400,
     "max_duration": 520000,
-    "duration_increment": 14400
+    "duration_increment": 14400,
+    "extra_effects": [
+      {
+        "id": "eoc_enhancement_setup",
+        "hit_self": true
+      }
+    ]
   },
   {
     "id": "electric_waves_damage",
     "type": "SPELL",
-    "name": { "str": "Electric Waves Damage" },
+    "name": {
+      "str": "Electric Waves Damage"
+    },
     "description": "Blasts, generated by Electric Waves.",
-    "valid_targets": [ "ally", "hostile", "ground" ],
+    "valid_targets": [
+      "ally",
+      "hostile",
+      "ground"
+    ],
     "effect": "attack",
     "shape": "blast",
     "min_damage": 10,
     "max_damage": 35,
     "min_range": 1,
     "damage_type": "electric",
-    "flags": [ "LOUD", "RANDOM_DURATION", "RANDOM_AOE", "RANDOM_DAMAGE" ],
+    "flags": [
+      "ENHANCEMENT_SPELL",
+      "LOUD",
+      "RANDOM_DURATION",
+      "RANDOM_AOE",
+      "RANDOM_DAMAGE"
+    ],
     "min_duration": 50,
     "max_duration": 200,
     "min_aoe": 1,
@@ -832,13 +1359,20 @@
   {
     "id": "electric_arts",
     "type": "SPELL",
-    "name": { "str": "Electric Arts" },
+    "name": {
+      "str": "Electric Arts"
+    },
     "description": "A spell designed for scholars having just started to learn stormshaping, allowing them to reduce the damage to themselves their often capricious new abilities may cause.",
-    "valid_targets": [ "self" ],
+    "valid_targets": [
+      "self"
+    ],
     "effect": "attack",
     "effect_str": "electric_arts",
     "shape": "blast",
-    "flags": [ "NO_EXPLOSION_SFX" ],
+    "flags": [
+      "ENHANCEMENT_SPELL",
+      "NO_EXPLOSION_SFX"
+    ],
     "spell_class": "STORMSHAPER",
     "energy_source": "MANA",
     "difficulty": 1,
@@ -849,14 +1383,24 @@
     "max_level": 37,
     "min_duration": 230400,
     "max_duration": 8650000,
-    "duration_increment": 230300
+    "duration_increment": 230300,
+    "extra_effects": [
+      {
+        "id": "eoc_enhancement_setup",
+        "hit_self": true
+      }
+    ]
   },
   {
     "id": "summon_teravolt",
     "type": "SPELL",
-    "name": { "str": "Summon Teravolt" },
+    "name": {
+      "str": "Summon Teravolt"
+    },
     "description": "Summon a Teravolt, a small, semi-intelligent spirit that homes onto hostile creatures before exploding into a huge spark cloud.",
-    "valid_targets": [ "ground" ],
+    "valid_targets": [
+      "ground"
+    ],
     "min_damage": 1,
     "max_damage": 1,
     "max_level": 37,
@@ -874,9 +1418,22 @@
     "casting_time_increment": -20,
     "min_aoe": 4,
     "max_aoe": 4,
-    "flags": [ "SOMATIC", "VERBAL", "CONCENTRATE", "PERMANENT", "NO_EXPLOSION_SFX" ],
+    "flags": [
+      "CONJURATION_SPELL",
+      "SOMATIC",
+      "VERBAL",
+      "CONCENTRATE",
+      "PERMANENT",
+      "NO_EXPLOSION_SFX"
+    ],
     "min_duration": 4800,
     "max_duration": 170000,
-    "duration_increment": 4800
+    "duration_increment": 4800,
+    "extra_effects": [
+      {
+        "id": "eoc_summon_setup",
+        "hit_self": true
+      }
+    ]
   }
 ]

--- a/Kenan-Structured-Modpack/High-Maintenance-Huge-Mods/MagicRevampAdditions/Spells_Override/technomancer.json
+++ b/Kenan-Structured-Modpack/High-Maintenance-Huge-Mods/MagicRevampAdditions/Spells_Override/technomancer.json
@@ -2,14 +2,27 @@
   {
     "id": "bless",
     "type": "SPELL",
-    "name": { "str": "Bless" },
+    "name": {
+      "str": "Bless"
+    },
     "description": "A spell of blessing that gives you energy and boosts your abilities.",
-    "valid_targets": [ "self", "ally" ],
-    "flags": [ "VERBAL", "SOMATIC", "NO_LEGS", "NO_PROJECTILE" ],
+    "valid_targets": [
+      "self",
+      "ally"
+    ],
+    "flags": [
+      "ENHANCEMENT_SPELL",
+      "VERBAL",
+      "SOMATIC",
+      "NO_LEGS",
+      "NO_PROJECTILE"
+    ],
     "effect": "attack",
     "effect_str": "bless",
     "shape": "blast",
-    "affected_body_parts": [ "torso" ],
+    "affected_body_parts": [
+      "torso"
+    ],
     "base_casting_time": 100,
     "base_energy_cost": 100,
     "energy_source": "MANA",
@@ -25,19 +38,33 @@
     "//": "duration is in moves",
     "min_duration": 6000,
     "max_duration": 50000,
-    "duration_increment": 1200
+    "duration_increment": 1200,
+    "extra_effects": [
+      {
+        "id": "eoc_enhancement_setup",
+        "hit_self": true
+      }
+    ]
   },
   {
     "id": "invisibility",
     "type": "SPELL",
-    "name": { "str": "Invisibility" },
+    "name": {
+      "str": "Invisibility"
+    },
     "description": "Creates a magical field that hides your visual presence to others.  Colloquially known as invisibility, but without all the science mumbo jumbo.",
     "message": "To the outside world, your body fades away and you cease to exist!",
-    "valid_targets": [ "self" ],
+    "valid_targets": [
+      "self"
+    ],
     "effect": "attack",
     "effect_str": "invisibility",
     "shape": "blast",
-    "flags": [ "NO_PROJECTILE" ],
+    "flags": [
+      "ENHANCEMENT_SPELL",
+      "SILENT",
+      "SOMATIC"
+    ],
     "spell_class": "TECHNOMANCER",
     "difficulty": 4,
     "base_casting_time": 100,
@@ -46,15 +73,30 @@
     "min_duration": 1250,
     "max_duration": 9000,
     "duration_increment": 250,
-    "max_level": 30
+    "max_level": 30,
+    "extra_effects": [
+      {
+        "id": "eoc_enhancement_setup",
+        "hit_self": true
+      }
+    ]
   },
   {
     "id": "holy_blade",
     "type": "SPELL",
-    "name": { "str": "Holy Blade" },
+    "name": {
+      "str": "Holy Blade"
+    },
     "description": "This blade of light will cut through any evil it makes contact with!",
-    "valid_targets": [ "self" ],
-    "flags": [ "VERBAL", "NO_LEGS", "CONCENTRATE" ],
+    "valid_targets": [
+      "self"
+    ],
+    "flags": [
+      "CONJURATION_SPELL",
+      "VERBAL",
+      "NO_LEGS",
+      "CONCENTRATE"
+    ],
     "min_range": 0,
     "max_range": 0,
     "min_damage": 1,
@@ -71,15 +113,32 @@
     "max_level": 22,
     "spell_class": "TECHNOMANCER",
     "energy_source": "MANA",
-    "learn_spells": { "holy_blade_plus": 15 }
+    "learn_spells": {
+      "holy_blade_plus": 15
+    },
+    "extra_effects": [
+      {
+        "id": "eoc_summon_setup",
+        "hit_self": true
+      }
+    ]
   },
   {
     "id": "holy_blade_plus",
     "type": "SPELL",
-    "name": { "str": "Enhanced Mage Blade" },
+    "name": {
+      "str": "Enhanced Mage Blade"
+    },
     "description": "This blade of light will cut through any evil it makes contact with!  Now you know this spell like the back of your hand, and start to design your own version.",
-    "valid_targets": [ "self" ],
-    "flags": [ "VERBAL", "NO_LEGS" ],
+    "valid_targets": [
+      "self"
+    ],
+    "flags": [
+      "CONJURATION_SPELL",
+      "VERBAL",
+      "NO_LEGS",
+      "NO_FAIL"
+    ],
     "min_range": 0,
     "max_range": 0,
     "min_damage": 1,
@@ -95,15 +154,31 @@
     "difficulty": 9,
     "max_level": 37,
     "spell_class": "TECHNOMANCER",
-    "energy_source": "MANA"
+    "energy_source": "MANA",
+    "extra_effects": [
+      {
+        "id": "eoc_summon_setup",
+        "hit_self": true
+      }
+    ]
   },
   {
     "id": "spirit_armor",
     "type": "SPELL",
-    "name": { "str": "Spiritual Armor" },
+    "name": {
+      "str": "Spiritual Armor"
+    },
     "description": "Evil will not make it through your defenses if your faith is strong enough!",
-    "valid_targets": [ "self" ],
-    "flags": [ "VERBAL", "NO_LEGS", "CONCENTRATE", "SOMATIC" ],
+    "valid_targets": [
+      "self"
+    ],
+    "flags": [
+      "CONJURATION_SPELL",
+      "VERBAL",
+      "NO_LEGS",
+      "CONCENTRATE",
+      "SOMATIC"
+    ],
     "min_range": 0,
     "max_range": 0,
     "min_damage": 1,
@@ -120,15 +195,33 @@
     "min_duration": 24000,
     "max_duration": 520000,
     "duration_increment": 24000,
-    "learn_spells": { "spirit_armor_plus": 15 }
+    "learn_spells": {
+      "spirit_armor_plus": 15
+    },
+    "extra_effects": [
+      {
+        "id": "eoc_summon_setup",
+        "hit_self": true
+      }
+    ]
   },
   {
     "id": "spirit_armor_plus",
     "type": "SPELL",
-    "name": { "str": "Enhanced Mage Armor" },
+    "name": {
+      "str": "Enhanced Mage Armor"
+    },
     "description": "Evil will not make it through your defenses if your faith is strong enough!  Now you know this spell like the back of your hand, and start to design your own version.",
-    "valid_targets": [ "self" ],
-    "flags": [ "VERBAL", "NO_LEGS", "SOMATIC" ],
+    "valid_targets": [
+      "self"
+    ],
+    "flags": [
+      "CONJURATION_SPELL",
+      "VERBAL",
+      "NO_LEGS",
+      "SOMATIC",
+      "NO_FAIL"
+    ],
     "min_range": 0,
     "max_range": 0,
     "min_damage": 1,
@@ -148,15 +241,30 @@
     "energy_increment": -14,
     "min_duration": 360000,
     "max_duration": 3220000,
-    "duration_increment": 72000
+    "duration_increment": 72000,
+    "extra_effects": [
+      {
+        "id": "eoc_summon_setup",
+        "hit_self": true
+      }
+    ]
   },
   {
     "id": "create_atomic_lamp",
     "type": "SPELL",
-    "name": { "str": "Lamp" },
+    "name": {
+      "str": "Lamp"
+    },
     "description": "Creates a magical lamp.",
-    "valid_targets": [ "none" ],
-    "flags": [ "VERBAL", "NO_LEGS", "CONCENTRATE" ],
+    "valid_targets": [
+      "none"
+    ],
+    "flags": [
+      "CONJURATION_SPELL",
+      "VERBAL",
+      "NO_LEGS",
+      "CONCENTRATE"
+    ],
     "min_range": 0,
     "max_range": 0,
     "min_damage": 1,
@@ -172,20 +280,37 @@
     "base_energy_cost": 750,
     "min_duration": 100000,
     "max_duration": 1500000,
-    "duration_increment": 45000
+    "duration_increment": 45000,
+    "extra_effects": [
+      {
+        "id": "eoc_summon_setup",
+        "hit_self": true
+      }
+    ]
   },
   {
     "id": "recover_bionic_power",
     "type": "SPELL",
-    "name": { "str": "Manatricity" },
+    "name": {
+      "str": "Manatricity"
+    },
     "description": "You have found a way to convert your spiritual energy into power you can use for your bionics.",
-    "valid_targets": [ "self" ],
-    "flags": [ "NO_LEGS", "NO_HANDS", "SOMATIC", "VERBAL", "SILENT" ],
+    "valid_targets": [
+      "self"
+    ],
+    "flags": [
+      "RESTORATION_SPELL",
+      "NO_LEGS",
+      "NO_HANDS",
+      "SOMATIC",
+      "VERBAL",
+      "SILENT"
+    ],
     "min_damage": 250,
-    "damage_increment": 50.0,
+    "damage_increment": 50,
     "max_damage": 22500,
     "base_energy_cost": 250,
-    "energy_increment": 50.0,
+    "energy_increment": 50,
     "final_energy_cost": 22500,
     "max_level": 37,
     "spell_class": "TECHNOMANCER",
@@ -194,14 +319,24 @@
     "shape": "blast",
     "energy_source": "MANA",
     "difficulty": 6,
-    "base_casting_time": 1000
+    "base_casting_time": 1000,
+    "extra_effects": [
+      {
+        "id": "eoc_restoration_setup",
+        "hit_self": true
+      }
+    ]
   },
   {
     "id": "create_rune_technomancer",
     "type": "SPELL",
-    "name": { "str": "Technomancer Rune" },
+    "name": {
+      "str": "Technomancer Rune"
+    },
     "description": "This ritual creates a small pebble attuned to Technomancers.  You can use the rune as a catalyst for recipes.",
-    "valid_targets": [ "self" ],
+    "valid_targets": [
+      "self"
+    ],
     "min_damage": 1,
     "max_damage": 1,
     "effect": "spawn_item",
@@ -216,42 +351,80 @@
     "max_level": 0,
     "spell_class": "TECHNOMANCER",
     "energy_source": "MANA",
-    "flags": [ "PERMANENT", "NO_LEGS", "CONCENTRATE" ]
+    "flags": [
+      "CHANNELING_SPELL",
+      "PERMANENT",
+      "NO_LEGS",
+      "CONCENTRATE"
+    ],
+    "extra_effects": [
+      {
+        "id": "eoc_channeling_setup",
+        "hit_self": true
+      }
+    ]
   },
   {
     "id": "taze",
     "type": "SPELL",
-    "name": { "str": "Taze" },
+    "name": {
+      "str": "Taze"
+    },
     "description": "This spell creates a very short range bolt of electricity to shock your foes.",
-    "valid_targets": [ "hostile", "ground", "ally" ],
-    "flags": [ "NO_LEGS", "LOUD", "SOMATIC", "NO_HANDS" ],
+    "valid_targets": [
+      "hostile",
+      "ground",
+      "ally"
+    ],
+    "flags": [
+      "EVOCATION_SPELL",
+      "NO_LEGS",
+      "LOUD",
+      "SOMATIC",
+      "NO_HANDS"
+    ],
     "effect": "attack",
     "shape": "blast",
     "spell_class": "TECHNOMANCER",
     "energy_source": "BIONIC",
     "difficulty": 1,
     "base_casting_time": 100,
-    "casting_time_increment": -1.0,
+    "casting_time_increment": -1,
     "final_casting_time": 70,
     "base_energy_cost": 50,
-    "energy_increment": -1.0,
+    "energy_increment": -1,
     "final_energy_cost": 20,
     "max_level": 30,
     "damage_type": "electric",
     "min_damage": 10,
     "max_damage": 45,
-    "damage_increment": 1.0,
+    "damage_increment": 1,
     "min_range": 1,
     "max_range": 6,
-    "range_increment": 0.2
+    "range_increment": 0.2,
+    "extra_effects": [
+      {
+        "id": "eoc_evocation_setup",
+        "hit_self": true
+      }
+    ]
   },
   {
     "id": "quantum_tunnel_lesser",
     "type": "SPELL",
-    "name": { "str": "Lesser Quantum Tunnel" },
+    "name": {
+      "str": "Lesser Quantum Tunnel"
+    },
     "description": "This spell manipulates some quantum something or other to tunnel you through a short distance of space, and even matter, unfortunately there's that whole uncertainty thing as to where you come out.  It leaves you a little dazed on the other side as you reorient yourself.",
-    "valid_targets": [ "none" ],
-    "flags": [ "NO_LEGS", "NO_HANDS", "SILENT" ],
+    "valid_targets": [
+      "none"
+    ],
+    "flags": [
+      "CONVEYANCE_SPELL",
+      "NO_LEGS",
+      "NO_HANDS",
+      "SILENT"
+    ],
     "effect": "short_range_teleport",
     "effect_str": "dazed",
     "shape": "blast",
@@ -260,10 +433,10 @@
     "difficulty": 2,
     "max_level": 30,
     "base_casting_time": 100,
-    "casting_time_increment": -1.0,
+    "casting_time_increment": -1,
     "final_casting_time": 70,
     "base_energy_cost": 100,
-    "energy_increment": -1.0,
+    "energy_increment": -1,
     "final_energy_cost": 70,
     "min_aoe": 4,
     "max_aoe": 1,
@@ -272,15 +445,30 @@
     "max_range": 15,
     "range_increment": 0.25,
     "min_duration": 100,
-    "max_duration": 100
+    "max_duration": 100,
+    "extra_effects": [
+      {
+        "id": "eoc_conveyance_setup",
+        "hit_self": true
+      }
+    ]
   },
   {
     "id": "synaptic_stimulation",
     "type": "SPELL",
-    "name": { "str": "Synaptic Stimulation" },
+    "name": {
+      "str": "Synaptic Stimulation"
+    },
     "description": "This spell stimulates the synapses in your brain beyond normal processing speeds, giving you a large boost in mental processing capability, including enhancing your reflexes, speed, and raw intellectual power.  Use responsibly!",
-    "valid_targets": [ "self" ],
-    "flags": [ "NO_LEGS", "VERBAL", "NO_PROJECTILE" ],
+    "valid_targets": [
+      "self"
+    ],
+    "flags": [
+      "ENHANCEMENT_SPELL",
+      "NO_LEGS",
+      "VERBAL",
+      "NO_PROJECTILE"
+    ],
     "effect": "attack",
     "effect_str": "synaptic_stim",
     "shape": "blast",
@@ -292,19 +480,37 @@
     "casting_time_increment": -2.5,
     "final_casting_time": 425,
     "base_energy_cost": 500,
-    "energy_increment": -5.0,
+    "energy_increment": -5,
     "final_energy_cost": 350,
     "min_duration": 7000,
     "max_duration": 298000,
-    "duration_increment": 10000
+    "duration_increment": 10000,
+    "extra_effects": [
+      {
+        "id": "eoc_enhancement_setup",
+        "hit_self": true
+      }
+    ]
   },
   {
     "id": "laze",
     "type": "SPELL",
-    "name": { "str": "Laze" },
+    "name": {
+      "str": "Laze"
+    },
     "description": "You concentrate and release a focused beam of photons at a target, also known as a laser.",
-    "valid_targets": [ "hostile", "ground", "ally" ],
-    "flags": [ "NO_LEGS", "LOUD", "SOMATIC", "NO_PROJECTILE" ],
+    "valid_targets": [
+      "hostile",
+      "ground",
+      "ally"
+    ],
+    "flags": [
+      "EVOCATION_SPELL",
+      "NO_LEGS",
+      "LOUD",
+      "SOMATIC",
+      "NO_PROJECTILE"
+    ],
     "effect": "attack",
     "shape": "blast",
     "spell_class": "TECHNOMANCER",
@@ -312,10 +518,10 @@
     "difficulty": 3,
     "max_level": 30,
     "base_casting_time": 100,
-    "casting_time_increment": -1.0,
+    "casting_time_increment": -1,
     "final_casting_time": 70,
     "base_energy_cost": 150,
-    "energy_increment": -2.0,
+    "energy_increment": -2,
     "final_energy_cost": 90,
     "min_damage": 15,
     "max_damage": 90,
@@ -323,15 +529,30 @@
     "damage_type": "heat",
     "min_range": 10,
     "max_range": 35,
-    "range_increment": 1.0
+    "range_increment": 1,
+    "extra_effects": [
+      {
+        "id": "eoc_evocation_setup",
+        "hit_self": true
+      }
+    ]
   },
   {
     "id": "animated_blade",
     "type": "SPELL",
-    "name": { "str": "Animated Blade" },
+    "name": {
+      "str": "Animated Blade"
+    },
     "description": "This spell conjures flying animated blades that will cut your enemies down to size.  Into small pieces that is.",
-    "valid_targets": [ "ground" ],
-    "flags": [ "SOMATIC", "VERBAL", "CONCENTRATE" ],
+    "valid_targets": [
+      "ground"
+    ],
+    "flags": [
+      "CONJURATION_SPELL",
+      "SOMATIC",
+      "VERBAL",
+      "CONCENTRATE"
+    ],
     "effect": "summon",
     "effect_str": "mon_animated_blade",
     "shape": "blast",
@@ -340,10 +561,10 @@
     "difficulty": 6,
     "max_level": 37,
     "base_casting_time": 200,
-    "casting_time_increment": -3.0,
+    "casting_time_increment": -3,
     "final_casting_time": 100,
     "base_energy_cost": 350,
-    "energy_increment": -7.0,
+    "energy_increment": -7,
     "final_energy_cost": 100,
     "min_damage": 1,
     "max_damage": 3,
@@ -355,15 +576,30 @@
     "max_aoe": 3,
     "min_duration": 7000,
     "max_duration": 221000,
-    "duration_increment": 7000
+    "duration_increment": 7000,
+    "extra_effects": [
+      {
+        "id": "eoc_summon_setup",
+        "hit_self": true
+      }
+    ]
   },
   {
     "id": "mirror_image",
     "type": "SPELL",
-    "name": { "str": "Mirror Image" },
+    "name": {
+      "str": "Mirror Image"
+    },
     "description": "This spell manipulates light into barely tangible duplicates of a living being, a magical hologram in short.",
-    "valid_targets": [ "ground" ],
-    "flags": [ "SOMATIC", "VERBAL", "CONCENTRATE" ],
+    "valid_targets": [
+      "ground"
+    ],
+    "flags": [
+      "CONJURATION_SPELL",
+      "SOMATIC",
+      "VERBAL",
+      "CONCENTRATE"
+    ],
     "effect": "summon",
     "effect_str": "mon_mirror_image",
     "shape": "blast",
@@ -372,10 +608,10 @@
     "difficulty": 4,
     "max_level": 30,
     "base_casting_time": 150,
-    "casting_time_increment": -2.0,
+    "casting_time_increment": -2,
     "final_casting_time": 100,
     "base_energy_cost": 200,
-    "energy_increment": -3.0,
+    "energy_increment": -3,
     "final_energy_cost": 100,
     "min_damage": 1,
     "max_damage": 8,
@@ -387,16 +623,37 @@
     "max_aoe": 3,
     "min_duration": 3000,
     "max_duration": 9000,
-    "duration_increment": 200
+    "duration_increment": 200,
+    "extra_effects": [
+      {
+        "id": "eoc_summon_setup",
+        "hit_self": true
+      }
+    ]
   },
   {
     "id": "holographic_transposition",
     "type": "SPELL",
-    "name": { "str": "Holographic Transposition" },
+    "name": {
+      "str": "Holographic Transposition"
+    },
     "description": "Allows you to swap places with a previously existing holographic image of yourself.  If the universe itself can't tell you apart, who could?",
-    "valid_targets": [ "hostile", "ally" ],
-    "targeted_monster_ids": [ "mon_mirror_image", "mon_hologram" ],
-    "flags": [ "NO_LEGS", "LOUD", "SOMATIC", "SWAP_POS", "NO_PROJECTILE" ],
+    "valid_targets": [
+      "hostile",
+      "ally"
+    ],
+    "targeted_monster_ids": [
+      "mon_mirror_image",
+      "mon_hologram"
+    ],
+    "flags": [
+      "CONVEYANCE_SPELL",
+      "NO_LEGS",
+      "LOUD",
+      "SOMATIC",
+      "SWAP_POS",
+      "NO_PROJECTILE"
+    ],
     "effect": "attack",
     "shape": "blast",
     "spell_class": "TECHNOMANCER",
@@ -404,22 +661,37 @@
     "difficulty": 3,
     "max_level": 30,
     "base_casting_time": 100,
-    "casting_time_increment": -2.0,
+    "casting_time_increment": -2,
     "final_casting_time": 70,
     "base_energy_cost": 150,
-    "energy_increment": -3.0,
+    "energy_increment": -3,
     "final_energy_cost": 70,
     "min_range": 20,
     "max_range": 45,
-    "range_increment": 1.0
+    "range_increment": 1,
+    "extra_effects": [
+      {
+        "id": "eoc_conveyance_setup",
+        "hit_self": true
+      }
+    ]
   },
   {
     "id": "summon_floating_disk",
     "type": "SPELL",
-    "name": { "str": "Summon floating disk" },
+    "name": {
+      "str": "Summon floating disk"
+    },
     "description": "Summons a floating disk that is sworn to carry your burdens.",
-    "valid_targets": [ "ground" ],
-    "flags": [ "SOMATIC", "VERBAL", "CONCENTRATE" ],
+    "valid_targets": [
+      "ground"
+    ],
+    "flags": [
+      "CONJURATION_SPELL",
+      "SOMATIC",
+      "VERBAL",
+      "CONCENTRATE"
+    ],
     "effect": "summon_vehicle",
     "spell_class": "TECHNOMANCER",
     "energy_source": "MANA",
@@ -434,15 +706,30 @@
     "range_increment": 1,
     "min_duration": 300000,
     "max_duration": 16000000,
-    "duration_increment": 500000
+    "duration_increment": 500000,
+    "extra_effects": [
+      {
+        "id": "eoc_summon_setup",
+        "hit_self": true
+      }
+    ]
   },
   {
     "id": "summon_magic_motorcycle",
     "type": "SPELL",
-    "name": { "str": "Summon Mojocycle" },
+    "name": {
+      "str": "Summon Mojocycle"
+    },
     "description": "You're not a cowboy, but on a steel horse you ride regardless.",
-    "valid_targets": [ "ground" ],
-    "flags": [ "SOMATIC", "VERBAL", "CONCENTRATE" ],
+    "valid_targets": [
+      "ground"
+    ],
+    "flags": [
+      "CONJURATION_SPELL",
+      "SOMATIC",
+      "VERBAL",
+      "CONCENTRATE"
+    ],
     "effect": "summon_vehicle",
     "spell_class": "TECHNOMANCER",
     "energy_source": "MANA",
@@ -457,12 +744,20 @@
     "range_increment": 1,
     "min_duration": 240000,
     "max_duration": 2160000,
-    "duration_increment": 60000
+    "duration_increment": 60000,
+    "extra_effects": [
+      {
+        "id": "eoc_summon_setup",
+        "hit_self": true
+      }
+    ]
   },
   {
     "id": "overcharge_burn",
     "type": "SPELL",
-    "name": { "str": "Overcharge Burn" },
+    "name": {
+      "str": "Overcharge Burn"
+    },
     "description": "The side effects of casting the overcharge spell.",
     "message": "",
     "effect": "spawn_item",
@@ -474,21 +769,34 @@
     "duration_increment": -10,
     "max_duration": 50,
     "max_level": 45,
-    "valid_targets": [ "none" ]
+    "valid_targets": [
+      "none"
+    ]
   },
   {
     "id": "overcharge_eyes",
     "type": "SPELL",
-    "name": { "str": "Optical Sneeze Beam" },
+    "name": {
+      "str": "Optical Sneeze Beam"
+    },
     "description": "You overcharge your internal batteries to send a semi-directed beam from your face.  The inventor of this spell must have had some weird sense of humor.",
     "message": "You overcharge your bionic energy through what ley lines you have left, and channel it through the center of your face.",
     "sound_description": "bzzzzzzt!",
     "sound_ambient": true,
     "effect": "attack",
     "shape": "cone",
-    "extra_effects": [ { "id": "overcharge_burn", "hit_self": true } ],
+    "extra_effects": [
+      {
+        "id": "overcharge_burn",
+        "hit_self": true
+      },
+      {
+        "id": "eoc_evocation_setup",
+        "hit_self": true
+      }
+    ],
     "min_damage": 90,
-    "damage_increment": 5.0,
+    "damage_increment": 5,
     "max_damage": 300,
     "min_range": 8,
     "range_increment": 0.35,
@@ -505,16 +813,35 @@
     "max_level": 45,
     "base_casting_time": 120,
     "final_casting_time": 120,
-    "valid_targets": [ "hostile", "ground" ],
-    "flags": [ "LOUD", "VERBAL", "NO_HANDS", "NO_LEGS" ]
+    "valid_targets": [
+      "hostile",
+      "ground"
+    ],
+    "flags": [
+      "EVOCATION_SPELL",
+      "LOUD",
+      "VERBAL",
+      "NO_HANDS",
+      "NO_LEGS"
+    ]
   },
   {
     "type": "SPELL",
-    "name": { "str": "X-ray Vision" },
+    "name": {
+      "str": "X-ray Vision"
+    },
     "id": "x-ray",
     "description": "You fire a cone of X-rays that magically allow you to see that area for a short time.",
-    "valid_targets": [ "hostile", "ground", "ally" ],
-    "flags": [ "CONCENTRATE", "IGNORE_WALLS" ],
+    "valid_targets": [
+      "hostile",
+      "ground",
+      "ally"
+    ],
+    "flags": [
+      "EVOCATION_SPELL",
+      "CONCENTRATE",
+      "IGNORE_WALLS"
+    ],
     "effect": "attack",
     "shape": "cone",
     "field_id": "fd_clairvoyant",
@@ -534,18 +861,34 @@
     "base_casting_time": 175,
     "base_energy_cost": 550,
     "energy_source": "BIONIC",
-    "spell_class": "TECHNOMANCER"
+    "spell_class": "TECHNOMANCER",
+    "extra_effects": [
+      {
+        "id": "eoc_evocation_setup",
+        "hit_self": true
+      }
+    ]
   },
   {
     "type": "SPELL",
-    "name": { "str": "Knock" },
+    "name": {
+      "str": "Knock"
+    },
     "id": "knock",
     "description": "You channel magic into a force capable of opening doors.  This variant can only open wooden doors.",
-    "valid_targets": [ "ground" ],
+    "valid_targets": [
+      "ground"
+    ],
     "effect": "ter_transform",
     "effect_str": "unlock_doors",
     "shape": "blast",
-    "flags": [ "NO_LEGS", "SOMATIC", "CONCENTRATE", "NO_PROJECTILE" ],
+    "flags": [
+      "CHANNELING_SPELL",
+      "NO_LEGS",
+      "SOMATIC",
+      "CONCENTRATE",
+      "NO_PROJECTILE"
+    ],
     "max_level": 22,
     "base_casting_time": 1200,
     "final_casting_time": 980,
@@ -556,18 +899,34 @@
     "max_range": 6,
     "range_increment": 0.2,
     "energy_source": "MANA",
-    "spell_class": "TECHNOMANCER"
+    "spell_class": "TECHNOMANCER",
+    "extra_effects": [
+      {
+        "id": "eoc_channeling_setup",
+        "hit_self": true
+      }
+    ]
   },
   {
     "type": "SPELL",
-    "name": { "str": "Improved Knock" },
+    "name": {
+      "str": "Improved Knock"
+    },
     "id": "improved_knock",
     "description": "You channel magic into a force capable of opening doors.  This variant can open any locked door.",
-    "valid_targets": [ "ground" ],
+    "valid_targets": [
+      "ground"
+    ],
     "effect": "ter_transform",
     "effect_str": "unlock_all_doors",
     "shape": "blast",
-    "flags": [ "NO_LEGS", "SOMATIC", "CONCENTRATE", "NO_PROJECTILE" ],
+    "flags": [
+      "CHANNELING_SPELL",
+      "NO_LEGS",
+      "SOMATIC",
+      "CONCENTRATE",
+      "NO_PROJECTILE"
+    ],
     "max_level": 22,
     "base_casting_time": 2600,
     "final_casting_time": 2270,
@@ -577,15 +936,32 @@
     "min_range": 6,
     "max_range": 6,
     "energy_source": "MANA",
-    "spell_class": "TECHNOMANCER"
+    "spell_class": "TECHNOMANCER",
+    "extra_effects": [
+      {
+        "id": "eoc_channeling_setup",
+        "hit_self": true
+      }
+    ]
   },
   {
     "id": "technomancer_knifeshot",
     "type": "SPELL",
-    "name": { "str": "Knifeshot" },
+    "name": {
+      "str": "Knifeshot"
+    },
     "description": "This spell generates a magnetic field around a knife, before launching it at high speed.",
-    "valid_targets": [ "hostile", "ally" ],
-    "flags": [ "CONCENTRATE", "SILENT", "SOMATIC" ],
+    "valid_targets": [
+      "hostile",
+      "ally"
+    ],
+    "flags": [
+      "EVOCATION_SPELL",
+      "CONCENTRATE",
+      "SILENT",
+      "SOMATIC",
+      "NO_HANDS"
+    ],
     "components": "spell_components_knifeshot",
     "effect": "attack",
     "shape": "blast",
@@ -599,7 +975,7 @@
     "base_energy_cost": 50,
     "min_damage": 30,
     "max_damage": 105,
-    "damage_increment": 2.0,
+    "damage_increment": 2,
     "damage_type": "stab",
     "min_range": 10,
     "max_range": 30,
@@ -607,15 +983,35 @@
     "min_pierce": 3,
     "max_pierce": 15,
     "pierce_increment": 0.35,
-    "learn_spells": { "technomancer_knifeshot_superior": 20 }
+    "learn_spells": {
+      "technomancer_knifeshot_superior": 20
+    },
+    "extra_effects": [
+      {
+        "id": "eoc_evocation_setup",
+        "hit_self": true
+      }
+    ]
   },
   {
     "id": "technomancer_knifeshot_superior",
     "type": "SPELL",
-    "name": { "str": "Hypervelocity Knifeshot" },
+    "name": {
+      "str": "Hypervelocity Knifeshot"
+    },
     "description": "This spell goes even further beyond, launching a knife so fast it can pierce through targets.",
-    "valid_targets": [ "hostile", "ally" ],
-    "flags": [ "CONCENTRATE", "LOUD", "SOMATIC" ],
+    "valid_targets": [
+      "hostile",
+      "ally"
+    ],
+    "flags": [
+      "EVOCATION_SPELL",
+      "CONCENTRATE",
+      "LOUD",
+      "SOMATIC",
+      "NO_HANDS",
+      "NO_FAIL"
+    ],
     "components": "spell_components_knifeshot",
     "effect": "attack",
     "shape": "line",
@@ -631,15 +1027,30 @@
     "min_range": 9,
     "max_range": 9,
     "min_pierce": 20,
-    "max_pierce": 20
+    "max_pierce": 20,
+    "extra_effects": [
+      {
+        "id": "eoc_evocation_setup",
+        "hit_self": true
+      }
+    ]
   },
   {
     "id": "technomancer_conjure_radio",
     "type": "SPELL",
-    "name": { "str": "Speak through the Aether" },
+    "name": {
+      "str": "Speak through the Aether"
+    },
     "description": "One of the most widely-known pre-modern technomantic spells, this allows technomancers to communicate at a distance.  Its use declined rapidly after Guglielmo Marconi invented the radio and suddenly everyone could listen in to their conversations.",
-    "valid_targets": [ "self" ],
-    "flags": [ "CONCENTRATE", "VERBAL", "SOMATIC" ],
+    "valid_targets": [
+      "self"
+    ],
+    "flags": [
+      "CONJURATION_SPELL",
+      "CONCENTRATE",
+      "VERBAL",
+      "SOMATIC"
+    ],
     "effect": "spawn_item",
     "effect_str": "technomancer_summoned_radio",
     "shape": "blast",
@@ -651,15 +1062,30 @@
     "duration_increment": 15000,
     "energy_source": "MANA",
     "base_casting_time": 6000,
-    "base_energy_cost": 450
+    "base_energy_cost": 450,
+    "extra_effects": [
+      {
+        "id": "eoc_summon_setup",
+        "hit_self": true
+      }
+    ]
   },
   {
     "id": "technomancer_conjure_ups",
     "type": "SPELL",
-    "name": { "str": "Power Supply" },
+    "name": {
+      "str": "Power Supply"
+    },
     "description": "For the technomancer with no enhancements, this spell summons a power supply composed of pure mana that can be used to charge any compatible device.  It will continually recharge until the duration expires.",
-    "valid_targets": [ "self" ],
-    "flags": [ "CONCENTRATE", "VERBAL", "SOMATIC" ],
+    "valid_targets": [
+      "self"
+    ],
+    "flags": [
+      "CONJURATION_SPELL",
+      "CONCENTRATE",
+      "VERBAL",
+      "SOMATIC"
+    ],
     "effect": "spawn_item",
     "effect_str": "technomancer_summoned_ups",
     "shape": "blast",
@@ -673,15 +1099,31 @@
     "base_casting_time": 3000,
     "base_energy_cost": 600,
     "final_energy_cost": 900,
-    "energy_increment": 15
+    "energy_increment": 15,
+    "extra_effects": [
+      {
+        "id": "eoc_summon_setup",
+        "hit_self": true
+      }
+    ]
   },
   {
     "id": "technomancer_welder",
     "type": "SPELL",
-    "name": { "str": "Voltaic Touch" },
+    "name": {
+      "str": "Voltaic Touch"
+    },
     "description": "Using the principles of what were once called \"voltaic arcs\", you can electrically heat metal hot enough to weld it together.",
-    "valid_targets": [ "self" ],
-    "flags": [ "CONCENTRATE", "VERBAL", "SOMATIC", "NO_EXPLOSION_SFX" ],
+    "valid_targets": [
+      "self"
+    ],
+    "flags": [
+      "CONJURATION_SPELL",
+      "CONCENTRATE",
+      "VERBAL",
+      "SOMATIC",
+      "NO_EXPLOSION_SFX"
+    ],
     "effect": "spawn_item",
     "effect_str": "technomancer_welder",
     "shape": "blast",
@@ -695,6 +1137,12 @@
     "duration_increment": 35000,
     "energy_source": "MANA",
     "base_energy_cost": 500,
-    "base_casting_time": 3000
+    "base_casting_time": 3000,
+    "extra_effects": [
+      {
+        "id": "eoc_summon_setup",
+        "hit_self": true
+      }
+    ]
   }
 ]


### PR DESCRIPTION
Hello, I've noticed spells weren't giving me proficiency exp and after digging a bit I saw that there were some flags and extra_effects missing.

This PR adds new flags and extra effects required to gain proficiency experience.
This PR only adds them to spells that have been overriden.
Only the `flags` and `extra_effects` have been ported from the vanilla jsons.

Also, sorry about the formatting, I didn't know how to keep the it the same using `JSON.stringify`
